### PR TITLE
WIP: Allow region filtering

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1208,7 +1208,7 @@ func (s *ScalewayAPI) GetServers(all bool, limit int) (*[]ScalewayServer, error)
 		}
 	)
 
-	serverChan := make(chan ScalewayServers, 2)
+	serverChan := make(chan ScalewayServers, len(apis))
 	for _, api := range apis {
 		g.Go(s.fetchServers(api, query, serverChan))
 	}

--- a/pkg/cli/cmd_ps.go
+++ b/pkg/cli/cmd_ps.go
@@ -35,6 +35,7 @@ var cmdPs = &Command{
     $ scw ps -f arch=ARCH
     $ scw ps -f server-type=COMMERCIALTYPE
     $ scw ps -f "state=booted image=docker tags=prod"
+    $ scw ps -f zone=ams1
 `,
 }
 


### PR DESCRIPTION
This is an answer to https://github.com/scaleway/scaleway-cli/issues/446
This PR adds an example showing `scw ps` with a filter.

Should we use the --region flag passed before the command `ps` to filter the API on which the `ps` commands run upon?