### PR TITLE
Add support for scw on Linux arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ prepare-release-dist: build
 	GOOS=linux  GOARCH=386    go build -o dist/latest/scw-linux-i386        github.com/scaleway/scaleway-cli/cmd/scw
 	GOOS=linux  GOARCH=amd64  go build -o dist/latest/scw-linux-amd64       github.com/scaleway/scaleway-cli/cmd/scw
 	GOOS=linux  GOARCH=arm    go build -o dist/latest/scw-linux-arm         github.com/scaleway/scaleway-cli/cmd/scw
+	GOOS=linux  GOARCH=arm64  go build -o dist/latest/scw-linux-arm64       github.com/scaleway/scaleway-cli/cmd/scw
 
 	GOOS=darwin  GOARCH=386   go build -o dist/latest/scw-darwin-i386       github.com/scaleway/scaleway-cli/cmd/scw
 	GOOS=darwin  GOARCH=amd64 go build -o dist/latest/scw-darwin-amd64      github.com/scaleway/scaleway-cli/cmd/scw
@@ -119,12 +120,13 @@ prepare-release-docker-image: dist/latest/scw-linux-i386
 	docker run scaleway/cli version
 	docker tag scaleway/cli:latest scaleway/cli:v$(VERSION)
 
-prepare-release-debian-packages: dist/latest/scw-linux-amd64 dist/latest/scw-linux-i386 dist/latest/scw-linux-arm
+prepare-release-debian-packages: dist/latest/scw-linux-amd64 dist/latest/scw-linux-i386 dist/latest/scw-linux-arm dist/latest/scw-linux-arm64
 	@echo ${VERSION} | grep -qv 'v' || ( echo "ERROR: VERSION not set or contains a leading 'v'" >&2 && exit 1 )
 	### Build debian packages ###
 	docker run -v $(PWD)/dist/latest/scw-linux-amd64:/input/usr/bin/scw $(FPM_DOCKER) $(FPM_ARGS) --version $(VERSION) -t deb -a x86_64 ./
 	docker run -v $(PWD)/dist/latest/scw-linux-i386:/input/usr/bin/scw  $(FPM_DOCKER) $(FPM_ARGS) --version $(VERSION) -t deb -a i386 ./
 	docker run -v $(PWD)/dist/latest/scw-linux-arm:/input/usr/bin/scw   $(FPM_DOCKER) $(FPM_ARGS) --version $(VERSION) -t deb -a arm ./
+	docker run -v $(PWD)/dist/latest/scw-linux-arm64:/input/usr/bin/scw $(FPM_DOCKER) $(FPM_ARGS) --version $(VERSION) -t deb -a arm64 ./
 
 
 .PHONY: golint


### PR DESCRIPTION
This is a simple change to the Makefile to include linux/arm64 as a default target. I tried adding the darwin/arm64 version too, but it fails at the last step with a rather obscure error:
```
# github.com/scaleway/scaleway-cli/cmd/scw
warning: unable to find runtime/cgo.a
/usr/local/Cellar/go/1.8.3/libexec/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: ignoring file /var/folders/hy/_ppky1c912jfgvvh610qz5600000gn/T/go-link-289996183/go.o, file was built for unsupported file format ( 0xCF 0xFA 0xED 0xFE 0x0C 0x00 0x00 0x01 0x00 0x00 0x00 0x00 0x01 0x00 0x00 0x00 ) which is not the architecture being linked (x86_64): /var/folders/hy/_ppky1c912jfgvvh610qz5600000gn/T/go-link-289996183/go.o
Undefined symbols for architecture x86_64:
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Considering that darwin/arm64 is not critical, I think this can be merged as is, so we can use the newly created linux/arm64 binary to make an [arm64 version of the image-builder](https://github.com/scaleway/image-builder/tree/arm64-support).