### PR TITLE
Rename scaleway-cli into scw at the end of packaging

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -5,3 +5,5 @@ targets:
   ubuntu-12.04:
   centos-6:
   debian-7:
+after:
+  - mv bin/scaleway-cli bin/scw


### PR DESCRIPTION
Now that the `.godir` uses `scaleway-cli` as the binary name, we need to rename it at the end of the compilation so that one can successfully run `scw` after the package is installed.