### PR TITLE
feat(instance): add servers in security-group get command

### DIFF
--- a/internal/namespaces/instance/v1/custom_marshal.go
+++ b/internal/namespaces/instance/v1/custom_marshal.go
@@ -44,7 +44,6 @@ func init() {
 	human.RegisterMarshalerFunc(instance.ServerLocation{}, serverLocationMarshallerFunc)
 	human.RegisterMarshalerFunc([]*instance.Server{}, serversMarshallerFunc)
 	human.RegisterMarshalerFunc(instance.GetServerResponse{}, getServerResponseMarshallerFunc)
-	human.RegisterMarshalerFunc([]*instance.ServerSummary{}, serverSummariesMarshallerFunc)
 	human.RegisterMarshalerFunc(instance.Bootscript{}, bootscriptMarshallerFunc)
 
 	// Snapshot
@@ -187,10 +186,6 @@ func volumeSummaryMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, 
 func volumeMapMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {
 	volumes := i.(map[string]*instance.Volume)
 	return fmt.Sprintf("%v", len(volumes)), nil
-}
-
-func serverSummariesMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {
-	return strconv.Itoa(len(i.([]*instance.ServerSummary))), nil
 }
 
 func getServerResponseMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {
@@ -346,5 +341,16 @@ func (sg *customSecurityGroupResponse) MarshalHuman() (out string, err error) {
 	}
 	outboundRulesView := terminal.Style(fmt.Sprintf("Outbound Rules (default policy %s):\n", defaultOutboundPolicy), color.Bold) + outboundRulesContent
 
-	return strings.Join([]string{securityGroupView, inboundRulesView, outboundRulesView}, "\n\n"), nil
+	serversContent, err := human.Marshal(sg.Servers, nil)
+	if err != nil {
+		return "", err
+	}
+	serversView := terminal.Style("Servers:\n", color.Bold) + serversContent
+
+	return strings.Join([]string{
+		securityGroupView,
+		inboundRulesView,
+		outboundRulesView,
+		serversView,
+	}, "\n\n"), nil
 }


### PR DESCRIPTION
Add servers list in the `security-group get` command.
AFAIK `serverSummariesMarshallerFunc` was not used anymore.

Result:
```
$ scw instance security-group get security-group-id=e5bf4522-94b4-4933-bebb-9b21f786b4af | anonuuid
Security Group:
id                       00000000-0000-1000-0000-000000000000
name                     Default security group
description              Auto generated security group.
enable-default-security  true
organization-id          11111111-1111-1111-1111-111111111111
use-by-default           true
creation-date            4 years ago
modification-date        1 year ago

Inbound Rules (default policy accept):
ID   PROTOCOL  ACTION  IP RANGE  DEST

Outbound Rules (default policy accept):
ID                                    PROTOCOL  ACTION  IP RANGE   DEST
22222222-2222-1222-2222-222222222222  TCP       drop    0.0.0.0/0  25
33333333-3333-1333-3333-333333333333  TCP       drop    0.0.0.0/0  465
44444444-4444-1444-4444-444444444444  TCP       drop    0.0.0.0/0  587
55555555-5555-1555-5555-555555555555  TCP       drop    ::/0       25
66666666-6666-1666-6666-666666666666  TCP       drop    ::/0       465
77777777-7777-1777-7777-777777777777  TCP       drop    ::/0       587

Servers:
ID                                    NAME
88888888-8888-1888-8888-888888888888  test02
99999999-9999-1999-9999-999999999999  test01
aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa  terraform-v2-doc
```