### PR TITLE
fix(instance): security-group marshalling

### DIFF
--- a/internal/namespaces/instance/v1/custom_commands.go
+++ b/internal/namespaces/instance/v1/custom_commands.go
@@ -205,10 +205,12 @@ func instanceSecurityGroupUpdate() *core.Command {
 			},
 			{
 				Name:       "inbound-default-policy",
+				Default:    core.DefaultValueSetter("accept"),
 				EnumValues: []string{"accept", "drop"},
 			},
 			{
 				Name:       "outbound-default-policy",
+				Default:    core.DefaultValueSetter("accept"),
 				EnumValues: []string{"accept", "drop"},
 			},
 		},


### PR DESCRIPTION
Fix `Data must be a marshable value (a scalar type or a Marshaler)` error.