### PR TITLE
Makefile fix go vet crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOBUILD ?=	$(GO) build
 GOCLEAN ?=	$(GO) clean
 GOINSTALL ?=	$(GO) install
 GOTEST ?=	$(GO) test $(GOTESTFLAGS)
-GOFMT ?=	gofmt -w
+GOFMT ?=	gofmt -w -s
 GODIR ?=	github.com/scaleway/scaleway-cli
 GOCOVER ?=	$(GOTEST) -covermode=count -v
 FPM_VERSION ?=	$(shell ./dist/scw-Darwin-i386 --version | sed 's/.*v\([0-9.]*\),.*/\1/g')
@@ -27,7 +27,7 @@ FPM_ARGS ?=	\
 
 NAME =		scw
 
-SOURCES :=	$(shell find . -type f -name "*.go")
+SOURCES :=	$(shell find ./pkg ./cmd -type f -name "*.go" | grep -v "_test.go$$")
 COMMANDS :=	$(shell go list ./... | grep -v /vendor/ | grep /cmd/)
 PACKAGES :=	$(shell go list ./... | grep -v /vendor/ | grep -v /cmd/)
 REL_COMMANDS :=	$(subst $(GODIR),.,$(COMMANDS))
@@ -70,7 +70,7 @@ fmt: $(FMT_LIST)
 
 
 $(BUILD_LIST): %_build: %_fmt
-	go tool vet --all=true ./cmd ./pkg
+	@go tool vet --all=true $(SOURCES)
 	$(GOBUILD) -ldflags $(LDFLAGS) -o $(NAME) $(subst $(GODIR),.,$*)
 $(CLEAN_LIST): %_clean:
 	$(GOCLEAN) $(subst $(GODIR),./,$*)
@@ -79,7 +79,7 @@ $(INSTALL_LIST): %_install:
 $(TEST_LIST): %_test:
 	$(GOTEST) -ldflags $(LDFLAGS) -v $(subst $(GODIR),.,$*)
 $(FMT_LIST): %_fmt:
-	$(GOFMT) $(subst $(GODIR),.,$*)
+	@$(GOFMT) $(SOURCES)
 
 
 


### PR DESCRIPTION
```console
go tool vet --all=true ./cmd ./pkg
panic: inconsistent import:
       	func errors.New(text string) error
previously imported as:
       	func errors.New(text string) error
 [recovered]
       	panic: inconsistent import:
       	func errors.New(text string) error
previously imported as:
       	func errors.New(text string) error


goroutine 1 [running]:
panic(0x2734c0, 0xc4203aebb0)
       	/usr/local/go/src/runtime/panic.go:500 +0x1a1
go/types.(*Checker).handleBailout(0xc4200b81c0, 0xc4200454a0)
       	/usr/local/go/src/go/types/check.go:213 +0xae
panic(0x2734c0, 0xc4203aebb0)
       	/usr/local/go/src/runtime/panic.go:458 +0x243
go/internal/gcimporter.(*importer).declare(0xc420306f70, 0x3f4180, 0xc420437c20)
       	/usr/local/go/src/go/internal/gcimporter/bimport.go:175 +0x17c
go/internal/gcimporter.(*importer).obj(0xc420306f70, 0xfffffffffffffffb)
       	/usr/local/go/src/go/internal/gcimporter/bimport.go:203 +0x4a2
go/internal/gcimporter.BImportData(0xc42000efc0, 0xc420439000, 0xb51, 0xe00, 0xc420302839, 0x6, 0x0, 0x6, 0xc41ffde579, 0x0)
       	/usr/local/go/src/go/internal/gcimporter/bimport.go:88 +0x390
go/internal/gcimporter.Import(0xc42000efc0, 0xc420302839, 0x6, 0xc4203027a0, 0x7, 0xc42024b630, 0x0, 0x0)
       	/usr/local/go/src/go/internal/gcimporter/gcimporter.go:166 +0x551
go/importer.gcimports.ImportFrom(0xc42000efc0, 0xc420302839, 0x6, 0xc4203027a0, 0x7, 0x0, 0x2, 0x4, 0x0)
       	/usr/local/go/src/go/importer/importer.go:70 +0x67
go/types.(*Checker).collectObjects(0xc4200b81c0)
       	/usr/local/go/src/go/types/resolver.go:191 +0x826
go/types.(*Checker).checkFiles(0xc4200b81c0, 0xc4203a6dc0, 0x5, 0x8, 0x0, 0x0)
       	/usr/local/go/src/go/types/check.go:225 +0xaa
go/types.(*Checker).Files(0xc4200b81c0, 0xc4203a6dc0, 0x5, 0x8, 0xc42036c030, 0xc4200c5528)
       	/usr/local/go/src/go/types/check.go:218 +0x49
go/types.(*Config).Check(0xc4203a6e40, 0xc420302810, 0x3, 0xc4202c5a00, 0xc4203a6dc0, 0x5, 0x8, 0xc4202ab590, 0x20, 0xc4200001a0, ...)
       	/usr/local/go/src/go/types/api.go:344 +0x1a3
main.(*Package).check(0xc42029dec0, 0xc4202c5a00, 0xc4203a6dc0, 0x5, 0x8, 0xc4203a6e00, 0x4)
       	/usr/local/go/src/cmd/vet/types.go:76 +0x370
main.doPackage(0xc420302059, 0x7, 0xc4202bd980, 0x5, 0x8, 0x0, 0x0)
       	/usr/local/go/src/cmd/vet/main.go:336 +0x999
main.doPackageDir(0xc420302059, 0x7)
       	/usr/local/go/src/cmd/vet/main.go:284 +0x606
main.visit(0xc420302059, 0x7, 0x3f34a0, 0xc420259520, 0x0, 0x0, 0x0, 0x0)
       	/usr/local/go/src/cmd/vet/main.go:371 +0xf3
path/filepath.walk(0xc420302059, 0x7, 0x3f34a0, 0xc420259520, 0x2f5950, 0x0, 0x0)
       	/usr/local/go/src/path/filepath/path.go:351 +0x81
path/filepath.walk(0x7fff5fbff8a1, 0x5, 0x3f34a0, 0xc4202585b0, 0x2f5950, 0x0, 0x0)
       	/usr/local/go/src/path/filepath/path.go:376 +0x344
path/filepath.Walk(0x7fff5fbff8a1, 0x5, 0x2f5950, 0x0, 0x0)
       	/usr/local/go/src/path/filepath/path.go:398 +0xd5
main.walkDir(0x7fff5fbff8a1, 0x5)
       	/usr/local/go/src/cmd/vet/main.go:386 +0x41
main.main()
       	/usr/local/go/src/cmd/vet/main.go:240 +0x2cb
make: *** [github.com/scaleway/scaleway-cli/cmd/scw_build] Error 1
```