### PR TITLE
Various cache file handling fixes

### DIFF
--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -185,6 +185,7 @@ func (c *ScalewayCache) Save() error {
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 		encoder := json.NewEncoder(file)
 		err = encoder.Encode(*c)
 		if err != nil {

--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -189,9 +189,14 @@ func (c *ScalewayCache) Save() error {
 		encoder := json.NewEncoder(file)
 		err = encoder.Encode(*c)
 		if err != nil {
+			os.Remove(file.Name())
 			return err
 		}
-		return os.Rename(file.Name(), c.Path)
+
+		if err := os.Rename(file.Name(), c.Path); err != nil {
+			os.Remove(file.Name())
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -181,7 +181,7 @@ func (c *ScalewayCache) Save() error {
 	logrus.Debugf("Writing cache file to disk")
 
 	if c.Modified {
-		file, err := ioutil.TempFile("", "")
+		file, err := ioutil.TempFile(filepath.Dir(c.Path), filepath.Base(c.Path))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`os.Rename` only works if src and dest are on the same partition. So if `$TMPDIR`
and `$HOME` are on different paritions the cache file was never written and a lot
of temp files were left behind.