### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -389,12 +389,12 @@ func WaitForServerState(api *ScalewayAPI, serverID string, targetState string) (
 
 	for {
 		server, err = api.GetServer(serverID)
+		if err != nil {
+			return nil, err
+		}
 		if currentState != server.State {
 			log.Infof("Server changed state to '%s'", server.State)
 			currentState = server.State
-		}
-		if err != nil {
-			return nil, err
 		}
 		if server.State == targetState {
 			break


### PR DESCRIPTION
I triggered this with:

    $ scw wait abcdef
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x0 pc=0x52137e]
    
    goroutine 1 [running]:
    github.com/scaleway/scaleway-cli/pkg/api.WaitForServerState(0xc820086580, 0xc8203e4c90, 0x24, 0x8993b8, 0x7, 0x0, 0x0, 0x0)
            go/src/github.com/scaleway/scaleway-cli/pkg/api/helpers.go:392 +0x30e
    github.com/scaleway/scaleway-cli/pkg/api.WaitForServerStopped(0xc820086580, 0xc8203e4c90, 0x24, 0xc8203e4c90, 0x0, 0x0)
            go/src/github.com/scaleway/scaleway-cli/pkg/api/helpers.go:468 +0x5a
    github.com/scaleway/scaleway-cli/pkg/commands.RunWait(0x7f6afb1eb220, 0xc82002a008, 0x7f6afb1eb308, 0xc82002a010, 0x7f6afb1eb308, 0xc82002a018, 0xc82000cc80, 0x28, 0x28, 0xc82000a2f0, ...)
            go/src/github.com/scaleway/scaleway-cli/pkg/commands/wait.go:25 +0x122
    github.com/scaleway/scaleway-cli/pkg/cli.runWait(0xab8220, 0xc82000a2f0, 0x1, 0x1, 0x0, 0x0)
            go/src/github.com/scaleway/scaleway-cli/pkg/cli/cmd_wait.go:35 +0x13c
    github.com/scaleway/scaleway-cli/pkg/cli.Start(0xc82000a2e0, 0x2, 0x2, 0xc82000bc80, 0x0, 0x0, 0x0)
            go/src/github.com/scaleway/scaleway-cli/pkg/cli/main.go:113 +0xc76
    main.main()
            go/src/github.com/scaleway/scaleway-cli/cmd/scw/main.go:16 +0x8e
    ...

But it's not easy to reproduce.