### PR TITLE
Add man pages (Fix #73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 .#*
 profile.cov
 .vendor
+
+man/man1
+man/man5

--- a/man/md2man-all.sh
+++ b/man/md2man-all.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Original from: https://github.com/docker/docker/blob/master/man/md2man-all.sh
+
+set -e
+
+# get into this script's directory
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+[ "$1" = '-q' ] || {
+	set -x
+	pwd
+}
+
+for FILE in *.md; do
+	base="$(basename "$FILE")"
+	name="${base%.md}"
+	num="${name##*.}"
+	if [ -z "$num" -o "$name" = "$num" ]; then
+		# skip files that aren't of the format xxxx.N.md (like README.md)
+		continue
+	fi
+	mkdir -p "./man${num}"
+	go-md2man -in "$FILE" -out "./man${num}/${name}"
+done

--- a/man/scw-attach.1.md
+++ b/man/scw-attach.1.md
@@ -1,0 +1,50 @@
+% SCW(1) Scw User Manuals
+% Scaleway Community
+% JULY 2015
+# NAME
+scw-attach - Attach to a running server
+
+# SYNOPSIS
+**scw attach**
+[**--help**]/
+[**--no-stdin**[=*false*]]
+SERVER
+
+# DESCRIPTION
+The **scw attach** command allows you to attach to a running server using
+the server's ID or name, either to view its ongoing output or to control it
+interactively.  You can't attach to the same server multiple times
+simultaneously.
+
+You can detach from the server (and leave it running) with `CTRL-q`
+(for a quiet exit).
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**--no-stdin**=*true*|*false*
+   Do not attach STDIN. The default is *false*.
+
+# EXAMPLES
+
+## Attaching to a server
+
+In this example the top command is run inside a server, from an image called
+fedora, in detached mode. The ID from the server is passed into the **scw
+attach** command:
+
+    # ID=$(scw run -d fedora)
+    # scw attach $ID
+    Booting Linux on physical CPU 0
+    Initializing cgroup subsys cpuset
+    Initializing cgroup subsys cpu
+    Linux version 3.2.34-30 (build-bot@cloud.online.net) (gcc version 4.9.1 (Ubuntu/Linaro 4.9.1-10ubuntu2) ) #17 SMP Mon Apr 13 15:53:45 UTC 2015
+    CPU: Marvell PJ4Bv7 Processor [562f5842] revision 2 (ARMv7), cr=10c53c7d
+    CPU: PIPT / VIPT nonaliasing data cache, PIPT instruction cache
+    Machine: Online Labs C1
+    Using UBoot passing parameters structure
+    [...]
+
+# HISTORY
+July 2015, Originally compiled by Scaleway Team

--- a/man/scw-commit.1.md
+++ b/man/scw-commit.1.md
@@ -1,0 +1,70 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-commit - Create a new image from a container's changes
+
+# SYNOPSIS
+**docker commit**
+[**-a**|**--author**[=*AUTHOR*]]
+[**--help**]
+[**-c**|**--change**[= []**]]
+[**-m**|**--message**[=*MESSAGE*]]
+[**-p**|**--pause**[=*true*]]
+CONTAINER [REPOSITORY[:TAG]]
+
+# DESCRIPTION
+Create a new image from an existing container specified by name or
+container ID.  The new image will contain the contents of the
+container filesystem, *excluding* any data volumes.
+
+While the `docker commit` command is a convenient way of extending an
+existing image, you should prefer the use of a Dockerfile and `docker
+build` for generating images that you intend to share with other
+people.
+
+# OPTIONS
+**-a**, **--author**=""
+   Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+
+**-c** , **--change**=[]
+   Apply specified Dockerfile instructions while committing the image
+   Supported Dockerfile instructions: `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`LABEL`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+
+**--help**
+  Print usage statement
+
+**-m**, **--message**=""
+   Commit message
+
+**-p**, **--pause**=*true*|*false*
+   Pause container during commit. The default is *true*.
+
+# EXAMPLES
+
+## Creating a new image from an existing container
+An existing Fedora based container has had Apache installed while running
+in interactive mode with the bash shell. Apache is also running. To
+create a new image run `docker ps` to find the container's ID and then run:
+
+    # docker commit -m="Added Apache to Fedora base image" \
+      -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
+
+Note that only a-z0-9-_. are allowed when naming images from an 
+existing container.
+
+## Apply specified Dockerfile instructions while committing the image
+If an existing container was created without the DEBUG environment
+variable set to "true", you can create a new image based on that
+container by first getting the container's ID with `docker ps` and
+then running:
+
+    # docker commit -c="ENV DEBUG true" 98bd7fc99854 debug-image
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and in
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+Oct 2014, updated by Daniel, Dao Quang Minh <daniel at nitrous dot io>
+June 2015, updated by Sally O'Malley <somalley@redhat.com>

--- a/man/scw-cp.1.md
+++ b/man/scw-cp.1.md
@@ -1,0 +1,151 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-cp - Copy files/folders between a container and the local filesystem.
+
+# SYNOPSIS
+**docker cp**
+[**--help**]
+CONTAINER:PATH LOCALPATH|-
+LOCALPATH|- CONTAINER:PATH
+
+# DESCRIPTION
+
+In the first synopsis form, the `docker cp` utility copies the contents of
+`PATH` from the filesystem of `CONTAINER` to the `LOCALPATH` (or stream as
+a tar archive to `STDOUT` if `-` is specified).
+
+In the second synopsis form, the contents of `LOCALPATH` (or a tar archive
+streamed from `STDIN` if `-` is specified) are copied from the local machine to
+`PATH` in the filesystem of `CONTAINER`.
+
+You can copy to or from either a running or stopped container. The `PATH` can
+be a file or directory. The `docker cp` command assumes all `CONTAINER:PATH`
+values are relative to the `/` (root) directory of the container. This means
+supplying the initial forward slash is optional; The command sees
+`compassionate_darwin:/tmp/foo/myfile.txt` and
+`compassionate_darwin:tmp/foo/myfile.txt` as identical. If a `LOCALPATH` value
+is not absolute, is it considered relative to the current working directory.
+
+Behavior is similar to the common Unix utility `cp -a` in that directories are
+copied recursively with permissions preserved if possible. Ownership is set to
+the user and primary group on the receiving end of the transfer. For example,
+files copied to a container will be created with `UID:GID` of the root user.
+Files copied to the local machine will be created with the `UID:GID` of the
+user which invoked the `docker cp` command.
+
+Assuming a path separator of `/`, a first argument of `SRC_PATH` and second
+argument of `DST_PATH`, the behavior is as follows:
+
+- `SRC_PATH` specifies a file
+    - `DST_PATH` does not exist
+        - the file is saved to a file created at `DST_PATH`
+    - `DST_PATH` does not exist and ends with `/`
+        - Error condition: the destination directory must exist.
+    - `DST_PATH` exists and is a file
+        - the destination is overwritten with the contents of the source file
+    - `DST_PATH` exists and is a directory
+        - the file is copied into this directory using the basename from
+          `SRC_PATH`
+- `SRC_PATH` specifies a directory
+    - `DST_PATH` does not exist
+        - `DST_PATH` is created as a directory and the *contents* of the source
+           directory are copied into this directory
+    - `DST_PATH` exists and is a file
+        - Error condition: cannot copy a directory to a file
+    - `DST_PATH` exists and is a directory
+        - `SRC_PATH` does not end with `/.`
+            - the source directory is copied into this directory
+        - `SRC_PAPTH` does end with `/.`
+            - the *content* of the source directory is copied into this
+              directory
+
+The command requires `SRC_PATH` and `DST_PATH` to exist according to the above
+rules. If `SRC_PATH` is local and is a symbolic link, the symbolic link, not
+the target, is copied.
+
+A colon (`:`) is used as a delimiter between `CONTAINER` and `PATH`, but `:`
+could also be in a valid `LOCALPATH`, like `file:name.txt`. This ambiguity is
+resolved by requiring a `LOCALPATH` with a `:` to be made explicit with a
+relative or absolute path, for example:
+
+    `/path/to/file:name.txt` or `./file:name.txt`
+
+It is not possible to copy certain system files such as resources under
+`/proc`, `/sys`, `/dev`, and mounts created by the user in the container.
+
+Using `-` as the first argument in place of a `LOCALPATH` will stream the
+contents of `STDIN` as a tar archive which will be extracted to the `PATH` in
+the filesystem of the destination container. In this case, `PATH` must specify
+a directory.
+
+Using `-` as the second argument in place of a `LOCALPATH` will stream the
+contents of the resource from the source container as a tar archive to
+`STDOUT`.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+# EXAMPLES
+
+Suppose a container has finished producing some output as a file it saves
+to somewhere in its filesystem. This could be the output of a build job or
+some other computation. You can copy these outputs from the container to a
+location on your local host.
+
+If you want to copy the `/tmp/foo` directory from a container to the
+existing `/tmp` directory on your host. If you run `docker cp` in your `~`
+(home) directory on the local host:
+
+		$ docker cp compassionate_darwin:tmp/foo /tmp
+
+Docker creates a `/tmp/foo` directory on your host. Alternatively, you can omit
+the leading slash in the command. If you execute this command from your home
+directory:
+
+		$ docker cp compassionate_darwin:tmp/foo tmp
+
+If `~/tmp` does not exist, Docker will create it and copy the contents of
+`/tmp/foo` from the container into this new directory. If `~/tmp` already
+exists as a directory, then Docker will copy the contents of `/tmp/foo` from
+the container into a directory at `~/tmp/foo`.
+
+When copying a single file to an existing `LOCALPATH`, the `docker cp` command
+will either overwrite the contents of `LOCALPATH` if it is a file or place it
+into `LOCALPATH` if it is a directory, overwriting an existing file of the same
+name if one exists. For example, this command:
+
+		$ docker cp sharp_ptolemy:/tmp/foo/myfile.txt /test
+
+If `/test` does not exist on the local machine, it will be created as a file
+with the contents of `/tmp/foo/myfile.txt` from the container. If `/test`
+exists as a file, it will be overwritten. Lastly, if `/tmp` exists as a
+directory, the file will be copied to `/test/myfile.txt`.
+
+Next, suppose you want to copy a file or folder into a container. For example,
+this could be a configuration file or some other input to a long running
+computation that you would like to place into a created container before it
+starts. This is useful because it does not require the configuration file or
+other input to exist in the container image.
+
+If you have a file, `config.yml`, in the current directory on your local host
+and wish to copy it to an existing directory at `/etc/my-app.d` in a container,
+this command can be used:
+
+		$ docker cp config.yml myappcontainer:/etc/my-app.d
+
+If you have several files in a local directory `/config` which you need to copy
+to a directory `/etc/my-app.d` in a container:
+
+		$ docker cp /config/. myappcontainer:/etc/my-app.d
+
+The above command will copy the contents of the local `/config` directory into
+the directory `/etc/my-app.d` in the container.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+May 2015, updated by Josh Hawn <josh.hawn@docker.com>

--- a/man/scw-create.1.md
+++ b/man/scw-create.1.md
@@ -1,0 +1,258 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-create - Create a new container
+
+# SYNOPSIS
+**docker create**
+[**-a**|**--attach**[=*[]*]]
+[**--add-host**[=*[]*]]
+[**--blkio-weight**[=*[BLKIO-WEIGHT]*]]
+[**-c**|**--cpu-shares**[=*0*]]
+[**--cap-add**[=*[]*]]
+[**--cap-drop**[=*[]*]]
+[**--cgroup-parent**[=*CGROUP-PATH*]]
+[**--cidfile**[=*CIDFILE*]]
+[**--cpu-period**[=*0*]]
+[**--cpu-quota**[=*0*]]
+[**--cpuset-cpus**[=*CPUSET-CPUS*]]
+[**--cpuset-mems**[=*CPUSET-MEMS*]]
+[**--device**[=*[]*]]
+[**--dns**[=*[]*]]
+[**--dns-search**[=*[]*]]
+[**-e**|**--env**[=*[]*]]
+[**--entrypoint**[=*ENTRYPOINT*]]
+[**--env-file**[=*[]*]]
+[**--expose**[=*[]*]]
+[**--group-add**[=*[]*]]
+[**-h**|**--hostname**[=*HOSTNAME*]]
+[**--help**]
+[**-i**|**--interactive**[=*false*]]
+[**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
+[**--link**[=*[]*]]
+[**--log-driver**[=*[]*]]
+[**--log-opt**[=*[]*]]
+[**--lxc-conf**[=*[]*]]
+[**-m**|**--memory**[=*MEMORY*]]
+[**--mac-address**[=*MAC-ADDRESS*]]
+[**--memory-swap**[=*MEMORY-SWAP*]]
+[**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
+[**--name**[=*NAME*]]
+[**--net**[=*"bridge"*]]
+[**--oom-kill-disable**[=*false*]]
+[**-P**|**--publish-all**[=*false*]]
+[**-p**|**--publish**[=*[]*]]
+[**--pid**[=*[]*]]
+[**--privileged**[=*false*]]
+[**--read-only**[=*false*]]
+[**--restart**[=*RESTART*]]
+[**--security-opt**[=*[]*]]
+[**-t**|**--tty**[=*false*]]
+[**-u**|**--user**[=*USER*]]
+[**--ulimit**[=*[]*]]
+[**--uts**[=*[]*]]
+[**-v**|**--volume**[=*[]*]]
+[**--volumes-from**[=*[]*]]
+[**-w**|**--workdir**[=*WORKDIR*]]
+IMAGE [COMMAND] [ARG...]
+
+# DESCRIPTION
+
+Creates a writeable container layer over the specified image and prepares it for
+running the specified command. The container ID is then printed to STDOUT. This
+is similar to **docker run -d** except the container is never started. You can 
+then use the **docker start <container_id>** command to start the container at
+any point.
+
+The initial status of the container created with **docker create** is 'created'.
+
+# OPTIONS
+**-a**, **--attach**=[]
+   Attach to STDIN, STDOUT or STDERR.
+
+**--add-host**=[]
+   Add a custom host-to-IP mapping (host:ip)
+
+**--blkio-weight**=0
+   Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+
+**-c**, **--cpu-shares**=0
+   CPU shares (relative weight)
+
+**--cap-add**=[]
+   Add Linux capabilities
+
+**--cap-drop**=[]
+   Drop Linux capabilities
+
+**--cidfile**=""
+   Write the container ID to the file
+
+**--cgroup-parent**=""
+   Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+
+**--cpu-period**=0
+    Limit the CPU CFS (Completely Fair Scheduler) period
+
+**--cpuset-cpus**=""
+   CPUs in which to allow execution (0-3, 0,1)
+
+**--cpuset-mems**=""
+   Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+   If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
+then processes in your Docker container will only use memory from the first
+two memory nodes.
+
+**-cpu-quota**=0
+   Limit the CPU CFS (Completely Fair Scheduler) quota
+
+**--device**=[]
+   Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
+
+**--dns-search**=[]
+   Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
+
+**--dns**=[]
+   Set custom DNS servers
+
+**-e**, **--env**=[]
+   Set environment variables
+
+**--entrypoint**=""
+   Overwrite the default ENTRYPOINT of the image
+
+**--env-file**=[]
+   Read in a line delimited file of environment variables
+
+**--expose**=[]
+   Expose a port or a range of ports (e.g. --expose=3300-3310) from the container without publishing it to your host
+
+**--group-add**=[]
+   Add additional groups to run as
+
+**-h**, **--hostname**=""
+   Container host name
+
+**--help**
+  Print usage statement
+
+**-i**, **--interactive**=*true*|*false*
+   Keep STDIN open even if not attached. The default is *false*.
+
+**--ipc**=""
+   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
+                               'container:<name|id>': reuses another container shared memory, semaphores and message queues
+                               'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Adds metadata to a container (e.g., --label=com.example.key=value)
+
+**--label-file**=[]
+   Read labels from a file. Delimit each label with an EOL.
+
+**--link**=[]
+   Add link to another container in the form of <name or id>:alias or just
+   <name or id> in which case the alias will match the name.
+
+**--lxc-conf**=[]
+   (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
+
+**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*none*"
+  Logging driver for container. Default is defined by daemon `--log-driver` flag.
+  **Warning**: `docker logs` command works only for `json-file` logging driver.
+
+**--log-opt**=[]
+  Logging driver specific options.
+
+**-m**, **--memory**=""
+   Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
+
+   Allows you to constrain the memory available to a container. If the host
+supports swap memory, then the **-m** memory setting can be larger than physical
+RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
+not limited. The actual limit may be rounded up to a multiple of the operating
+system's page size (the value would be very large, that's millions of trillions).
+
+**--memory-swap**=""
+   Total memory limit (memory + swap)
+
+   Set `-1` to disable swap (format: <number><optional unit>, where unit = b, k, m or g).
+This value should always larger than **-m**, so you should always use this with **-m**.
+
+**--mac-address**=""
+   Container MAC address (e.g. 92:d0:c6:0a:29:33)
+
+**--name**=""
+   Assign a name to the container
+
+**--net**="bridge"
+   Set the Network mode for the container
+                               'bridge': creates a new network stack for the container on the docker bridge
+                               'none': no networking for this container
+                               'container:<name|id>': reuses another container network stack
+                               'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+
+**--oom-kill-disable**=*true*|*false*
+	Whether to disable OOM Killer for the container or not.
+
+**-P**, **--publish-all**=*true*|*false*
+   Publish all exposed ports to random ports on the host interfaces. The default is *false*.
+
+**-p**, **--publish**=[]
+   Publish a container's port, or a range of ports, to the host
+                               format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
+                               Both hostPort and containerPort can be specified as a range of ports. 
+                               When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
+                               (use 'docker port' to see the actual mapping)
+
+**--pid**=host
+   Set the PID mode for the container
+     **host**: use the host's PID namespace inside the container.
+     Note: the host mode gives the container full access to local PID and is therefore considered insecure.
+
+**--uts**=host
+   Set the UTS mode for the container
+     **host**: use the host's UTS namespace inside the container.
+     Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
+
+**--privileged**=*true*|*false*
+   Give extended privileges to this container. The default is *false*.
+
+**--read-only**=*true*|*false*
+   Mount the container's root filesystem as read only.
+
+**--restart**="no"
+   Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
+
+**--security-opt**=[]
+   Security Options
+
+**--memory-swappiness**=""
+   Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+
+**-t**, **--tty**=*true*|*false*
+   Allocate a pseudo-TTY. The default is *false*.
+
+**-u**, **--user**=""
+   Username or UID
+
+**--ulimit**=[]
+   Ulimit options
+
+**-v**, **--volume**=[]
+   Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
+
+**--volumes-from**=[]
+   Mount volumes from the specified container(s)
+
+**-w**, **--workdir**=""
+   Working directory inside the container
+
+# HISTORY
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+September 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-events.1.md
+++ b/man/scw-events.1.md
@@ -1,0 +1,86 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-events - Get real time events from the server
+
+# SYNOPSIS
+**docker events**
+[**--help**]
+[**-f**|**--filter**[=*[]*]]
+[**--since**[=*SINCE*]]
+[**--until**[=*UNTIL*]]
+
+
+# DESCRIPTION
+Get event information from the Docker daemon. Information can include historical
+information and real-time information.
+
+Docker containers will report the following events:
+
+    create, destroy, die, export, kill, pause, restart, start, stop, unpause
+
+and Docker images will report:
+
+    untag, delete
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-f**, **--filter**=[]
+   Provide filter values (i.e., 'event=stop')
+
+**--since**=""
+   Show all events created since timestamp
+
+**--until**=""
+   Stream events until this timestamp
+
+You can specify `--since` and `--until` parameters as an RFC 3339 date,
+a UNIX timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Docker computes
+the date relative to the client machine’s time.
+
+# EXAMPLES
+
+## Listening for Docker events
+
+After running docker events a container 786d698004576 is started and stopped
+(The container name has been shortened in the output below):
+
+    # docker events
+    2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) start
+    2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) die
+    2015-01-28T20:21:32.000000000-08:00 59211849bc10: (from whenry/testimage:latest) stop
+
+## Listening for events since a given date
+Again the output container IDs have been shortened for the purposes of this document:
+
+    # docker events --since '2015-01-28'
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+    2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:40.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+    2015-01-28T20:25:42.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+    2015-01-28T20:25:46.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+
+The following example outputs all events that were generated in the last 3 minutes,
+relative to the current time on the client machine:
+
+    # docker events --since '3m'
+    2015-05-12T11:51:30.999999999Z07:00 4386fb97867d: (from ubuntu-1:14.04) die
+    2015-05-12T15:52:12.999999999Z07:00 4 4386fb97867d: (from ubuntu-1:14.04) stop
+    2015-05-12T15:53:45.999999999Z07:00  7805c1d35632: (from redis:2.8) die
+    2015-05-12T15:54:03.999999999Z07:00  7805c1d35632: (from redis:2.8) stop
+
+If you do not provide the --since option, the command returns only new and/or
+live events.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2015, updated by Brian Goff <cpuguy83@gmail.com>

--- a/man/scw-exec.1.md
+++ b/man/scw-exec.1.md
@@ -1,0 +1,51 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-exec - Run a command in a running container
+
+# SYNOPSIS
+**docker exec**
+[**-d**|**--detach**[=*false*]]
+[**--help**]
+[**-i**|**--interactive**[=*false*]]
+[**-t**|**--tty**[=*false*]]
+[**-u**|**--user**[=*USER*]]
+CONTAINER COMMAND [ARG...]
+
+# DESCRIPTION
+
+Run a process in a running container. 
+
+The command started using `docker exec` will only run while the container's primary
+process (`PID 1`) is running, and will not be restarted if the container is restarted.
+
+If the container is paused, then the `docker exec` command will wait until the
+container is unpaused, and then run
+
+# OPTIONS
+**-d**, **--detach**=*true*|*false*
+   Detached mode: run command in the background. The default is *false*.
+
+**--help**
+  Print usage statement
+
+**-i**, **--interactive**=*true*|*false*
+   Keep STDIN open even if not attached. The default is *false*.
+
+**-t**, **--tty**=*true*|*false*
+   Allocate a pseudo-TTY. The default is *false*.
+
+**-u**, **--user**=""
+   Sets the username or UID used and optionally the groupname or GID for the specified command.
+
+   The followings examples are all valid:
+   --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
+
+   Without this argument the command will be run as root in the container.
+
+The **-t** option is incompatible with a redirection of the docker client
+standard input.
+
+# HISTORY
+November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-history.1.md
+++ b/man/scw-history.1.md
@@ -1,0 +1,51 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-history - Show the history of an image
+
+# SYNOPSIS
+**docker history**
+[**--help**]
+[**--no-trunc**[=*false*]]
+[**-q**|**--quiet**[=*false*]]
+IMAGE
+
+# DESCRIPTION
+
+Show the history of when and how an image was created.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-H**. **--human**=*true*|*false*
+    Print sizes and dates in human readable format. The default is *true*.
+
+**--no-trunc**=*true*|*false*
+   Don't truncate output. The default is *false*.
+
+**-q**, **--quiet**=*true*|*false*
+   Only show numeric IDs. The default is *false*.
+
+# EXAMPLES
+    $ docker history fedora
+    IMAGE          CREATED          CREATED BY                                      SIZE                COMMENT
+    105182bb5e8b   5 days ago       /bin/sh -c #(nop) ADD file:71356d2ad59aa3119d   372.7 MB
+    73bd853d2ea5   13 days ago      /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
+    511136ea3c5a   10 months ago                                                    0 B                 Imported from -
+
+## Display comments in the image history
+The `docker commit` command has a **-m** flag for adding comments to the image. These comments will be displayed in the image history.
+
+    $ sudo docker history docker:scm
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
+    88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            
+    c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B                 
+    511136ea3c5a        19 months ago                                                       0 B                 Imported from -
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-images.1.md
+++ b/man/scw-images.1.md
@@ -1,0 +1,84 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-images - List images
+
+# SYNOPSIS
+**docker images**
+[**--help**]
+[**-a**|**--all**[=*false*]]
+[**--digests**[=*false*]]
+[**-f**|**--filter**[=*[]*]]
+[**--no-trunc**[=*false*]]
+[**-q**|**--quiet**[=*false*]]
+[REPOSITORY]
+
+# DESCRIPTION
+This command lists the images stored in the local Docker repository.
+
+By default, intermediate images, used during builds, are not listed. Some of the
+output, e.g., image ID, is truncated, for space reasons. However the truncated
+image ID, and often the first few characters, are enough to be used in other
+Docker commands that use the image ID. The output includes repository, tag, image
+ID, date created and the virtual size.
+
+The title REPOSITORY for the first title may seem confusing. It is essentially
+the image name. However, because you can tag a specific image, and multiple tags
+(image instances) can be associated with a single name, the name is really a
+repository for all tagged images of the same name. For example consider an image
+called fedora. It may be tagged with 18, 19, or 20, etc. to manage different
+versions.
+
+# OPTIONS
+**-a**, **--all**=*true*|*false*
+   Show all images (by default filter out the intermediate image layers). The default is *false*.
+
+**--digests**=*true*|*false*
+   Show image digests. The default is *false*.
+
+**-f**, **--filter**=[]
+   Filters the output. The dangling=true filter finds unused images. While label=com.foo=amd64 filters for images with a com.foo value of amd64. The label=com.foo filter finds images with the label com.foo of any value.
+
+**--help**
+  Print usage statement
+
+**--no-trunc**=*true*|*false*
+   Don't truncate output. The default is *false*.
+
+**-q**, **--quiet**=*true*|*false*
+   Only show numeric IDs. The default is *false*.
+
+# EXAMPLES
+
+## Listing the images
+
+To list the images in a local repository (not the registry) run:
+
+    docker images
+
+The list will contain the image repository name, a tag for the image, and an
+image ID, when it was created and its virtual size. Columns: REPOSITORY, TAG,
+IMAGE ID, CREATED, and VIRTUAL SIZE.
+
+To get a verbose list of images which contains all the intermediate images
+used in builds use **-a**:
+
+    docker images -a
+
+Previously, the docker images command supported the --tree and --dot arguments,
+which displayed different visualizations of the image data. Docker core removed
+this functionality in the 1.7 version. If you liked this functionality, you can
+still find it in the third-party dockviz tool: https://github.com/justone/dockviz.
+
+## Listing only the shortened image IDs
+
+Listing just the shortened image IDs. This can be useful for some automated
+tools.
+
+    docker images -q
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-info.1.md
+++ b/man/scw-info.1.md
@@ -1,0 +1,49 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-info - Display system-wide information
+
+# SYNOPSIS
+**docker info**
+[**--help**]
+
+
+# DESCRIPTION
+This command displays system wide information regarding the Docker installation.
+Information displayed includes the number of containers and images, pool name,
+data file, metadata file, data space used, total data space, metadata space used
+, total metadata space, execution driver, and the kernel version.
+
+The data file is where the images are stored and the metadata file is where the
+meta data regarding those images are stored. When run for the first time Docker
+allocates a certain amount of data space and meta data space from the space
+available on the volume where `/var/lib/docker` is mounted.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+# EXAMPLES
+
+## Display Docker system information
+
+Here is a sample output:
+
+    # docker info
+    Containers: 14
+    Images: 52
+    Storage Driver: aufs
+     Root Dir: /var/lib/docker/aufs
+     Dirs: 80
+    Execution Driver: native-0.2
+    Logging Driver: json-file
+    Kernel Version: 3.13.0-24-generic
+    Operating System: Ubuntu 14.04 LTS
+    CPUs: 1
+    Total Memory: 2 GiB
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-inspect.1.md
+++ b/man/scw-inspect.1.md
@@ -1,0 +1,290 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-inspect - Return low-level information on a container or image
+
+# SYNOPSIS
+**docker inspect**
+[**--help**]
+[**-f**|**--format**[=*FORMAT*]]
+[**--type**=*container*|*image*]
+CONTAINER|IMAGE [CONTAINER|IMAGE...]
+
+# DESCRIPTION
+
+This displays all the information available in Docker for a given
+container or image. By default, this will render all results in a JSON
+array. If a format is specified, the given template will be executed for
+each result.
+
+# OPTIONS
+**--help**
+    Print usage statement
+
+**-f**, **--format**=""
+    Format the output using the given go template.
+
+**--type**=*container*|*image*
+    Return JSON for specified type, permissible values are "image" or "container"
+
+# EXAMPLES
+
+Getting information on an image where image name conflict with the container name,
+e,g both image and container are named rhel7.
+
+    $ docker inspect --type=image rhel7
+    [
+    {
+     "Id": "fe01a428b9d9de35d29531e9994157978e8c48fa693e1bf1d221dffbbb67b170",
+     "Parent": "10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2",
+     ....
+    }
+    ]
+
+## Getting information on a container
+
+To get information on a container use its ID or instance name:
+
+    $ docker inspect d2cc496561d6
+    [{
+    "Id": "d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47",
+    "Created": "2015-06-08T16:18:02.505155285Z",
+    "Path": "bash",
+    "Args": [],
+    "State": {
+        "Running": false,
+        "Paused": false,
+        "Restarting": false,
+        "OOMKilled": false,
+        "Dead": false,
+        "Pid": 0,
+        "ExitCode": 0,
+        "Error": "",
+        "StartedAt": "2015-06-08T16:18:03.643865954Z",
+        "FinishedAt": "2015-06-08T16:57:06.448552862Z"
+    },
+    "Image": "ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4",
+    "NetworkSettings": {
+        "Bridge": "",
+        "EndpointID": "",
+        "Gateway": "",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "HairpinMode": false,
+        "IPAddress": "",
+        "IPPrefixLen": 0,
+        "IPv6Gateway": "",
+        "LinkLocalIPv6Address": "",
+        "LinkLocalIPv6PrefixLen": 0,
+        "MacAddress": "",
+        "NetworkID": "",
+        "PortMapping": null,
+        "Ports": null,
+        "SandboxKey": "",
+        "SecondaryIPAddresses": null,
+        "SecondaryIPv6Addresses": null
+    },
+    "ResolvConfPath": "/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/resolv.conf",
+    "HostnamePath": "/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/hostname",
+    "HostsPath": "/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/hosts",
+    "LogPath": "/var/lib/docker/containers/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47/d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47-json.log",
+    "Name": "/adoring_wozniak",
+    "RestartCount": 0,
+    "Driver": "devicemapper",
+    "ExecDriver": "native-0.2",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "Mounts": [
+      {
+        "Source": "/data",
+        "Destination": "/data",
+        "Mode": "ro,Z",
+        "RW": false
+      }
+    ],
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+        "Binds": null,
+        "ContainerIDFile": "",
+        "LxcConf": [],
+        "Memory": 0,
+        "MemorySwap": 0,
+        "CpuShares": 0,
+        "CpuPeriod": 0,
+        "CpusetCpus": "",
+        "CpusetMems": "",
+        "CpuQuota": 0,
+        "BlkioWeight": 0,
+        "OomKillDisable": false,
+        "Privileged": false,
+        "PortBindings": {},
+        "Links": null,
+        "PublishAllPorts": false,
+        "Dns": null,
+        "DnsSearch": null,
+        "ExtraHosts": null,
+        "VolumesFrom": null,
+        "Devices": [],
+        "NetworkMode": "bridge",
+        "IpcMode": "",
+        "PidMode": "",
+        "UTSMode": "",
+        "CapAdd": null,
+        "CapDrop": null,
+        "RestartPolicy": {
+            "Name": "no",
+            "MaximumRetryCount": 0
+        },
+        "SecurityOpt": null,
+        "ReadonlyRootfs": false,
+        "Ulimits": null,
+        "LogConfig": {
+            "Type": "json-file",
+            "Config": {}
+        },
+        "CgroupParent": ""
+    },
+    "GraphDriver": {
+        "Name": "devicemapper",
+        "Data": {
+            "DeviceId": "5",
+            "DeviceName": "docker-253:1-2763198-d2cc496561d6d520cbc0236b4ba88c362c446a7619992123f11c809cded25b47",
+            "DeviceSize": "171798691840"
+        }
+    },
+    "Config": {
+        "Hostname": "d2cc496561d6",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": true,
+        "AttachStdout": true,
+        "AttachStderr": true,
+        "ExposedPorts": null,
+        "Tty": true,
+        "OpenStdin": true,
+        "StdinOnce": true,
+        "Env": null,
+        "Cmd": [
+            "bash"
+        ],
+        "Image": "fedora",
+        "Volumes": null,
+        "VolumeDriver": "",
+        "WorkingDir": "",
+        "Entrypoint": null,
+        "NetworkDisabled": false,
+        "MacAddress": "",
+        "OnBuild": null,
+        "Labels": {},
+        "Memory": 0,
+        "MemorySwap": 0,
+        "CpuShares": 0,
+        "Cpuset": ""
+    }
+    }
+    ]
+## Getting the IP address of a container instance
+
+To get the IP address of a container use:
+
+    $ docker inspect --format='{{.NetworkSettings.IPAddress}}' d2cc496561d6
+    172.17.0.2
+
+## Listing all port bindings
+
+One can loop over arrays and maps in the results to produce simple text
+output:
+
+    $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} \
+      {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' d2cc496561d6
+      80/tcp -> 80
+
+You can get more information about how to write a go template from:
+http://golang.org/pkg/text/template/.
+
+## Getting information on an image
+
+Use an image's ID or name (e.g., repository/name[:tag]) to get information
+on it.
+
+    $ docker inspect ded7cd95e059
+    [{
+    "Id": "ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4",
+    "Parent": "48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731",
+    "Comment": "",
+    "Created": "2015-05-27T16:58:22.937503085Z",
+    "Container": "76cf7f67d83a7a047454b33007d03e32a8f474ad332c3a03c94537edd22b312b",
+    "ContainerConfig": {
+        "Hostname": "76cf7f67d83a",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": null,
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": null,
+        "Cmd": [
+            "/bin/sh",
+            "-c",
+            "#(nop) ADD file:4be46382bcf2b095fcb9fe8334206b584eff60bb3fad8178cbd97697fcb2ea83 in /"
+        ],
+        "Image": "48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731",
+        "Volumes": null,
+        "VolumeDriver": "",
+        "WorkingDir": "",
+        "Entrypoint": null,
+        "NetworkDisabled": false,
+        "MacAddress": "",
+        "OnBuild": null,
+        "Labels": {}
+    },
+    "DockerVersion": "1.6.0",
+    "Author": "Lokesh Mandvekar \u003clsm5@fedoraproject.org\u003e",
+    "Config": {
+        "Hostname": "76cf7f67d83a",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": null,
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": null,
+        "Cmd": null,
+        "Image": "48ecf305d2cf7046c1f5f8fcbcd4994403173441d4a7f125b1bb0ceead9de731",
+        "Volumes": null,
+        "VolumeDriver": "",
+        "WorkingDir": "",
+        "Entrypoint": null,
+        "NetworkDisabled": false,
+        "MacAddress": "",
+        "OnBuild": null,
+        "Labels": {}
+    },
+    "Architecture": "amd64",
+    "Os": "linux",
+    "Size": 186507296,
+    "VirtualSize": 186507296,
+    "GraphDriver": {
+        "Name": "devicemapper",
+        "Data": {
+            "DeviceId": "3",
+            "DeviceName": "docker-253:1-2763198-ded7cd95e059788f2586a51c275a4f151653779d6a7f4dad77c2bd34601d94e4",
+            "DeviceSize": "171798691840"
+        }
+    }
+    }
+    ]
+
+# HISTORY
+April 2014, originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Qiang Huang <h.huangqiang@huawei.com>

--- a/man/scw-kill.1.md
+++ b/man/scw-kill.1.md
@@ -1,0 +1,28 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-kill - Kill a running container using SIGKILL or a specified signal
+
+# SYNOPSIS
+**docker kill**
+[**--help**]
+[**-s**|**--signal**[=*"KILL"*]]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+
+The main process inside each container specified will be sent SIGKILL,
+ or any signal specified with option --signal.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-s**, **--signal**="KILL"
+   Signal to send to the container
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+ based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-login.1.md
+++ b/man/scw-login.1.md
@@ -1,0 +1,51 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-login - Register or log in to a Docker registry. 
+
+# SYNOPSIS
+**docker login**
+[**-e**|**--email**[=*EMAIL*]]
+[**--help**]
+[**-p**|**--password**[=*PASSWORD*]]
+[**-u**|**--username**[=*USERNAME*]]
+[SERVER]
+
+# DESCRIPTION
+Register or log in to a Docker Registry located on the specified
+`SERVER`.  You can specify a URL or a `hostname` for the `SERVER` value. If you
+do not specify a `SERVER`, the command uses Docker's public registry located at
+`https://registry-1.docker.io/` by default.  To get a username/password for Docker's public registry, create an account on Docker Hub.
+
+You can log into any public or private repository for which you have
+credentials.  When you log in, the command stores encoded credentials in
+`$HOME/.docker/config.json` on Linux or `%USERPROFILE%/.docker/config.json` on Windows.
+
+# OPTIONS
+**-e**, **--email**=""
+   Email
+
+**--help**
+  Print usage statement
+
+**-p**, **--password**=""
+   Password
+
+**-u**, **--username**=""
+   Username
+
+# EXAMPLES
+
+## Login to a registry on your localhost
+
+    # docker login localhost:8080
+
+# See also
+**docker-logout(1)** to log out from a Docker registry.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Mary Anthony for v2 <mary@docker.com>

--- a/man/scw-logout.1.md
+++ b/man/scw-logout.1.md
@@ -1,0 +1,32 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-logout - Log out from a Docker registry.
+
+# SYNOPSIS
+**docker logout**
+[SERVER]
+
+# DESCRIPTION
+Log out of a Docker Registry located on the specified `SERVER`. You can
+specify a URL or a `hostname` for the `SERVER` value. If you do not specify a
+`SERVER`, the command attempts to log you out of Docker's public registry
+located at `https://registry-1.docker.io/` by default.  
+
+# OPTIONS
+There are no available options.
+
+# EXAMPLES
+
+## Log out from a registry on your localhost
+
+    # docker logout localhost:8080
+
+# See also
+**docker-login(1)** to register or log in to a Docker registry server.
+
+# HISTORY
+June 2014, Originally compiled by Daniel, Dao Quang Minh (daniel at nitrous dot io)
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Mary Anthony for v2 <mary@docker.com>

--- a/man/scw-logs.1.md
+++ b/man/scw-logs.1.md
@@ -1,0 +1,55 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-logs - Fetch the logs of a container
+
+# SYNOPSIS
+**docker logs**
+[**-f**|**--follow**[=*false*]]
+[**--help**]
+[**--since**[=*SINCE*]]
+[**-t**|**--timestamps**[=*false*]]
+[**--tail**[=*"all"*]]
+CONTAINER
+
+# DESCRIPTION
+The **docker logs** command batch-retrieves whatever logs are present for
+a container at the time of execution. This does not guarantee execution
+order when combined with a docker run (i.e., your run may not have generated
+any logs at the time you execute docker logs).
+
+The **docker logs --follow** command combines commands **docker logs** and
+**docker attach**. It will first return all logs from the beginning and
+then continue streaming new output from the container’s stdout and stderr.
+
+**Warning**: This command works only for **json-file** logging driver.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-f**, **--follow**=*true*|*false*
+   Follow log output. The default is *false*.
+
+**--since**=""
+   Show logs since timestamp
+
+**-t**, **--timestamps**=*true*|*false*
+   Show timestamps. The default is *false*.
+
+**--tail**="all"
+   Output the specified number of lines at the end of logs (defaults to all logs)
+
+The `--since` option shows only the container logs generated after
+a given date. You can specify the date as an RFC 3339 date, a UNIX
+timestamp, or a Go duration string (e.g. `1m30s`, `3h`). Docker computes
+the date relative to the client machine’s time. You can combine
+the `--since` option with either or both of the `--follow` or `--tail` options.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>

--- a/man/scw-port.1.md
+++ b/man/scw-port.1.md
@@ -1,0 +1,47 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-port - List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
+
+# SYNOPSIS
+**docker port**
+[**--help**]
+CONTAINER [PRIVATE_PORT[/PROTO]]
+
+# DESCRIPTION
+List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+# EXAMPLES
+
+    # docker ps
+    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
+    b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
+
+## Find out all the ports mapped
+
+    # docker port test
+    7890/tcp -> 0.0.0.0:4321
+    9876/tcp -> 0.0.0.0:1234
+
+## Find out a specific mapping
+
+    # docker port test 7890/tcp
+    0.0.0.0:4321
+
+    # docker port test 7890
+    0.0.0.0:4321
+
+## An example showing error for non-existent mapping
+
+    # docker port test 7890/udp
+    2014/06/24 11:53:36 Error: No public port '7890/udp' published for test
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-ps.1.md
+++ b/man/scw-ps.1.md
@@ -1,0 +1,132 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% FEBRUARY 2015
+# NAME
+docker-ps - List containers
+
+# SYNOPSIS
+**docker ps**
+[**-a**|**--all**[=*false*]]
+[**--before**[=*BEFORE*]]
+[**--help**]
+[**-f**|**--filter**[=*[]*]]
+[**-l**|**--latest**[=*false*]]
+[**-n**[=*-1*]]
+[**--no-trunc**[=*false*]]
+[**-q**|**--quiet**[=*false*]]
+[**-s**|**--size**[=*false*]]
+[**--since**[=*SINCE*]]
+[**--format**=*"TEMPLATE"*]
+
+
+# DESCRIPTION
+
+List the containers in the local repository. By default this shows only
+the running containers.
+
+# OPTIONS
+**-a**, **--all**=*true*|*false*
+   Show all containers. Only running containers are shown by default. The default is *false*.
+
+**--before**=""
+   Show only containers created before Id or Name, including non-running containers.
+
+**--help**
+  Print usage statement
+
+**-f**, **--filter**=[]
+   Provide filter values. Valid filters:
+                          exited=<int> - containers with exit code of <int>
+                          label=<key> or label=<key>=<value>
+                          status=(created|restarting|running|paused|exited)
+                          name=<string> - container's name
+                          id=<ID> - container's ID
+
+**-l**, **--latest**=*true*|*false*
+   Show only the latest created container, include non-running ones. The default is *false*.
+
+**-n**=-1
+   Show n last created containers, include non-running ones.
+
+**--no-trunc**=*true*|*false*
+   Don't truncate output. The default is *false*.
+
+**-q**, **--quiet**=*true*|*false*
+   Only display numeric IDs. The default is *false*.
+
+**-s**, **--size**=*true*|*false*
+   Display total file sizes. The default is *false*.
+
+**--since**=""
+   Show only containers created since Id or Name, include non-running ones.
+
+**--format**=*"TEMPLATE"*
+   Pretty-print containers using a Go template.
+   Valid placeholders:
+      .ID - Container ID
+      .Image - Image ID
+      .Command - Quoted command
+      .CreatedAt - Time when the container was created.
+      .RunningFor - Elapsed time since the container was started.
+      .Ports - Exposed ports.
+      .Status - Container status.
+      .Size - Container disk size.
+      .Labels - All labels asigned to the container.
+      .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
+
+# EXAMPLES
+# Display all containers, including non-running
+
+    # docker ps -a
+    CONTAINER ID        IMAGE                 COMMAND                CREATED             STATUS      PORTS    NAMES
+    a87ecb4f327c        fedora:20             /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
+    01946d9d34d8        vpavlin/rhel7:latest  /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
+    c1d3b0166030        acffc0358b9e          /bin/sh -c yum -y up   2 weeks ago         Exit 1               determined_torvalds
+    41d50ecd2f57        fedora:20             /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
+
+# Display only IDs of all containers, including non-running
+
+    # docker ps -a -q
+    a87ecb4f327c
+    01946d9d34d8
+    c1d3b0166030
+    41d50ecd2f57
+
+# Display only IDs of all containers that have the name `determined_torvalds`
+
+    # docker ps -a -q --filter=name=determined_torvalds
+    c1d3b0166030
+
+# Display containers with their commands
+
+    # docker ps --format "{{.ID}}: {{.Command}}"
+    a87ecb4f327c: /bin/sh -c #(nop) MA
+    01946d9d34d8: /bin/sh -c #(nop) MA
+    c1d3b0166030: /bin/sh -c yum -y up
+    41d50ecd2f57: /bin/sh -c #(nop) MA
+
+# Display containers with their labels in a table
+
+    # docker ps --format "table {{.ID}}\t{{.Labels}}"
+    CONTAINER ID        LABELS
+    a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
+    01946d9d34d8
+    c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
+    41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+
+# Display containers with their node label in a table
+
+    # docker ps --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
+    CONTAINER ID        NODE
+    a87ecb4f327c        ubuntu
+    01946d9d34d8
+    c1d3b0166030        debian
+    41d50ecd2f57        fedora
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+February 2015, updated by André Martins <martins@noironetworks.com>

--- a/man/scw-rename.1.md
+++ b/man/scw-rename.1.md
@@ -1,0 +1,13 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% OCTOBER 2014
+# NAME
+docker-rename - Rename a container
+
+# SYNOPSIS
+**docker rename**
+OLD_NAME NEW_NAME
+
+# OPTIONS
+There are no available options.
+

--- a/man/scw-restart.1.md
+++ b/man/scw-restart.1.md
@@ -1,0 +1,26 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-restart - Restart a running container
+
+# SYNOPSIS
+**docker restart**
+[**--help**]
+[**-t**|**--time**[=*10*]]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+Restart each container listed.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-t**, **--time**=10
+   Number of seconds to try to stop for before killing the container. Once killed it will then be restarted. Default is 10 seconds.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-rm.1.md
+++ b/man/scw-rm.1.md
@@ -1,0 +1,56 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-rm - Remove one or more containers
+
+# SYNOPSIS
+**docker rm**
+[**-f**|**--force**[=*false*]]
+[**-l**|**--link**[=*false*]]
+[**-v**|**--volumes**[=*false*]]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+
+**docker rm** will remove one or more containers from the host node. The
+container name or ID can be used. This does not remove images. You cannot
+remove a running container unless you use the **-f** option. To see all
+containers on a host use the **docker ps -a** command.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-f**, **--force**=*true*|*false*
+   Force the removal of a running container (uses SIGKILL). The default is *false*.
+
+**-l**, **--link**=*true*|*false*
+   Remove the specified link and not the underlying container. The default is *false*.
+
+**-v**, **--volumes**=*true*|*false*
+   Remove the volumes associated with the container. The default is *false*.
+
+# EXAMPLES
+
+##Removing a container using its ID##
+
+To remove a container using its ID, find either from a **docker ps -a**
+command, or use the ID returned from the **docker run** command, or retrieve
+it from a file used to store it using the **docker run --cidfile**:
+
+    docker rm abebf7571666
+
+##Removing a container using the container name##
+
+The name of the container can be found using the **docker ps -a**
+command. The use that name as follows:
+
+    docker rm hopeful_morse
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-rmi.1.md
+++ b/man/scw-rmi.1.md
@@ -1,0 +1,42 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-rmi - Remove one or more images
+
+# SYNOPSIS
+**docker rmi**
+[**-f**|**--force**[=*false*]]
+[**--help**]
+[**--no-prune**[=*false*]]
+IMAGE [IMAGE...]
+
+# DESCRIPTION
+
+Removes one or more images from the host node. This does not remove images from
+a registry. You cannot remove an image of a running container unless you use the
+**-f** option. To see all images on a host use the **docker images** command.
+
+# OPTIONS
+**-f**, **--force**=*true*|*false*
+   Force removal of the image. The default is *false*.
+
+**--help**
+  Print usage statement
+
+**--no-prune**=*true*|*false*
+   Do not delete untagged parents. The default is *false*.
+
+# EXAMPLES
+
+## Removing an image
+
+Here is an example of removing an image:
+
+    docker rmi fedora/httpd
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Mary Anthony for v2 <mary@docker.com>

--- a/man/scw-run.1.md
+++ b/man/scw-run.1.md
@@ -1,0 +1,670 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-run - Run a command in a new container
+
+# SYNOPSIS
+**docker run**
+[**-a**|**--attach**[=*[]*]]
+[**--add-host**[=*[]*]]
+[**--blkio-weight**[=*[BLKIO-WEIGHT]*]]
+[**-c**|**--cpu-shares**[=*0*]]
+[**--cap-add**[=*[]*]]
+[**--cap-drop**[=*[]*]]
+[**--cgroup-parent**[=*CGROUP-PATH*]]
+[**--cidfile**[=*CIDFILE*]]
+[**--cpu-period**[=*0*]]
+[**--cpu-quota**[=*0*]]
+[**--cpuset-cpus**[=*CPUSET-CPUS*]]
+[**--cpuset-mems**[=*CPUSET-MEMS*]]
+[**-d**|**--detach**[=*false*]]
+[**--device**[=*[]*]]
+[**--dns**[=*[]*]]
+[**--dns-search**[=*[]*]]
+[**-e**|**--env**[=*[]*]]
+[**--entrypoint**[=*ENTRYPOINT*]]
+[**--env-file**[=*[]*]]
+[**--expose**[=*[]*]]
+[**--group-add**[=*[]*]]
+[**-h**|**--hostname**[=*HOSTNAME*]]
+[**--help**]
+[**-i**|**--interactive**[=*false*]]
+[**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
+[**--link**[=*[]*]]
+[**--log-driver**[=*[]*]]
+[**--log-opt**[=*[]*]]
+[**--lxc-conf**[=*[]*]]
+[**-m**|**--memory**[=*MEMORY*]]
+[**--mac-address**[=*MAC-ADDRESS*]]
+[**--memory-swap**[=*MEMORY-SWAP*]]
+[**--memory-swappiness**[=*MEMORY-SWAPPINESS*]]
+[**--name**[=*NAME*]]
+[**--net**[=*"bridge"*]]
+[**--oom-kill-disable**[=*false*]]
+[**-P**|**--publish-all**[=*false*]]
+[**-p**|**--publish**[=*[]*]]
+[**--pid**[=*[]*]]
+[**--privileged**[=*false*]]
+[**--read-only**[=*false*]]
+[**--restart**[=*RESTART*]]
+[**--rm**[=*false*]]
+[**--security-opt**[=*[]*]]
+[**--sig-proxy**[=*true*]]
+[**-t**|**--tty**[=*false*]]
+[**-u**|**--user**[=*USER*]]
+[**-v**|**--volume**[=*[]*]]
+[**--ulimit**[=*[]*]]
+[**--uts**[=*[]*]]
+[**--volumes-from**[=*[]*]]
+[**-w**|**--workdir**[=*WORKDIR*]]
+IMAGE [COMMAND] [ARG...]
+
+# DESCRIPTION
+
+Run a process in a new container. **docker run** starts a process with its own
+file system, its own networking, and its own isolated process tree. The IMAGE
+which starts the process may define defaults related to the process that will be
+run in the container, the networking to expose, and more, but **docker run**
+gives final control to the operator or administrator who starts the container
+from the image. For that reason **docker run** has more options than any other
+Docker command.
+
+If the IMAGE is not already loaded then **docker run** will pull the IMAGE, and
+all image dependencies, from the repository in the same way running **docker
+pull** IMAGE, before it starts the container from that image.
+
+# OPTIONS
+**-a**, **--attach**=[]
+   Attach to STDIN, STDOUT or STDERR.
+
+   In foreground mode (the default when **-d**
+is not specified), **docker run** can start the process in the container
+and attach the console to the process’s standard input, output, and standard
+error. It can even pretend to be a TTY (this is what most commandline
+executables expect) and pass along signals. The **-a** option can be set for
+each of stdin, stdout, and stderr.
+
+**--add-host**=[]
+   Add a custom host-to-IP mapping (host:ip)
+
+   Add a line to /etc/hosts. The format is hostname:ip.  The **--add-host**
+option can be set multiple times.
+
+**--blkio-weight**=0
+   Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+
+**-c**, **--cpu-shares**=0
+   CPU shares (relative weight)
+
+   By default, all containers get the same proportion of CPU cycles. This proportion
+can be modified by changing the container's CPU share weighting relative
+to the weighting of all other running containers.
+
+To modify the proportion from the default of 1024, use the **-c** or **--cpu-shares**
+flag to set the weighting to 2 or higher.
+
+The proportion will only apply when CPU-intensive processes are running.
+When tasks in one container are idle, other containers can use the
+left-over CPU time. The actual amount of CPU time will vary depending on
+the number of containers running on the system.
+
+For example, consider three containers, one has a cpu-share of 1024 and
+two others have a cpu-share setting of 512. When processes in all three
+containers attempt to use 100% of CPU, the first container would receive
+50% of the total CPU time. If you add a fourth container with a cpu-share
+of 1024, the first container only gets 33% of the CPU. The remaining containers
+receive 16.5%, 16.5% and 33% of the CPU.
+
+On a multi-core system, the shares of CPU time are distributed over all CPU
+cores. Even if a container is limited to less than 100% of CPU time, it can
+use 100% of each individual CPU core.
+
+For example, consider a system with more than three cores. If you start one
+container **{C0}** with **-c=512** running one process, and another container
+**{C1}** with **-c=1024** running two processes, this can result in the following
+division of CPU shares:
+
+    PID    container	CPU	CPU share
+    100    {C0}		0	100% of CPU0
+    101    {C1}		1	100% of CPU1
+    102    {C1}		2	100% of CPU2
+
+**--cap-add**=[]
+   Add Linux capabilities
+
+**--cap-drop**=[]
+   Drop Linux capabilities
+
+**--cgroup-parent**=""
+   Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
+
+**--cidfile**=""
+   Write the container ID to the file
+
+**--cpu-period**=0
+   Limit the CPU CFS (Completely Fair Scheduler) period
+
+   Limit the container's CPU usage. This flag tell the kernel to restrict the container's CPU usage to the period you specify.
+
+**--cpuset-cpus**=""
+   CPUs in which to allow execution (0-3, 0,1)
+
+**--cpuset-mems**=""
+   Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
+
+   If you have four memory nodes on your system (0-3), use `--cpuset-mems=0,1`
+then processes in your Docker container will only use memory from the first
+two memory nodes.
+
+**--cpu-quota**=0
+   Limit the CPU CFS (Completely Fair Scheduler) quota
+
+   Limit the container's CPU usage. By default, containers run with the full
+CPU resource. This flag tell the kernel to restrict the container's CPU usage
+to the quota you specify.
+
+**-d**, **--detach**=*true*|*false*
+   Detached mode: run the container in the background and print the new container ID. The default is *false*.
+
+   At any time you can run **docker ps** in
+the other shell to view a list of the running containers. You can reattach to a
+detached container with **docker attach**. If you choose to run a container in
+the detached mode, then you cannot use the **-rm** option.
+
+   When attached in the tty mode, you can detach from a running container without
+stopping the process by pressing the keys CTRL-P CTRL-Q.
+
+**--device**=[]
+   Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
+
+**--dns-search**=[]
+   Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
+
+**--dns**=[]
+   Set custom DNS servers
+
+   This option can be used to override the DNS
+configuration passed to the container. Typically this is necessary when the
+host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
+is the case the **--dns** flags is necessary for every run.
+
+**-e**, **--env**=[]
+   Set environment variables
+
+   This option allows you to specify arbitrary
+environment variables that are available for the process that will be launched
+inside of the container.
+
+**--entrypoint**=""
+   Overwrite the default ENTRYPOINT of the image
+
+   This option allows you to overwrite the default entrypoint of the image that
+is set in the Dockerfile. The ENTRYPOINT of an image is similar to a COMMAND
+because it specifies what executable to run when the container starts, but it is
+(purposely) more difficult to override. The ENTRYPOINT gives a container its
+default nature or behavior, so that when you set an ENTRYPOINT you can run the
+container as if it were that binary, complete with default options, and you can
+pass in more options via the COMMAND. But, sometimes an operator may want to run
+something else inside the container, so you can override the default ENTRYPOINT
+at runtime by using a **--entrypoint** and a string to specify the new
+ENTRYPOINT.
+
+**--env-file**=[]
+   Read in a line delimited file of environment variables
+
+**--expose**=[]
+   Expose a port, or a range of ports (e.g. --expose=3300-3310), from the container without publishing it to your host
+
+**--group-add**=[]
+   Add additional groups to run as
+
+**-h**, **--hostname**=""
+   Container host name
+
+   Sets the container host name that is available inside the container.
+
+**--help**
+  Print usage statement
+
+**-i**, **--interactive**=*true*|*false*
+   Keep STDIN open even if not attached. The default is *false*.
+
+   When set to true, keep stdin open even if not attached. The default is false.
+
+**--ipc**=""
+   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
+                               'container:<name|id>': reuses another container shared memory, semaphores and message queues
+                               'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Set metadata on the container (e.g., --label com.example.key=value)
+
+**--label-file**=[]
+   Read in a line delimited file of labels
+
+**--link**=[]
+   Add link to another container in the form of <name or id>:alias or just <name or id>
+in which case the alias will match the name
+
+   If the operator
+uses **--link** when starting the new client container, then the client
+container can access the exposed port via a private networking interface. Docker
+will set some environment variables in the client container to help indicate
+which interface and port to use.
+
+**--lxc-conf**=[]
+   (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
+
+**--log-driver**="|*json-file*|*syslog*|*journald*|*gelf*|*fluentd*|*none*"
+  Logging driver for container. Default is defined by daemon `--log-driver` flag.
+  **Warning**: `docker logs` command works only for `json-file` logging driver.
+
+**--log-opt**=[]
+  Logging driver specific options.
+
+**-m**, **--memory**=""
+   Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
+
+   Allows you to constrain the memory available to a container. If the host
+supports swap memory, then the **-m** memory setting can be larger than physical
+RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
+not limited. The actual limit may be rounded up to a multiple of the operating
+system's page size (the value would be very large, that's millions of trillions).
+
+**--memory-swap**=""
+   Total memory limit (memory + swap)
+
+   Set `-1` to disable swap (format: <number><optional unit>, where unit = b, k, m or g).
+This value should always larger than **-m**, so you should always use this with **-m**.
+
+**--mac-address**=""
+   Container MAC address (e.g. 92:d0:c6:0a:29:33)
+
+   Remember that the MAC address in an Ethernet network must be unique.
+The IPv6 link-local address will be based on the device's MAC address
+according to RFC4862.
+
+**--name**=""
+   Assign a name to the container
+
+   The operator can identify a container in three ways:
+    UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
+    UUID short identifier (“f78375b1c487”)
+    Name (“jonah”)
+
+   The UUID identifiers come from the Docker daemon, and if a name is not assigned
+to the container with **--name** then the daemon will also generate a random
+string name. The name is useful when defining links (see **--link**) (or any
+other place you need to identify a container). This works for both background
+and foreground Docker containers.
+
+**--net**="bridge"
+   Set the Network mode for the container
+                               'bridge': creates a new network stack for the container on the docker bridge
+                               'none': no networking for this container
+                               'container:<name|id>': reuses another container network stack
+                               'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+
+**--oom-kill-disable**=*true*|*false*
+   Whether to disable OOM Killer for the container or not.
+
+**-P**, **--publish-all**=*true*|*false*
+   Publish all exposed ports to random ports on the host interfaces. The default is *false*.
+
+   When set to true publish all exposed ports to the host interfaces. The
+default is false. If the operator uses -P (or -p) then Docker will make the
+exposed port accessible on the host and the ports will be available to any
+client that can reach the host. When using -P, Docker will bind any exposed
+port to a random port on the host within an *ephemeral port range* defined by
+`/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
+ports and the exposed ports, use `docker port`.
+
+**-p**, **--publish**=[]
+   Publish a container's port, or range of ports, to the host.
+                               format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
+                               Both hostPort and containerPort can be specified as a range of ports. 
+                               When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
+                               (use 'docker port' to see the actual mapping)
+
+**--pid**=host
+   Set the PID mode for the container
+     **host**: use the host's PID namespace inside the container.
+     Note: the host mode gives the container full access to local PID and is therefore considered insecure.
+
+**--uts**=host
+   Set the UTS mode for the container
+     **host**: use the host's UTS namespace inside the container.
+     Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
+
+**--privileged**=*true*|*false*
+   Give extended privileges to this container. The default is *false*.
+
+   By default, Docker containers are
+“unprivileged” (=false) and cannot, for example, run a Docker daemon inside the
+Docker container. This is because by default a container is not allowed to
+access any devices. A “privileged” container is given access to all devices.
+
+   When the operator executes **docker run --privileged**, Docker will enable access
+to all devices on the host as well as set some configuration in AppArmor to
+allow the container nearly all the same access to the host as processes running
+outside of a container on the host.
+
+**--read-only**=*true*|*false*
+   Mount the container's root filesystem as read only.
+
+   By default a container will have its root filesystem writable allowing processes
+to write files anywhere.  By specifying the `--read-only` flag the container will have
+its root filesystem mounted as read only prohibiting any writes.
+
+**--restart**="no"
+   Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
+      
+**--rm**=*true*|*false*
+   Automatically remove the container when it exits (incompatible with -d). The default is *false*.
+
+**--security-opt**=[]
+   Security Options
+
+   "label:user:USER"   : Set the label user for the container
+    "label:role:ROLE"   : Set the label role for the container
+    "label:type:TYPE"   : Set the label type for the container
+    "label:level:LEVEL" : Set the label level for the container
+    "label:disable"     : Turn off label confinement for the container
+
+**--sig-proxy**=*true*|*false*
+   Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+
+**--memory-swappiness**=""
+   Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.
+
+**-t**, **--tty**=*true*|*false*
+   Allocate a pseudo-TTY. The default is *false*.
+
+   When set to true Docker can allocate a pseudo-tty and attach to the standard
+input of any container. This can be used, for example, to run a throwaway
+interactive shell. The default is value is false.
+
+The **-t** option is incompatible with a redirection of the docker client
+standard input.
+
+**-u**, **--user**=""
+   Sets the username or UID used and optionally the groupname or GID for the specified command.
+
+   The followings examples are all valid:
+   --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
+
+   Without this argument the command will be run as root in the container.
+
+""--ulimit""=[]
+    Ulimit options
+
+**-v**, **--volume**=[]
+   Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
+
+   The **-v** option can be used one or
+more times to add one or more mounts to a container. These mounts can then be
+used in other containers using the **--volumes-from** option.
+
+   The volume may be optionally suffixed with :ro or :rw to mount the volumes in
+read-only or read-write mode, respectively. By default, the volumes are mounted
+read-write. See examples.
+
+Labeling systems like SELinux require that proper labels are placed on volume
+content mounted into a container. Without a label, the security system might
+prevent the processes running inside the container from using the content. By
+default, Docker does not change the labels set by the OS.
+
+To change a label in the container context, you can add either of two suffixes
+`:z` or `:Z` to the volume mount. These suffixes tell Docker to relabel file
+objects on the shared volumes. The `z` option tells Docker that two containers
+share the volume content. As a result, Docker labels the content with a shared
+content label. Shared volume labels allow all containers to read/write content.
+The `Z` option tells Docker to label the content with a private unshared label.
+Only the current container can use a private volume.
+
+Note: Multiple Volume options can be added separated by a ","
+
+**--volumes-from**=[]
+   Mount volumes from the specified container(s)
+
+   Mounts already mounted volumes from a source container onto another
+   container. You must supply the source's container-id. To share 
+   a volume, use the **--volumes-from** option when running
+   the target container. You can share volumes even if the source container 
+   is not running.
+
+   By default, Docker mounts the volumes in the same mode (read-write or 
+   read-only) as it is mounted in the source container. Optionally, you 
+   can change this by suffixing the container-id with either the `:ro` or 
+   `:rw ` keyword.
+
+   If the location of the volume from the source container overlaps with
+   data residing on a target container, then the volume hides
+   that data on the target.
+
+**-w**, **--workdir**=""
+   Working directory inside the container
+
+   The default working directory for
+running binaries within a container is the root directory (/). The developer can
+set a different default with the Dockerfile WORKDIR instruction. The operator
+can override the working directory by using the **-w** option.
+
+# EXAMPLES
+
+## Exposing log messages from the container to the host's log
+
+If you want messages that are logged in your container to show up in the host's
+syslog/journal then you should bind mount the /dev/log directory as follows.
+
+    # docker run -v /dev/log:/dev/log -i -t fedora /bin/bash
+
+From inside the container you can test this by sending a message to the log.
+
+    (bash)# logger "Hello from my container"
+
+Then exit and check the journal.
+
+    # exit
+
+    # journalctl -b | grep Hello
+
+This should list the message sent to logger.
+
+## Attaching to one or more from STDIN, STDOUT, STDERR
+
+If you do not specify -a then Docker will attach everything (stdin,stdout,stderr)
+. You can specify to which of the three standard streams (stdin, stdout, stderr)
+you’d like to connect instead, as in:
+
+    # docker run -a stdin -a stdout -i -t fedora /bin/bash
+
+## Sharing IPC between containers
+
+Using shm_server.c available here: https://www.cs.cf.ac.uk/Dave/C/node27.html
+
+Testing `--ipc=host` mode:
+
+Host shows a shared memory segment with 7 pids attached, happens to be from httpd:
+
+```
+ $ sudo ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                       
+```
+
+Now run a regular container, and it correctly does NOT see the shared memory segment from the host:
+
+```
+ $ docker run -it shm ipcs -m
+
+ ------ Shared Memory Segments --------	
+ key        shmid      owner      perms      bytes      nattch     status      
+```
+
+Run a container with the new `--ipc=host` option, and it now sees the shared memory segment from the host httpd:
+
+ ```
+ $ docker run -it --ipc=host shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                   
+```
+Testing `--ipc=container:CONTAINERID` mode:
+
+Start a container with a program to create a shared memory segment:
+```
+ $ docker run -it shm bash
+ $ sudo shm/shm_server &
+ $ sudo ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1                       
+```
+Create a 2nd container correctly shows no shared memory segment from 1st container:
+```
+ $ docker run shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+```
+
+Create a 3rd container using the new --ipc=container:CONTAINERID option, now it shows the shared memory segment from the first:
+
+```
+ $ docker run -it --ipc=container:ed735b2264ac shm ipcs -m
+ $ sudo ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1
+```
+
+## Linking Containers
+
+The link feature allows multiple containers to communicate with each other. For
+example, a container whose Dockerfile has exposed port 80 can be run and named
+as follows:
+
+    # docker run --name=link-test -d -i -t fedora/httpd
+
+A second container, in this case called linker, can communicate with the httpd
+container, named link-test, by running with the **--link=<name>:<alias>**
+
+    # docker run -t -i --link=link-test:lt --name=linker fedora /bin/bash
+
+Now the container linker is linked to container link-test with the alias lt.
+Running the **env** command in the linker container shows environment variables
+ with the LT (alias) context (**LT_**)
+
+    # env
+    HOSTNAME=668231cb0978
+    TERM=xterm
+    LT_PORT_80_TCP=tcp://172.17.0.3:80
+    LT_PORT_80_TCP_PORT=80
+    LT_PORT_80_TCP_PROTO=tcp
+    LT_PORT=tcp://172.17.0.3:80
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PWD=/
+    LT_NAME=/linker/lt
+    SHLVL=1
+    HOME=/
+    LT_PORT_80_TCP_ADDR=172.17.0.3
+    _=/usr/bin/env
+
+When linking two containers Docker will use the exposed ports of the container
+to create a secure tunnel for the parent to access.
+
+
+## Mapping Ports for External Usage
+
+The exposed port of an application can be mapped to a host port using the **-p**
+flag. For example, a httpd port 80 can be mapped to the host port 8080 using the
+following:
+
+    # docker run -p 8080:80 -d -i -t fedora/httpd
+
+## Creating and Mounting a Data Volume Container
+
+Many applications require the sharing of persistent data across several
+containers. Docker allows you to create a Data Volume Container that other
+containers can mount from. For example, create a named container that contains
+directories /var/volume1 and /tmp/volume2. The image will need to contain these
+directories so a couple of RUN mkdir instructions might be required for you
+fedora-data image:
+
+    # docker run --name=data -v /var/volume1 -v /tmp/volume2 -i -t fedora-data true
+    # docker run --volumes-from=data --name=fedora-container1 -i -t fedora bash
+
+Multiple --volumes-from parameters will bring together multiple data volumes from
+multiple containers. And it's possible to mount the volumes that came from the
+DATA container in yet another container via the fedora-container1 intermediary
+container, allowing to abstract the actual data source from users of that data:
+
+    # docker run --volumes-from=fedora-container1 --name=fedora-container2 -i -t fedora bash
+
+## Mounting External Volumes
+
+To mount a host directory as a container volume, specify the absolute path to
+the directory and the absolute path for the container directory separated by a
+colon:
+
+    # docker run -v /var/db:/data1 -i -t fedora bash
+
+When using SELinux, be aware that the host has no knowledge of container SELinux
+policy. Therefore, in the above example, if SELinux policy is enforced, the
+`/var/db` directory is not writable to the container. A "Permission Denied"
+message will occur and an avc: message in the host's syslog.
+
+
+To work around this, at time of writing this man page, the following command
+needs to be run in order for the proper SELinux policy type label to be attached
+to the host directory:
+
+    # chcon -Rt svirt_sandbox_file_t /var/db
+
+
+Now, writing to the /data1 volume in the container will be allowed and the
+changes will also be reflected on the host in /var/db.
+
+## Using alternative security labeling
+
+You can override the default labeling scheme for each container by specifying
+the `--security-opt` flag. For example, you can specify the MCS/MLS level, a
+requirement for MLS systems. Specifying the level in the following command
+allows you to share the same content between containers.
+
+    # docker run --security-opt label:level:s0:c100,c200 -i -t fedora bash
+
+An MLS example might be:
+
+    # docker run --security-opt label:level:TopSecret -i -t rhel7 bash
+
+To disable the security labeling for this container versus running with the
+`--permissive` flag, use the following command:
+
+    # docker run --security-opt label:disable -i -t fedora bash
+
+If you want a tighter security policy on the processes within a container,
+you can specify an alternate type for the container. You could run a container
+that is only allowed to listen on Apache ports by executing the following
+command:
+
+    # docker run --security-opt label:type:svirt_apache_t -i -t centos bash
+
+Note:
+
+You would have to write policy defining a `svirt_apache_t` type.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-search.1.md
+++ b/man/scw-search.1.md
@@ -1,0 +1,65 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-search - Search the Docker Hub for images
+
+# SYNOPSIS
+**docker search**
+[**--automated**[=*false*]]
+[**--help**]
+[**--no-trunc**[=*false*]]
+[**-s**|**--stars**[=*0*]]
+TERM
+
+# DESCRIPTION
+
+Search Docker Hub for images that match the specified `TERM`. The table
+of images returned displays the name, description (truncated by default), number
+of stars awarded, whether the image is official, and whether it is automated.
+
+*Note* - Search queries will only return up to 25 results
+
+# OPTIONS
+**--automated**=*true*|*false*
+   Only show automated builds. The default is *false*.
+
+**--help**
+  Print usage statement
+
+**--no-trunc**=*true*|*false*
+   Don't truncate output. The default is *false*.
+
+**-s**, **--stars**=0
+   Only displays with at least x stars
+
+# EXAMPLES
+
+## Search Docker Hub for ranked images
+
+Search a registry for the term 'fedora' and only display those images
+ranked 3 or higher:
+
+    $ docker search -s 3 fedora
+    NAME                  DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
+    mattdm/fedora         A basic Fedora image corresponding roughly...  50
+    fedora                (Semi) Official Fedora base image.             38
+    mattdm/fedora-small   A small Fedora image on which to build. Co...  8
+    goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
+
+## Search Docker Hub for automated images
+
+Search Docker Hub for the term 'fedora' and only display automated images
+ranked 1 or higher:
+
+    $ docker search -s 1 fedora
+    NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
+    goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
+    tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Mary Anthony for v2 <mary@docker.com>
+

--- a/man/scw-start.1.md
+++ b/man/scw-start.1.md
@@ -1,0 +1,34 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-start - Start one or more stopped containers
+
+# SYNOPSIS
+**docker start**
+[**-a**|**--attach**[=*false*]]
+[**--help**]
+[**-i**|**--interactive**[=*false*]]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+
+Start one or more stopped containers.
+
+# OPTIONS
+**-a**, **--attach**=*true*|*false*
+   Attach container's STDOUT and STDERR and forward all signals to the process. The default is *false*.
+
+**--help**
+  Print usage statement
+
+**-i**, **--interactive**=*true*|*false*
+   Attach container's STDIN. The default is *false*.
+
+# See also
+**docker-stop(1)** to stop a running container.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-stats.1.md
+++ b/man/scw-stats.1.md
@@ -1,0 +1,30 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-stats - Display a live stream of one or more containers' resource usage statistics
+
+# SYNOPSIS
+**docker stats**
+[**--help**]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+
+Display a live stream of one or more containers' resource usage statistics
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**--no-stream**="false"
+  Disable streaming stats and only pull the first result
+
+# EXAMPLES
+
+Run **docker stats** with multiple containers.
+
+    $ docker stats redis1 redis2
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
+    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B

--- a/man/scw-stop.1.md
+++ b/man/scw-stop.1.md
@@ -1,0 +1,30 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-stop - Stop a running container by sending SIGTERM and then SIGKILL after a grace period
+
+# SYNOPSIS
+**docker stop**
+[**--help**]
+[**-t**|**--time**[=*10*]]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+Stop a running container (Send SIGTERM, and then SIGKILL after
+ grace period)
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**-t**, **--time**=10
+   Number of seconds to wait for the container to stop before killing it. Default is 10 seconds.
+
+#See also
+**docker-start(1)** to restart a stopped container.
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw-tag.1.md
+++ b/man/scw-tag.1.md
@@ -1,0 +1,66 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-tag - Tag an image into a repository
+
+# SYNOPSIS
+**docker tag**
+[**-f**|**--force**[=*false*]]
+[**--help**]
+IMAGE[:TAG] [REGISTRY_HOST/][USERNAME/]NAME[:TAG]
+
+# DESCRIPTION
+Assigns a new alias to an image in a registry. An alias refers to the
+entire image name including the optional `TAG` after the ':'. 
+
+If you do not specify a `REGISTRY_HOST`, the command uses Docker's public
+registry located at `registry-1.docker.io` by default. 
+
+# "OPTIONS"
+**-f**, **--force**=*true*|*false*
+   When set to true, force the alias. The default is *false*.
+
+**REGISTRYHOST**
+   The hostname of the registry if required. This may also include the port
+separated by a ':'
+
+**USERNAME**
+   The username or other qualifying identifier for the image.
+
+**NAME**
+   The image name.
+
+**TAG**
+   The tag you are assigning to the image.  Though this is arbitrary it is
+recommended to be used for a version to distinguish images with the same name.
+Also, for consistency tags should only include a-z0-9-_. .
+Note that here TAG is a part of the overall name or "tag".
+
+# OPTIONS
+**-f**, **--force**=*true*|*false*
+   Force. The default is *false*.
+
+# EXAMPLES
+
+## Giving an image a new alias
+
+Here is an example of aliasing an image (e.g., 0e5574283393) as "httpd" and 
+tagging it into the "fedora" repository with "version1.0":
+
+    docker tag 0e5574283393 fedora/httpd:version1.0
+
+## Tagging an image for a private repository
+
+To push an image to an private registry and not the central Docker
+registry you must tag it with the registry hostname and port (if needed).
+
+    docker tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+April 2015, updated by Mary Anthony for v2 <mary@docker.com>
+June 2015, updated by Sally O'Malley <somalley@redhat.com>

--- a/man/scw-top.1.md
+++ b/man/scw-top.1.md
@@ -1,0 +1,34 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-top - Display the running processes of a container
+
+# SYNOPSIS
+**docker top**
+[**--help**]
+CONTAINER [ps OPTIONS]
+
+# DESCRIPTION
+
+Display the running process of the container. ps-OPTION can be any of the
+ options you would pass to a Linux ps command.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+# EXAMPLES
+
+Run **docker top** with the ps option of -x:
+
+    $ docker top 8601afda2b -x
+    PID      TTY       STAT       TIME         COMMAND
+    16623    ?         Ss         0:00         sleep 99999
+
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2015, updated by Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

--- a/man/scw-version.1.md
+++ b/man/scw-version.1.md
@@ -1,0 +1,62 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2015
+# NAME
+docker-version - Show the Docker version information.
+
+# SYNOPSIS
+**docker version**
+[**--help**]
+[**-f**|**--format**[=*FORMAT*]]
+
+# DESCRIPTION
+This command displays version information for both the Docker client and 
+daemon. 
+
+# OPTIONS
+**--help**
+    Print usage statement
+
+**-f**, **--format**=""
+    Format the output using the given go template.
+
+# EXAMPLES
+
+## Display Docker version information
+
+The default output:
+
+    $ docker version
+	Client:
+	 Version:      1.8.0
+	 API version:  1.20
+	 Go version:   go1.4.2
+	 Git commit:   f5bae0a
+	 Built:        Tue Jun 23 17:56:00 UTC 2015
+	 OS/Arch:      linux/amd64
+
+	Server:
+	 Version:      1.8.0
+	 API version:  1.20
+	 Go version:   go1.4.2
+	 Git commit:   f5bae0a
+	 Built:        Tue Jun 23 17:56:00 UTC 2015
+	 OS/Arch:      linux/amd64
+
+Get server version:
+
+    $ docker version --format '{{.Server.Version}}'
+	1.8.0
+
+Dump raw data:
+
+To view all available fields, you can use the format `{{json .}}`.
+
+    $ docker version --format '{{json .}}'
+    {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+
+	
+# HISTORY
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2015, updated by John Howard <jhoward@microsoft.com>
+June 2015, updated by Patrick Hemmer <patrick.hemmer@gmail.com

--- a/man/scw-wait.1.md
+++ b/man/scw-wait.1.md
@@ -1,0 +1,30 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-wait - Block until a container stops, then print its exit code.
+
+# SYNOPSIS
+**docker wait**
+[**--help**]
+CONTAINER [CONTAINER...]
+
+# DESCRIPTION
+
+Block until a container stops, then print its exit code.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+# EXAMPLES
+
+    $ docker run -d fedora sleep 99
+    079b83f558a2bc52ecad6b2a5de13622d584e6bb1aea058c11b36511e85e7622
+    $ docker wait 079b83f558a2bc
+    0
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.com source material and internal work.
+June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/scw.1.md
+++ b/man/scw.1.md
@@ -1,0 +1,152 @@
+% SCW(1) Scaleway-cli User Manuals
+% Scaleway Team
+% August 2015
+# NAME
+scw \- Scaleway command line interface
+
+# SYNOPSIS
+**scw** [OPTIONS] COMMAND [arg...]
+
+# DESCRIPTION
+**scw** is a client to the Scaleway API, through the CLI.
+
+The Scaleway CLI has near 30 commands. The commands are listed below and each
+has its own man page which explain usage and arguments.
+
+To see the man page for a command run **man scw <command>**.
+
+# OPTIONS
+**-h**, **--help**
+  Print usage statement
+
+**-D**, **--debug**=*true*|*false*
+  Enable debug mode. Default is false.
+
+**-v**, **--version**=*true*|*false*
+  Print version information and quit. Default is false.
+
+**--sensitive**=*true*|*false*
+  Show sensitive data in outputs, i.e. API Token/Organization. Default is false.
+
+# COMMANDS
+**attach**
+  Attach to a server serial console
+  See **scw-attach(1)** for full documentation on the **attach** command.
+
+**commit**
+  Create a new snapshot from a server's volume
+  See **scw-commit(1)** for full documentation on the **commit** command.
+
+**cp**
+  Copy files/folders from a PATH on the server to a HOSTDIR on the host
+  See **scw-cp(1)** for full documentation on the **cp** command.
+
+**create**
+  Create a new server but do not start it
+  See **scw-create(1)** for full documentation on the **create** command.
+
+**events**
+  Get real time events from the server
+  See **scw-events(1)** for full documentation on the **events** command.
+
+**exec**
+  Run a command in a running server
+  See **scw-exec(1)** for full documentation on the **exec** command.
+
+**history**
+  Show the history of an image
+  See **scw-history(1)** for full documentation on the **history** command.
+
+**images**
+  List images
+  See **scw-images(1)** for full documentation on the **images** command.
+
+**info**
+  Display system-wide information
+  See **scw-info(1)** for full documentation on the **info** command.
+
+**inspect**
+  Return low-level information on a server, image, snapshot, volume or bootscript
+  See **scw-inspect(1)** for full documentation on the **inspect** command.
+
+**kill**
+  Kill a running server
+  See **scw-kill(1)** for full documentation on the **kill** command.
+
+**login**
+  Log in to Scaleway API
+  See **scw-login(1)** for full documentation on the **login** command.
+
+**logout**
+  Log out from the Scaleway API
+  See **scw-logout(1)** for full documentation on the **logout** command.
+
+**logs**
+  Fetch the logs of a server
+  See **scw-logs(1)** for full documentation on the **logs** command.
+
+**port**
+  Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+  See **scw-port(1)** for full documentation on the **port** command.
+
+**ps**
+  List servers
+  See **scw-ps(1)** for full documentation on the **ps** command.
+
+**rename**
+  Rename a server
+  See **scw-ps(1)** for full documentation on the **ps** command.
+
+**restart**
+  Restart a running server
+  See **scw-restart(1)** for full documentation on the **restart** command.
+
+**rm**
+  Remove one or more servers
+  See **scw-rm(1)** for full documentation on the **rm** command.
+
+**rmi**
+  Remove one or more images
+  See **scw-rmi(1)** for full documentation on the **rmi** command.
+
+**run**
+  Run a command in a new server
+  See **scw-run(1)** for full documentation on the **run** command.
+
+**search**
+  Search the Scaleway Hub for images
+  See **scw-search(1)** for full documentation on the **search** command.
+
+**start**
+  Start a stopped server
+  See **scw-start(1)** for full documentation on the **start** command.
+
+**stop**
+  Stop a running server
+  See **scw-stop(1)** for full documentation on the **stop** command.
+
+**tag**
+  Tag a snapshot into an image
+  See **scw-tag(1)** for full documentation on the **tag** command.
+
+**top**
+  Lookup the running processes of a server
+  See **scw-top(1)** for full documentation on the **top** command.
+
+**version**
+  Show the Scaleway CLI version information
+  See **scw-version(1)** for full documentation on the **version** command.
+
+**wait**
+  Block until a server stops
+  See **scw-wait(1)** for full documentation on the **wait** command.
+
+
+#### Client
+For specific client examples please see the man page for the specific Scw
+command. For example:
+
+    man scw-run
+
+# HISTORY
+August 2015, Originally compiled by Scaleway Team based on scaleway.com source material and internal work.


### PR DESCRIPTION
To do:
- [x] Add scw.1.md
- [x] Add scw-attach.1.md
- [ ] Add scw-commit.1.md
- [ ] Add scw-cp.1.md
- [ ] Add scw-create.1.md
- [ ] Add scw-events.1.md
- [ ] Add scw-exec.1.md
- [ ] Add scw-history.1.md
- [ ] Add scw-images.1.md
- [ ] Add scw-info.1.md
- [ ] Add scw-inspect.1.md
- [ ] Add scw-kill.1.md
- [ ] Add scw-login.1.md
- [ ] Add scw-logout.1.md
- [ ] Add scw-logs.1.md
- [ ] Add scw-port.1.md
- [ ] Add scw-ps.1.md
- [ ] Add scw-rename.1.md
- [ ] Add scw-restart.1.md
- [ ] Add scw-rm.1.md
- [ ] Add scw-rmi.1.md
- [ ] Add scw-run.1.md
- [ ] Add scw-search.1.md
- [ ] Add scw-start.1.md
- [ ] Add scw-stats.1.md
- [ ] Add scw-stop.1.md
- [ ] Add scw-tag.1.md
- [ ] Add scw-top.1.md
- [ ] Add scw-version.1.md
- [ ] Add scw-wait.1.md
- [ ] Configure homebrew to install man pages
