### PR TITLE
Check go version in cmd/scw too

### DIFF
--- a/cmd/scw/main.go
+++ b/cmd/scw/main.go
@@ -3,6 +3,9 @@
 // license that can be found in the LICENSE.md file.
 
 // Manage BareMetal Servers from Command Line (as easily as with Docker)
+
+// +build go1.5
+
 package main
 
 import (

--- a/cmd/scw/main_unsupported.go
+++ b/cmd/scw/main_unsupported.go
@@ -1,0 +1,7 @@
+// +build !go1.5
+
+package main
+
+func error() {
+	`Bad go version, please install a version greater than or equal to 1.5`
+}


### PR DESCRIPTION
```console
root@733000e59cca:~/bin# eval "$(GIMME_GO_VERSION=1.4 ./gimme)"
go version go1.4 linux/amd64
root@733000e59cca:~/bin# go get -u github.com/QuentinPerez/scaleway-cli/cmd/scw
# github.com/QuentinPerez/scaleway-cli/cmd/scw
../src/src/github.com/QuentinPerez/scaleway-cli/cmd/scw/main_unsupported.go:6: "Bad go version, please install a version greater than or equal to 1.5" evaluated but not used
root@733000e59cca:~/bin# rm -fr /root/src/*
root@733000e59cca:~/bin# eval "$(GIMME_GO_VERSION=1.5 ./gimme)"
go version go1.5 linux/amd64
root@733000e59cca:~/bin# go get -u github.com/QuentinPerez/scaleway-cli/cmd/scw
root@733000e59cca:~/bin#
```