### PR TITLE
Enable packaging with https://packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,11 @@
+cli: scw
+targets:
+  ubuntu-14.04:
+  centos-7:
+  ubuntu-12.04:
+  centos-6:
+  debian-7:
+before:
+  - echo "scw" > .godir
+after:
+  - rm -f .godir


### PR DESCRIPTION
I saw you tried packaging on https://packager.io, but were missing the [`.godir` file](https://packager.io/documentation/golang/). So here is a working `.pkgr.yml` file for some of the supported distributions.

Packages can be found at https://packager.io/gh/pkgr/scaleway-cli/install?bid=2#ubuntu-14-04-scw, and I verified that you can install and run the `scw` command on Ubuntu 14.04, so it should work on the other distributions as well.

Let me know if this is of interest to you! We can also provide a standalone server so that you can serve the generated packages from your own domain and servers.