### PR TITLE
Fix no error when getting server without ID in api

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1188,6 +1188,9 @@ func (s ScalewaySortServers) Less(i, j int) bool {
 
 // GetServer gets a server from the ScalewayAPI
 func (s *ScalewayAPI) GetServer(serverID string) (*ScalewayServer, error) {
+	if serverID == "" {
+		return nil, fmt.Errorf("cannot get server without serverID")
+	}
 	resp, err := s.GetResponsePaginate(s.computeAPI, "servers/"+serverID, url.Values{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
will fix a problem described here: https://github.com/scaleway/docker-machine-driver-scaleway/pull/64#issuecomment-292787479