### PR TITLE
Add DetachIP helper

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2313,6 +2313,35 @@ func (s *ScalewayAPI) AttachIP(ipID, serverID string) error {
 	return err
 }
 
+// DetachIP detaches an IP from a server
+func (s *ScalewayAPI) DetachIP(ipID string) error {
+	var update struct {
+		Address      string `json:"address"`
+		ID           string `json:"id"`
+		Organization string `json:"organization"`
+	}
+
+	ip, err := s.GetIP(ipID)
+	if err != nil {
+		return err
+	}
+
+	if ip.IP.Server.Identifier == "" {
+		return nil
+	}
+
+	update.Address = ip.IP.Address
+	update.ID = ip.IP.ID
+	update.Organization = ip.IP.Organization
+	resp, err := s.PutResponse(ComputeAPI, fmt.Sprintf("ips/%s", ipID), update)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = s.handleHTTPError([]int{200}, resp)
+	return err
+}
+
 // DeleteIP deletes an IP
 func (s *ScalewayAPI) DeleteIP(ipID string) error {
 	resp, err := s.DeleteResponse(ComputeAPI, fmt.Sprintf("ips/%s", ipID))


### PR DESCRIPTION
While working on my [terraform provider](https://github.com/hashicorp/terraform/pull/7331) I had the need to detach IPs from servers.

This doesn't seem to be exposed in the SDK so I added a [helper function](https://github.com/hashicorp/terraform/pull/7331/commits/51d188233ade206f3b232b090f83b985cc0bcfe0). However, I think it should be public within the SDK.

One question tho: do we need to stop servers in order to detach IPs ?