### PR TITLE
exec: Add warning to flush cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 ### master (unreleased)
 
+* `scw exec` Add warning to try to clean the cache when an error occurred
 * `scw rename` fix nil dereference ([#289](https://github.com/scaleway/scaleway-cli/issues/289))
 * Support of `scw [run|create] --ip-address=[none|dynamic]` ([#283](https://github.com/scaleway/scaleway-cli/pull/283)) ([@ElNounch](https://github.com/ElNounch))
 * Support of `scw ps -f server-type=COMMERCIALTYPE` ([#280](https://github.com/scaleway/scaleway-cli/issues/280))

--- a/pkg/commands/exec.go
+++ b/pkg/commands/exec.go
@@ -70,7 +70,11 @@ func RunExec(ctx CommandContext, args ExecArgs) error {
 		log.Debugf("scw won't wait for the server to be ready, if it is not, the command will fail")
 		server, err = ctx.API.GetServer(serverID)
 		if err != nil {
-			return fmt.Errorf("Failed to get server information for %s: %v", serverID, err)
+			rerr := fmt.Errorf("Failed to get server information for %s: %v", serverID, err)
+			if err.Error() == `"`+serverID+`" not found` {
+				return fmt.Errorf("%v\nmaybe try to flush the cache with : scw _flush-cache", rerr)
+			}
+			return rerr
 		}
 	}
 


### PR DESCRIPTION
Before
```console
./scw exec toto
FATA[0000] cannot execute 'exec': Failed to get server information for 0c1e61b8-d8fc-476e-9a1c-9b218ee82604: "0c1e61b8-d8fc-476e-9a1c-9b218ee82604" not found
```
After
```console
./scw exec toto
FATA[0000] cannot execute 'exec': Failed to get server information for 0c1e61b8-d8fc-476e-9a1c-9b218ee82604: "0c1e61b8-d8fc-476e-9a1c-9b218ee82604" not found
maybe try to flush the cache with : scw _flush-cache
```