### PR TITLE
Fix help typo for _security-groups

### DIFF
--- a/pkg/cli/x_security-groups.go
+++ b/pkg/cli/x_security-groups.go
@@ -21,7 +21,7 @@ var cmdSecurityGroups = &Command{
 	Examples: `
 
 	SGID = SecurityGroupID
-	ACTION = "{\"action\":"string", \"direction\": \"string\", \"ip_range\": \"string\", \"protocol\": \"string\", \"dest_port_from\": \"int\"}"
+	ACTION = "{\"action\":\"string\", \"direction\": \"string\", \"ip_range\": \"string\", \"protocol\": \"string\", \"dest_port_from\": int}"
 
 	$ scw _security-groups list-groups
 	$ scw _security-groups show-group SGID


### PR DESCRIPTION
Hello, 
There were a typo in _security-groups example. 
