### PR TITLE
Fix volume size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,7 @@ $ scw inspect myserver | jq '.[0].public_ip.address'
 
 ### v1.10.1 (2016-10-24)
 
+* `scw image -a -f type=volume` fix unmarshal error on size field
 * `scw login` fix CheckCredentials ([418](https://github.com/scaleway/scaleway-cli/issues/418))
 
 View full [commits list](https://github.com/scaleway/scaleway-cli/compare/v1.10...v1.10.1)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -142,7 +142,7 @@ type ScalewayVolume struct {
 	Identifier string `json:"id,omitempty"`
 
 	// Size is the allocated size of the volume
-	Size uint64 `json:"size,omitempty"`
+	Size interface{} `json:"size,omitempty"`
 
 	// CreationDate is the creation date of the volume
 	CreationDate string `json:"creation_date,omitempty"`
@@ -1667,6 +1667,7 @@ func (s *ScalewayAPI) GetVolumes() (*[]ScalewayVolume, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var volumes ScalewayVolumes
 
 	if err = json.Unmarshal(body, &volumes); err != nil {

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -445,6 +445,7 @@ func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 			return "", err
 		}
 		currentVolume := createdServer.Volumes["0"]
+		size := currentVolume.Size.(uint64)
 
 		var volumePayload ScalewayVolumePutDefinition
 		newName := fmt.Sprintf("%s-%s", createdServer.Hostname, currentVolume.Name)
@@ -454,7 +455,7 @@ func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 		volumePayload.Server.Identifier = &currentVolume.Server.Identifier
 		volumePayload.Server.Name = &currentVolume.Server.Name
 		volumePayload.Identifier = &currentVolume.Identifier
-		volumePayload.Size = &currentVolume.Size
+		volumePayload.Size = &size
 		volumePayload.ModificationDate = &currentVolume.ModificationDate
 		volumePayload.ExportURI = &currentVolume.ExportURI
 		volumePayload.VolumeType = &currentVolume.VolumeType

--- a/pkg/commands/history.go
+++ b/pkg/commands/history.go
@@ -50,7 +50,7 @@ func RunHistory(ctx CommandContext, args HistoryArgs) error {
 	creationDateStr := units.HumanDuration(time.Now().UTC().Sub(creationDate))
 
 	volumeName := utils.TruncIf(image.RootVolume.Name, 25, !args.NoTrunc)
-	size := units.HumanSize(float64(image.RootVolume.Size))
+	size := units.HumanSize(image.RootVolume.Size.(float64))
 
 	fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", identifier, creationDateStr, volumeName, size)
 	return nil

--- a/pkg/commands/images.go
+++ b/pkg/commands/images.go
@@ -153,7 +153,7 @@ func RunImages(ctx CommandContext, args ImagesArgs) error {
 						Identifier:   val.Identifier,
 						Name:         val.Name,
 						Tag:          "<volume>",
-						VirtualSize:  float64(val.Size),
+						VirtualSize:  val.Size.(float64),
 						Public:       false,
 						Organization: val.Organization,
 						// FIXME the region should not be hardcoded


### PR DESCRIPTION
fix unmarshal error

```console
FATA[0002] cannot execute 'images': unable to fetch volumes from the Scaleway API: json: cannot unmarshal number 5e+10 into Go value of type uint64
```