### PR TITLE
Support of 'scw _patch SERVER tags="tag1 tag2 tag3"'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 #### Features
 
+* Support of `_patch SERVER tags="tag1 tag2=value2 tag3"`
 * `scw -D login` displays a fake password
 * Support --skip-ssh-key `scw login` ([#129](https://github.com/scaleway/scaleway-cli/issues/129))
 * Now `scw login` ask your login/password, you can also pass token and organization with -o and -t ([#59](https://github.com/scaleway/scaleway-cli/issues/59))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -449,7 +449,7 @@ type ScalewayServerPatchDefinition struct {
 	Volumes           *map[string]ScalewayVolume `json:"volumes,omitempty"`
 	SecurityGroup     *ScalewaySecurityGroup     `json:"security_group,omitempty"`
 	Organization      *string                    `json:"organization,omitempty"`
-	//Tags            *[]string                  `json:"tags,omitempty"`
+	Tags              *[]string                  `json:"tags,omitempty"`
 }
 
 // ScalewayServerDefinition represents a Scaleway C1 server with image definition

--- a/pkg/cli/x_patch.go
+++ b/pkg/cli/x_patch.go
@@ -41,7 +41,7 @@ func runPatch(cmd *Command, args []string) error {
 	}
 
 	// Parsing FIELD=VALUE
-	updateParts := strings.Split(args[1], "=")
+	updateParts := strings.SplitN(args[1], "=", 2)
 	if len(updateParts) != 2 {
 		cmd.PrintShortUsage()
 	}
@@ -86,6 +86,12 @@ func runPatch(cmd *Command, args []string) error {
 				changes++
 				payload.SecurityGroup.Identifier = newValue
 			}
+		case "tags":
+			newTags := strings.Split(newValue, " ")
+			log.Debugf("%s=%s  =>  %s=%s", fieldName, currentServer.Tags, fieldName, newTags)
+			// fixme test equality with reflect.DeepEqual ?
+			changes++
+			payload.Tags = &newTags
 		default:
 			log.Fatalf("'_patch server %s=' not implemented", fieldName)
 		}


### PR DESCRIPTION
i.e: `scw _patch server:bitrig-build tags="test test=test toto=titi tutu"`