### PR TITLE
WIP: test: fix before_install ci scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ matrix:
 
 
 before_install:
-  - go get github.com/golang/go/src/cmd/vet
   - go get -u github.com/axw/gocov/gocov
   - go get -u github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get -u moul.io/anonuuid/cmd/anonuuid
+  - env GO111MODULE="on" go get moul.io/anonuuid/cmd/anonuuid
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - go get -u github.com/axw/gocov/gocov
   - go get -u github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - env GO111MODULE="on" go get moul.io/anonuuid/cmd/anonuuid
+  - env GO111MODULE="on" go get moul.io/anonuuid/cmd/anonuuid@v1.2.1
 
 
 script:


### PR DESCRIPTION
- Remove useless get of go vet in `before_install`
- Force the use of modules for `anonuuid` to respect the required version (`v1.21.0`) of `github.com/urfave/cli` dependency.

- [x] Blocked by https://github.com/moul/anonuuid/pull/30 who upgrades `github.com/urfave/cli` to `v1.22.1` in order to support Go `1.11`.
- [x] Blocked by https://github.com/cpuguy83/go-md2man/pull/57