### PR TITLE
add boot-type option to create/run commands

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -545,6 +545,9 @@ type ScalewayServer struct {
 	// State is the current status of the server
 	State string `json:"state,omitempty"`
 
+	// BootType is the boot method used, can be local or bootscript
+	BootType string `json:"boot_type,omitempty"`
+
 	// StateDetail is the detailed status of the server
 	StateDetail string `json:"state_detail,omitempty"`
 
@@ -619,6 +622,7 @@ type ScalewayServerPatchDefinition struct {
 	Tags              *[]string                  `json:"tags,omitempty"`
 	IPV6              *ScalewayIPV6Definition    `json:"ipv6,omitempty"`
 	EnableIPV6        *bool                      `json:"enable_ipv6,omitempty"`
+	BootType          *string                    `json:"boot_type,omitempty"`
 }
 
 // ScalewayServerDefinition represents a Scaleway server with image definition

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -652,6 +652,8 @@ type ScalewayServerDefinition struct {
 	EnableIPV6 bool `json:"enable_ipv6,omitempty"`
 
 	SecurityGroup string `json:"security_group,omitempty"`
+
+  BootType string `json:"boot_type,omitempty"`
 }
 
 // ScalewayOneServer represents the response of a GET /servers/UUID API call

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -653,7 +653,7 @@ type ScalewayServerDefinition struct {
 
 	SecurityGroup string `json:"security_group,omitempty"`
 
-  BootType string `json:"boot_type,omitempty"`
+	BootType string `json:"boot_type,omitempty"`
 }
 
 // ScalewayOneServer represents the response of a GET /servers/UUID API call

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -319,6 +319,7 @@ type ConfigCreateServer struct {
 	CommercialType    string
 	DynamicIPRequired bool
 	EnableIPV6        bool
+	BootType          string
 }
 
 // Return offer from any of the product name or alternate names
@@ -350,6 +351,10 @@ func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 		return "", errors.New("Invalid commercial type")
 	}
 
+	if !(c.BootType == "local" || c.BootType == "bootscript") {
+		return "", errors.New("Invalid boot type")
+	}
+
 	if c.Name == "" {
 		c.Name = strings.Replace(namesgenerator.GetRandomName(0), "_", "-", -1)
 	}
@@ -360,6 +365,7 @@ func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 	server.Volumes = make(map[string]string)
 	server.DynamicIPRequired = &c.DynamicIPRequired
 	server.EnableIPV6 = c.EnableIPV6
+	server.BootType = c.BootType
 	if commercialType == "" {
 		return "", errors.New("You need to specify a commercial-type")
 	}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -351,7 +351,7 @@ func CreateServer(api *ScalewayAPI, c *ConfigCreateServer) (string, error) {
 		return "", errors.New("Invalid commercial type")
 	}
 
-	if !(c.BootType == "local" || c.BootType == "bootscript") {
+	if c.BootType != "local" && c.BootType != "bootscript" {
 		return "", errors.New("Invalid boot type")
 	}
 

--- a/pkg/cli/cmd_create.go
+++ b/pkg/cli/cmd_create.go
@@ -32,6 +32,7 @@ func init() {
 	cmdCreate.Flag.StringVar(&createVolume, []string{"v", "-volume"}, "", "Attach additional volume (i.e., 50G)")
 	cmdCreate.Flag.StringVar(&createIPAddress, []string{"-ip-address"}, "dynamic", "Assign a reserved public IP, a 'dynamic' one or 'none'")
 	cmdCreate.Flag.StringVar(&createCommercialType, []string{"-commercial-type"}, "X64-2GB", "Create a server with specific commercial-type C1, C2[S|M|L], X64-[2|4|8|15|30|60|120]GB, ARM64-[2|4|8]GB")
+	cmdCreate.Flag.StringVar(&createBootType, []string{"-boot-type"}, "local", "Choose between 'local' and 'bootscript' boot")
 	cmdCreate.Flag.BoolVar(&createHelp, []string{"h", "-help"}, false, "Print usage")
 	cmdCreate.Flag.BoolVar(&createIPV6, []string{"-ipv6"}, false, "Enable IPV6")
 	cmdCreate.Flag.BoolVar(&createTmpSSHKey, []string{"-tmp-ssh-key"}, false, "Access your server without uploading your SSH key to your account")
@@ -47,6 +48,7 @@ var createTmpSSHKey bool        // --tmp-ssh-key flag
 var createIPAddress string      // --ip-address flag
 var createCommercialType string // --commercial-type flag
 var createIPV6 bool             // --ipv6 flag
+var createBootType string       // --boot-type flag
 
 func runCreate(cmd *Command, rawArgs []string) error {
 	if createHelp {
@@ -64,6 +66,7 @@ func runCreate(cmd *Command, rawArgs []string) error {
 		IP:             createIPAddress,
 		CommercialType: createCommercialType,
 		IPV6:           createIPV6,
+		BootType:       createBootType,
 	}
 
 	if len(createEnv) > 0 {

--- a/pkg/cli/cmd_run.go
+++ b/pkg/cli/cmd_run.go
@@ -46,6 +46,7 @@ func init() {
 	cmdRun.Flag.StringVar(&runGateway, []string{"g", "-gateway"}, "", "Use a SSH gateway")
 	cmdRun.Flag.StringVar(&runUserdatas, []string{"u", "-userdata"}, "", "Start a server with userdata predefined")
 	cmdRun.Flag.StringVar(&runCommercialType, []string{"-commercial-type"}, "X64-2GB", "Start a server with specific commercial-type C1, C2[S|M|L], X64-[2|4|8|15|30|60|120]GB, ARM64-[2|4|8]GB")
+	cmdRun.Flag.StringVar(&runBootType, []string{"-boot-type"}, "local", "Choose between 'local' and 'bootscript' boot")
 	cmdRun.Flag.StringVar(&runSSHUser, []string{"-user"}, "root", "Specify SSH User")
 	cmdRun.Flag.BoolVar(&runAutoRemove, []string{"-rm"}, false, "Automatically remove the server when it exits")
 	cmdRun.Flag.BoolVar(&runIPV6, []string{"-ipv6"}, false, "Enable IPV6")
@@ -68,6 +69,7 @@ var runDetachFlag bool         // -d, --detach flag
 var runGateway string          // -g, --gateway flag
 var runUserdatas string        // -u, --userdata flag
 var runCommercialType string   // --commercial-type flag
+var runBootType string         // --boot-type flag
 var runTmpSSHKey bool          // --tmp-ssh-key flag
 var runShowBoot bool           // --show-boot flag
 var runIPV6 bool               // --ipv6 flag
@@ -124,6 +126,7 @@ func runRun(cmd *Command, rawArgs []string) error {
 		IPV6:           runIPV6,
 		SSHUser:        runSSHUser,
 		SSHPort:        runSSHPort,
+		BootType:       runBootType,
 		// FIXME: Timeout
 	}
 

--- a/pkg/cli/x_patch.go
+++ b/pkg/cli/x_patch.go
@@ -83,6 +83,10 @@ func runPatch(cmd *Command, args []string) error {
 				changes++
 				payload.Bootscript = &newValue
 			}
+		case "boot_type":
+			log.Debugf("%s=%s  =>  %s=%s", fieldName, currentServer.BootType, fieldName, newValue)
+			changes++
+			payload.BootType = &newValue
 		case "security_group":
 			log.Debugf("%s=%s  =>  %s=%s", fieldName, currentServer.SecurityGroup.Identifier, fieldName, newValue)
 			if currentServer.SecurityGroup.Identifier != newValue {

--- a/pkg/commands/create.go
+++ b/pkg/commands/create.go
@@ -23,6 +23,7 @@ type CreateArgs struct {
 	CommercialType string
 	TmpSSHKey      bool
 	IPV6           bool
+	BootType       string
 }
 
 // RunCreate is the handler for 'scw create'
@@ -46,6 +47,7 @@ func RunCreate(ctx CommandContext, args CreateArgs) error {
 		IP:                args.IP,
 		CommercialType:    args.CommercialType,
 		EnableIPV6:        args.IPV6,
+		BootType:          args.BootType,
 	}
 	if args.IP == "dynamic" || args.IP == "" {
 		config.DynamicIPRequired = true

--- a/pkg/commands/create_test.go
+++ b/pkg/commands/create_test.go
@@ -65,6 +65,7 @@ func TestRunCreate_realAPI(t *testing.T) {
 				Image:          "ubuntu-mini-xenial-25g",
 				CommercialType: "X64-2GB",
 				IP:             "dynamic",
+				BootType:       "bootscript",
 			}
 
 			scopedCtx, scopedStdout, scopedStderr := getScopedCtx(ctx)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -32,6 +32,7 @@ type RunArgs struct {
 	CommercialType string
 	State          string
 	SSHUser        string
+	BootType       string
 	Timeout        int64
 	SSHPort        int
 	AutoRemove     bool
@@ -170,6 +171,7 @@ func Run(ctx CommandContext, args RunArgs) error {
 		IP:                args.IP,
 		CommercialType:    args.CommercialType,
 		EnableIPV6:        args.IPV6,
+		BootType:          args.BootType,
 	}
 	if args.IP == "dynamic" || (args.IP == "" && args.Gateway == "") {
 		config.DynamicIPRequired = true


### PR DESCRIPTION
Option allows to choose between `local`and `bootscript` boot for `scw create` and `scw run` command.