### PR TITLE
fix: change function comments based on best practices from Effective Go

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2822,7 +2822,7 @@ func (s *ScalewayAPI) ResolveTTYUrl() string {
 	return ""
 }
 
-// GetProductServers Fetches all the server type and their constraints from the Products API
+// GetProductsServers Fetches all the server type and their constraints from the Products API
 func (s *ScalewayAPI) GetProductsServers() (*ScalewayProductsServers, error) {
 	resp, err := s.GetResponsePaginate(s.computeAPI, "products/servers", url.Values{})
 	if err != nil {

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -322,7 +322,7 @@ type ConfigCreateServer struct {
 	BootType          string
 }
 
-// Return offer from any of the product name or alternate names
+// OfferNameFromName returns offer from any of the product name or alternate names
 func OfferNameFromName(name string, products *ScalewayProductsServers) (*ProductServer, error) {
 	offer, ok := products.Servers[name]
 	if ok {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?