### PR TITLE
feat(core): inline marshalling for scalar slices

### DIFF
--- a/internal/human/marshal.go
+++ b/internal/human/marshal.go
@@ -265,7 +265,7 @@ func marshalSlice(slice reflect.Value, opt *MarshalOpt) (string, error) {
 	return formatGrid(grid)
 }
 
-// marshalInlineSlice transform nested scalar slices in an inline string representation
+// marshalInlineSlice transforms nested scalar slices in an inline string representation
 // and other types of slices in a count representation.
 func marshalInlineSlice(slice reflect.Value) (string, error) {
 	itemType := slice.Type().Elem()

--- a/internal/human/marshal.go
+++ b/internal/human/marshal.go
@@ -240,7 +240,7 @@ func marshalSlice(slice reflect.Value, opt *MarshalOpt) (string, error) {
 			fieldValue := getFieldValue(item, fieldSpec.FieldName)
 			str := ""
 			if fieldValue.IsValid() {
-				err := error(nil)
+				var err error
 				switch {
 				// Handle inline slice.
 				case fieldValue.Type().Kind() == reflect.Slice:

--- a/internal/human/marshal.go
+++ b/internal/human/marshal.go
@@ -279,7 +279,7 @@ func marshalInlineSlice(slice reflect.Value) (string, error) {
 	case marshalerFuncs[itemType] != nil:
 		return marshalerFuncs[itemType](slice.Interface(), nil)
 
-	// If it's a scalar value we marshall it inline.
+	// If it is a slice of scalar values.
 	case itemType.Kind() != reflect.Slice &&
 		itemType.Kind() != reflect.Map &&
 		itemType.Kind() != reflect.Struct:

--- a/internal/namespaces/instance/v1/custom_marshal.go
+++ b/internal/namespaces/instance/v1/custom_marshal.go
@@ -44,7 +44,6 @@ func init() {
 	human.RegisterMarshalerFunc(instance.ServerLocation{}, serverLocationMarshallerFunc)
 	human.RegisterMarshalerFunc([]*instance.Server{}, serversMarshallerFunc)
 	human.RegisterMarshalerFunc(instance.GetServerResponse{}, getServerResponseMarshallerFunc)
-	human.RegisterMarshalerFunc([]*instance.ServerSummary{}, serverSummariesMarshallerFunc)
 	human.RegisterMarshalerFunc(instance.Bootscript{}, bootscriptMarshallerFunc)
 
 	// Snapshot
@@ -114,10 +113,11 @@ func serversMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error)
 		Zone              scw.Zone
 		PublicIP          net.IP
 		PrivateIP         *string
+		ImageName         string
+		Tags              []string
 		ModificationDate  time.Time
 		CreationDate      time.Time
 		ImageId           string
-		ImageName         string
 		Protected         bool
 		Volumes           int
 		SecurityGroupId   string
@@ -166,6 +166,7 @@ func serversMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error)
 			StateDetail:       server.StateDetail,
 			Arch:              server.Arch,
 			PlacementGroup:    server.PlacementGroup,
+			Tags:              server.Tags,
 		})
 	}
 	return human.Marshal(humanServers, opt)
@@ -187,10 +188,6 @@ func volumeSummaryMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, 
 func volumeMapMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {
 	volumes := i.(map[string]*instance.Volume)
 	return fmt.Sprintf("%v", len(volumes)), nil
-}
-
-func serverSummariesMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {
-	return strconv.Itoa(len(i.([]*instance.ServerSummary))), nil
 }
 
 func getServerResponseMarshallerFunc(i interface{}, opt *human.MarshalOpt) (string, error) {

--- a/internal/namespaces/instance/v1/updated_commands.go
+++ b/internal/namespaces/instance/v1/updated_commands.go
@@ -12,7 +12,6 @@ func updateCommands(commands *core.Commands) {
 }
 
 func updateInstancePlacementGroupGet(c *core.Command) {
-
 	c.Run = func(ctx context.Context, argsI interface{}) (i interface{}, e error) {
 		req := argsI.(*instance.GetPlacementGroupRequest)
 


### PR DESCRIPTION
* Implement `marshalInlineSlice`
* Remove `serverSummariesMarshallerFunc` as it is now the default behavior
* Add `Tags` to `humanServerInList` 🎁 

Result:
```
$ scw instance security-group list
ID                                    NAME                    [...]  SERVERS  STATEFUL
00000000-0000-1000-0000-000000000000  Default security group  [...]  3        false
22222222-2222-1222-2222-222222222222  test01                  [...]  0        true
                                                                     ^ a count representation as the ServerSummary is not a scalar type.

$ scw instance server get server-id=64c3ed5c-72f6-495b-94f5-f43c4536f49c
Server:
id                        00000000-0000-1000-0000-000000000000
name                      terraform-v2-doc
organization              11111111-1111-1111-1111-111111111111
allowed-actions.0         backup
tags.0                    tf
tags.1                    test1
tags.2                    test2
                          ^ a {label}.{idx} representation as it is a struct{Slice: []interface{}}
[...]

Server Image:
[...]

$ scw instance server list
ID                                    TAGS              VOLUMES
00000000-0000-1000-0000-000000000000  [tf test1 test2]  1      
                                      ^ an inline slice representation as it's elements are scalar

                                                        ^ use volumeMapMarshallerFunc
```