### PR TITLE
Allow security groups to be marked as organizational default

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -448,11 +448,19 @@ type ScalewaySecurityGroup struct {
 	Name string `json:"name,omitempty"`
 }
 
-// ScalewayNewSecurityGroup definition POST/PUT request /security_groups
+// ScalewayNewSecurityGroup definition POST request /security_groups
 type ScalewayNewSecurityGroup struct {
 	Organization string `json:"organization"`
 	Name         string `json:"name"`
 	Description  string `json:"description"`
+}
+
+// ScalewayUpdateSecurityGroup definition PUT request /security_groups
+type ScalewayUpdateSecurityGroup struct {
+	Organization        string `json:"organization"`
+	Name                string `json:"name"`
+	Description         string `json:"description"`
+	OrganizationDefault bool   `json:"organization_default"`
 }
 
 // ScalewayServer represents a Scaleway server
@@ -2154,7 +2162,7 @@ func (s *ScalewayAPI) DeleteSecurityGroup(securityGroupID string) error {
 }
 
 // PutSecurityGroup updates a SecurityGroup
-func (s *ScalewayAPI) PutSecurityGroup(group ScalewayNewSecurityGroup, securityGroupID string) error {
+func (s *ScalewayAPI) PutSecurityGroup(group ScalewayUpdateSecurityGroup, securityGroupID string) error {
 	resp, err := s.PutResponse(ComputeAPI, fmt.Sprintf("security_groups/%s", securityGroupID), group)
 	if resp != nil {
 		defer resp.Body.Close()

--- a/pkg/cli/x_security-groups.go
+++ b/pkg/cli/x_security-groups.go
@@ -99,7 +99,7 @@ func updateSecurityGroup(cmd *Command, args []string) error {
 	if securityGroupsName == "" || securityGroupsDesc == "" || len(args) != 1 {
 		return cmd.PrintShortUsage()
 	}
-	return cmd.API.PutSecurityGroup(api.ScalewayNewSecurityGroup{
+	return cmd.API.PutSecurityGroup(api.ScalewayUpdateSecurityGroup{
 		Organization: cmd.API.Organization,
 		Name:         securityGroupsName,
 		Description:  securityGroupsDesc,


### PR DESCRIPTION
This PR exposes the `organization_default` attribute when updating security groups.

It's possible to mark security groups as default when using the UI, however it's not possible when using the SDK. Now you can change default SGs using the SDK.

This is usefull when you want to promote a different SG to be your organizational SG.