### PR TITLE
expose SecurityGroup on ServerDefinition

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -592,6 +592,8 @@ type ScalewayServerDefinition struct {
 	PublicIP string `json:"public_ip,omitempty"`
 
 	EnableIPV6 bool `json:"enable_ipv6,omitempty"`
+
+	SecurityGroup string `json:"security_group,omitempty"`
 }
 
 // ScalewayOneServer represents the response of a GET /servers/UUID API call


### PR DESCRIPTION
this way you can programatically spawn a server into a specific SG