### PR TITLE
Fix bug that starting an already started server succeeds.

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -485,7 +485,7 @@ func StartServer(api *ScalewayAPI, needle string, wait bool) error {
 
 	err := api.PostServerAction(server, "poweron")
 	if err != nil {
-		if err.Error() != "server should be stopped" {
+		if err.Error() == "server should be stopped" {
 			return fmt.Errorf("server %s is already started: %v", server, err)
 		}
 	}


### PR DESCRIPTION
The code should catch when the server is already started and you try
to call "scw start <id>" but currently that doesn't happen due to a
typo s/!=/==/.