### PR TITLE
fix(autocomplete): bash arg value autocompletion

### DIFF
--- a/internal/core/autocomplete.go
+++ b/internal/core/autocomplete.go
@@ -15,7 +15,7 @@ type AutocompleteSuggestions []string
 
 // AutocompleteResponse contains the autocomplete suggestions
 type AutocompleteResponse struct {
-	Propositions AutocompleteSuggestions
+	Suggestions AutocompleteSuggestions
 }
 
 // AutoCompleteArgFunc is the function called to complete arguments values.
@@ -36,7 +36,7 @@ type AutoCompleteNode struct {
 func newAutoCompleteResponse(suggestions []string) *AutocompleteResponse {
 	sort.Strings(suggestions)
 	return &AutocompleteResponse{
-		Propositions: suggestions,
+		Suggestions: suggestions,
 	}
 }
 

--- a/internal/core/autocomplete_test.go
+++ b/internal/core/autocomplete_test.go
@@ -77,7 +77,7 @@ func TestAutocomplete(t *testing.T) {
 			rightWord := words[wordToCompleteIndex+1:]
 
 			result := AutoComplete(ctx, leftWords, wordToComplete, rightWord)
-			assert.Equal(t, tc.Suggestions, result.Propositions)
+			assert.Equal(t, tc.Suggestions, result.Suggestions)
 		}
 	}
 


### PR DESCRIPTION
The previous implementation was using a local variable outside of a function (cf: `local can only be used in a function`).
It could be dangerous for other program autocompletions.