### PR TITLE
Fix nil dereference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 ### master (unreleased)
 
+* Fix `scw _patch bootscript` nil dereference
 * Fix `scw images` bad error message ([#336](https://github.com/scaleway/scaleway-cli/issues/337))
 * Fix sshExecCommand with Windows ([#338](https://github.com/scaleway/scaleway-cli/issues/338))
 * Fix `scw login` with Windows ([#341](https://github.com/scaleway/scaleway-cli/issues/341))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -546,7 +546,7 @@ type ScalewayServerPatchDefinition struct {
 	State             *string                    `json:"state,omitempty"`
 	StateDetail       *string                    `json:"state_detail,omitempty"`
 	PrivateIP         *string                    `json:"private_ip,omitempty"`
-	Bootscript        *ScalewayBootscript        `json:"bootscript,omitempty"`
+	Bootscript        *string                    `json:"bootscript,omitempty"`
 	Hostname          *string                    `json:"hostname,omitempty"`
 	Volumes           *map[string]ScalewayVolume `json:"volumes,omitempty"`
 	SecurityGroup     *ScalewaySecurityGroup     `json:"security_group,omitempty"`

--- a/pkg/cli/x_patch.go
+++ b/pkg/cli/x_patch.go
@@ -81,7 +81,7 @@ func runPatch(cmd *Command, args []string) error {
 			log.Debugf("%s=%s  =>  %s=%s", fieldName, currentServer.Bootscript.Identifier, fieldName, newValue)
 			if currentServer.Bootscript.Identifier != newValue {
 				changes++
-				payload.Bootscript.Identifier = newValue
+				payload.Bootscript = &newValue
 			}
 		case "security_group":
 			log.Debugf("%s=%s  =>  %s=%s", fieldName, currentServer.SecurityGroup.Identifier, fieldName, newValue)


### PR DESCRIPTION
```console
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x8866a]

goroutine 1 [running]:
panic(0x4f2980, 0xc8200120c0)
	/usr/local/Cellar/go/1.6.1/libexec/src/runtime/panic.go:464 +0x3e6
github.com/scaleway/scaleway-cli/pkg/cli.runPatch(0x821a60, 0xc820084030, 0x2, 0x2, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/scaleway/scaleway-cli/pkg/cli/x_patch.go:86 +0x1d7a
github.com/scaleway/scaleway-cli/pkg/cli.Start(0xc820084010, 0x4, 0x4, 0xc82011c390, 0xc82006e058, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/scaleway/scaleway-cli/pkg/cli/main.go:112 +0xb88
main.main()
	/Users/quentinperez/go/src/github.com/scaleway/scaleway-cli/cmd/scw/main.go:19 +0x8a
```