### PR TITLE
Use proxy configuration from environment in 'scw attach' command

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -203,6 +203,8 @@ func AttachToSerial(serverID string, apiToken string) (*gottyclient.Client, chan
 		gottycli.SkipTLSVerify = true
 	}
 
+	gottycli.UseProxyFromEnv = true
+
 	if err = gottycli.Connect(); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This will use HTTP_PROXY and HTTPS_PROXY environment variables in 'scw attach' command.