### PR TITLE
Printing `curl` commands when debugging API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1128,6 +1128,7 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 #### Features
 
+* `-D,--debug` mode shows ready to copy-paste `curl` commands when using the API (must be used with `--sensitive` to unhide private token)
 * Support of `_patch SERVER tags="tag1 tag2=value2 tag3"`
 * `scw -D login` displays a fake password
 * Support --skip-ssh-key `scw login` ([#129](https://github.com/scaleway/scaleway-cli/issues/129))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,9 +20,9 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	"github.com/moul/http2curl"
 	log "github.com/scaleway/scaleway-cli/vendor/github.com/Sirupsen/logrus"
 	"github.com/scaleway/scaleway-cli/vendor/github.com/moul/anonuuid"
+	"github.com/scaleway/scaleway-cli/vendor/github.com/moul/http2curl"
 )
 
 // Default values

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,6 +20,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	"github.com/moul/http2curl"
 	log "github.com/scaleway/scaleway-cli/vendor/github.com/Sirupsen/logrus"
 	"github.com/scaleway/scaleway-cli/vendor/github.com/moul/anonuuid"
 )
@@ -626,13 +627,21 @@ func (s *ScalewayAPI) Sync() {
 // GetResponse returns an http.Response object for the requested resource
 func (s *ScalewayAPI) GetResponse(resource string) (*http.Response, error) {
 	uri := fmt.Sprintf("%s/%s", strings.TrimRight(s.APIUrl, "/"), resource)
-	log.Debugf("GET %s", uri)
+
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Auth-Token", s.Token)
 	req.Header.Set("Content-Type", "application/json")
+
+	curl, err := http2curl.GetCurlCommand(req)
+	if os.Getenv("SCW_SENSITIVE") != "1" {
+		log.Debug(s.HideAPICredentials(curl.String()))
+	} else {
+		log.Debug(curl.String())
+	}
+
 	return s.client.Do(req)
 }
 
@@ -645,18 +654,20 @@ func (s *ScalewayAPI) PostResponse(resource string, data interface{}) (*http.Res
 		return nil, err
 	}
 
-	payloadString := strings.TrimSpace(fmt.Sprintf("%s", payload))
-	if os.Getenv("SCW_SENSITIVE") != "1" {
-		payloadString = s.HideAPICredentials(payloadString)
-	}
-	log.Debugf("POST %s payload=%s", uri, payloadString)
-
 	req, err := http.NewRequest("POST", uri, payload)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Auth-Token", s.Token)
 	req.Header.Set("Content-Type", "application/json")
+
+	curl, err := http2curl.GetCurlCommand(req)
+	if os.Getenv("SCW_SENSITIVE") != "1" {
+		log.Debug(s.HideAPICredentials(curl.String()))
+	} else {
+		log.Debug(curl.String())
+	}
+
 	return s.client.Do(req)
 }
 
@@ -669,18 +680,20 @@ func (s *ScalewayAPI) PatchResponse(resource string, data interface{}) (*http.Re
 		return nil, err
 	}
 
-	payloadString := strings.TrimSpace(fmt.Sprintf("%s", payload))
-	if os.Getenv("SCW_SENSITIVE") != "1" {
-		payloadString = s.HideAPICredentials(payloadString)
-	}
-	log.Debugf("PATCH %s payload=%s", uri, payloadString)
-
 	req, err := http.NewRequest("PATCH", uri, payload)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Auth-Token", s.Token)
 	req.Header.Set("Content-Type", "application/json")
+
+	curl, err := http2curl.GetCurlCommand(req)
+	if os.Getenv("SCW_SENSITIVE") != "1" {
+		log.Debug(s.HideAPICredentials(curl.String()))
+	} else {
+		log.Debug(curl.String())
+	}
+
 	return s.client.Do(req)
 }
 
@@ -693,31 +706,41 @@ func (s *ScalewayAPI) PutResponse(resource string, data interface{}) (*http.Resp
 		return nil, err
 	}
 
-	payloadString := strings.TrimSpace(fmt.Sprintf("%s", payload))
-	if os.Getenv("SCW_SENSITIVE") != "1" {
-		payloadString = s.HideAPICredentials(payloadString)
-	}
-	log.Debugf("PUT %s payload=%s", uri, payloadString)
-
 	req, err := http.NewRequest("PUT", uri, payload)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Auth-Token", s.Token)
 	req.Header.Set("Content-Type", "application/json")
+
+	curl, err := http2curl.GetCurlCommand(req)
+	if os.Getenv("SCW_SENSITIVE") != "1" {
+		log.Debug(s.HideAPICredentials(curl.String()))
+	} else {
+		log.Debug(curl.String())
+	}
+
 	return s.client.Do(req)
 }
 
 // DeleteResponse returns an http.Response object for the deleted resource
 func (s *ScalewayAPI) DeleteResponse(resource string) (*http.Response, error) {
 	uri := fmt.Sprintf("%s/%s", strings.TrimRight(s.APIUrl, "/"), resource)
-	log.Debugf("DELETE %s", uri)
+
 	req, err := http.NewRequest("DELETE", uri, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Auth-Token", s.Token)
 	req.Header.Set("Content-Type", "application/json")
+
+	curl, err := http2curl.GetCurlCommand(req)
+	if os.Getenv("SCW_SENSITIVE") != "1" {
+		log.Debug(s.HideAPICredentials(curl.String()))
+	} else {
+		log.Debug(curl.String())
+	}
+
 	return s.client.Do(req)
 }
 

--- a/pkg/cli/x_patch.go
+++ b/pkg/cli/x_patch.go
@@ -104,7 +104,7 @@ func runPatch(cmd *Command, args []string) error {
 			log.Debugf("no changes, not updating server")
 		}
 		if err != nil {
-			log.Fatalf("Cannot rename server: %v", err)
+			log.Fatalf("Cannot update server: %v", err)
 		}
 	default:
 		log.Fatalf("_patch not implemented for this kind of object")

--- a/pkg/sshcommand/sshcommand.go
+++ b/pkg/sshcommand/sshcommand.go
@@ -107,8 +107,9 @@ func (c *Command) Slice() []string {
 func (c *Command) String() string {
 	slice := c.Slice()
 	for i := range slice {
-		if strings.Contains(slice[i], " ") {
-			slice[i] = fmt.Sprintf("%q", slice[i])
+		quoted := fmt.Sprintf("%q", slice[i])
+		if strings.Contains(slice[i], " ") || len(quoted) != len(slice[i])+2 {
+			slice[i] = quoted
 		}
 	}
 	return strings.Join(slice, " ")

--- a/vendor/github.com/moul/http2curl/LICENSE
+++ b/vendor/github.com/moul/http2curl/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Manfred Touron
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/moul/http2curl/Makefile
+++ b/vendor/github.com/moul/http2curl/Makefile
@@ -1,0 +1,3 @@
+convey:
+	go get github.com/smartystreets/goconvey
+	goconvey -cover -port=9393 -workDir="$(realpath .)" -depth=0

--- a/vendor/github.com/moul/http2curl/README.md
+++ b/vendor/github.com/moul/http2curl/README.md
@@ -1,0 +1,2 @@
+# http2curl
+:triangular_ruler: Convert Golang's http.Request to CURL command line

--- a/vendor/github.com/moul/http2curl/http2curl.go
+++ b/vendor/github.com/moul/http2curl/http2curl.go
@@ -1,0 +1,66 @@
+package http2curl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// CurlCommand contains exec.Command compatible slice + helpers
+type CurlCommand struct {
+	slice []string
+}
+
+// append appends a string to the CurlCommand
+func (c *CurlCommand) append(newSlice ...string) {
+	c.slice = append(c.slice, newSlice...)
+}
+
+// String returns a ready to copy/paste command
+func (c *CurlCommand) String() string {
+	slice := make([]string, len(c.slice))
+	copy(slice, c.slice)
+	for i := range slice {
+		quoted := fmt.Sprintf("%q", slice[i])
+		if strings.Contains(slice[i], " ") || len(quoted) != len(slice[i])+2 {
+			slice[i] = quoted
+		}
+	}
+	return strings.Join(slice, " ")
+}
+
+// nopCloser is used to create a new io.ReadCloser for req.Body
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+// GetCurlCommand returns a CurlCommand corresponding to an http.Request
+func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
+	command := CurlCommand{}
+
+	command.append("curl")
+
+	command.append("-X", req.Method)
+
+	if req.Body != nil {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = nopCloser{bytes.NewBuffer(body)}
+		command.append("-d", fmt.Sprintf("%s", bytes.Trim(body, "\n")))
+	}
+
+	for key, values := range req.Header {
+		command.append("-H", fmt.Sprintf("%s: %s", key, strings.Join(values, " ")))
+	}
+
+	command.append(req.URL.String())
+
+	return &command, nil
+}

--- a/vendor/github.com/moul/http2curl/http2curl_test.go
+++ b/vendor/github.com/moul/http2curl/http2curl_test.go
@@ -1,0 +1,38 @@
+package http2curl
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	. "github.com/scaleway/scaleway-cli/vendor/github.com/smartystreets/goconvey/convey"
+)
+
+func ExampleGetCurlCommand() {
+	req, _ := http.NewRequest("PUT", "http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu", bytes.NewBufferString(`{"hello":"world","answer":42}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	command, _ := GetCurlCommand(req)
+	fmt.Println(command)
+
+	// Output:
+	// curl -X PUT -d "{\"hello\":\"world\",\"answer\":42}" -H "Content-Type: application/json" http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu
+}
+
+func TestGetCurlCommand(t *testing.T) {
+	Convey("Testing http2curl", t, func() {
+		uri := "http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu"
+		payload := new(bytes.Buffer)
+		payload.Write([]byte(`{"hello":"world","answer":42}`))
+		req, err := http.NewRequest("PUT", uri, payload)
+		So(err, ShouldBeNil)
+		req.Header.Set("X-Auth-Token", "private-token")
+		req.Header.Set("Content-Type", "application/json")
+
+		command, err := GetCurlCommand(req)
+		So(err, ShouldBeNil)
+		expected := `curl -X PUT -d "{\"hello\":\"world\",\"answer\":42}" -H "X-Auth-Token: private-token" -H "Content-Type: application/json" http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu`
+		So(command.String(), ShouldEqual, expected)
+	})
+}


### PR DESCRIPTION
```console
$ scw -D inspect server:alpine | anonuuid
DEBU[0000] curl -X GET -H "X-Auth-Token: 00000000-0000-0000-0000-000000000000" -H "Content-Type: application/json" https://api.scaleway.com/servers/4275e304-9b40-4c1b-9baf-36e888721c1e
[{
  "id": "00000000-0000-1000-0000-000000000000",
  "name": "[rescue] distrib-alpine-latest",
  "creation_date": "2015-03-18T10:01:42.761470+00:00",
...
```

```console
$ scw -D create alpine
DEBU[0000] curl -X POST -d "{\"name\":\"focused-morse\",\"image\":\"00000000-0000-1000-0000-000000000000\",\"dynamic_ip_required\":true,\"bootscript\":null,\"organization\":\"11111111-1111-1111-1111-111111111111\"}" -H "X-Auth-Token: 00000000-0000-0000-0000-000000000000" -H "Content-Type: application/json" https://api.scaleway.com/servers
DEBU[0001] curl -X GET -H "Content-Type: application/json" -H "X-Auth-Token: 00000000-0000-0000-0000-000000000000" https://api.scaleway.com/servers/22222222-2222-1222-2222-222222222222
DEBU[0002] curl -X PUT -d "{\"id\":\"33333333-3333-1333-3333-333333333333\",\"size\":50000000000,\"creation_date\":\"2015-08-27T13:31:32.451912+00:00\",\"modification_date\":\"2015-08-27T13:31:32.451912+00:00\",\"organization\":\"11111111-1111-1111-1111-111111111111\",\"name\":\"focused-morse-scw-distrib-alpine-latest-2015-06-19_17:09\",\"server\":{\"id\":\"22222222-2222-1222-2222-222222222222\",\"name\":\"focused-morse\"},\"volume_type\":\"l_ssd\",\"export_uri\":\"\"}" -H "X-Auth-Token: 00000000-0000-0000-0000-000000000000" -H "Content-Type: application/json" https://api.scaleway.com/volumes/33333333-3333-1333-3333-333333333333
22222222-2222-1222-2222-222222222222
```

```console
$ scw -D rename focused-morse hello-world
DEBU[0000] curl -X PATCH -d "{\"name\":\"hello-world\"}" -H "X-Auth-Token: 00000000-0000-0000-0000-000000000000" -H "Content-Type: application/json" https://api.scaleway.com/servers/22222222-2222-1222-2222-222222222222
```