### PR TITLE
Make WaitForServerReady use IPv6 if IPv4 unavailable

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -566,7 +566,11 @@ func WaitForServerReady(api *ScalewayAPI, serverID, gateway string) (*ScalewaySe
 		}
 
 		if gateway == "" {
-			dest := fmt.Sprintf("%s:22", server.PublicAddress.IP)
+			ip := server.PublicAddress.IP
+			if ip == "" && server.EnableIPV6 {
+				ip = fmt.Sprintf("[%s]", server.IPV6.Address)
+			}
+			dest := fmt.Sprintf("%s:22", ip)
 			log.Debugf("Waiting for server SSH port %s", dest)
 			err = utils.WaitForTCPPortOpen(dest)
 			if err != nil {


### PR DESCRIPTION
This makes WaitForServerReady work for servers that only need an IPv6 address.