### PR TITLE
Remove .godir generation from .pkgr.yml

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -5,7 +5,3 @@ targets:
   ubuntu-12.04:
   centos-6:
   debian-7:
-before:
-  - echo "scw" > .godir
-after:
-  - rm -f .godir


### PR DESCRIPTION
Since you've created a proper `.godir` already, let's use that (successful build available at https://packager.io/gh/pkgr/scaleway-cli/build_runs/5),