### PR TITLE
feat(instance): update organization default security group

### DIFF
--- a/internal/namespaces/instance/v1/custom_commands.go
+++ b/internal/namespaces/instance/v1/custom_commands.go
@@ -238,7 +238,7 @@ func instanceSecurityGroupUpdate() *core.Command {
 				return nil, &core.CliError{
 					Err: fmt.Errorf("your default security group can't be stateful"),
 					Details: interactive.RemoveIndent(`
-						You have to make this security group stateless to use it as a organization default.
+						You have to make this security group stateless to use it as an organization default.
 						More info: https://www.scaleway.com/en/docs/how-to-activate-a-stateful-cloud-firewall
 					`),
 					Hint: "scw instance security-group update security-group-id=" + req.SecurityGroupID + " organization-default=true stateful=false",

--- a/internal/namespaces/instance/v1/custom_commands.go
+++ b/internal/namespaces/instance/v1/custom_commands.go
@@ -236,7 +236,7 @@ func instanceSecurityGroupUpdate() *core.Command {
 			switch resErr.Message {
 			case "default security group can't be stateful":
 				return nil, &core.CliError{
-					Err: fmt.Errorf("your default security group can't be stateful"),
+					Err: fmt.Errorf("your default security group cannot be stateful"),
 					Details: interactive.RemoveIndent(`
 						You have to make this security group stateless to use it as an organization default.
 						More info: https://www.scaleway.com/en/docs/how-to-activate-a-stateful-cloud-firewall
@@ -286,7 +286,7 @@ func getDefaultOrganizationSecurityGroup(ctx context.Context) (*instance.Securit
 		}
 	}
 
-	return nil, fmt.Errorf("%s organization doesn't have a default security group", orgID)
+	return nil, fmt.Errorf("%s organization does not have a default security group", orgID)
 }
 
 func instanceUserDataList() *core.Command {

--- a/internal/namespaces/instance/v1/custom_commands.go
+++ b/internal/namespaces/instance/v1/custom_commands.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/scaleway/scaleway-cli/internal/core"
+	"github.com/scaleway/scaleway-cli/internal/interactive"
 	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
@@ -213,11 +214,79 @@ func instanceSecurityGroupUpdate() *core.Command {
 				Default:    core.DefaultValueSetter("accept"),
 				EnumValues: []string{"accept", "drop"},
 			},
+			{
+				Name: "organization-default",
+			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {
-			return instance.NewAPI(core.ExtractClient(ctx)).UpdateSecurityGroup(argsI.(*instance.UpdateSecurityGroupRequest))
+			req := argsI.(*instance.UpdateSecurityGroupRequest)
+
+			api := instance.NewAPI(core.ExtractClient(ctx))
+			res, err := api.UpdateSecurityGroup(req)
+			if err == nil {
+				return res, nil
+			}
+
+			resErr, isResErr := err.(*scw.ResponseError)
+			if !isResErr {
+				return nil, err
+			}
+
+			// Try to find the error type and create a more user friendly one.
+			switch resErr.Message {
+			case "default security group can't be stateful":
+				return nil, &core.CliError{
+					Err: fmt.Errorf("your default security group can't be stateful"),
+					Details: interactive.RemoveIndent(`
+						You have to make this security group stateless to use it as a organization default.
+						More info: https://www.scaleway.com/en/docs/how-to-activate-a-stateful-cloud-firewall
+					`),
+					Hint: "scw instance security-group update security-group-id=" + req.SecurityGroupID + " organization-default=true stateful=false",
+				}
+
+			case "cannot have more than one organization default":
+				defaultSG, err := getDefaultOrganizationSecurityGroup(ctx)
+				if err != nil {
+					// Abort and return the original error.
+					return nil, resErr
+				}
+
+				return nil, &core.CliError{
+					Err: fmt.Errorf("you cannot have more than one organization default"),
+					Details: interactive.RemoveIndent(`
+						You already have an organization default security-group (` + defaultSG.ID + `).
+
+						First, you need to set your current organization default security-group as non-default with:
+						scw instance security-group update security-group-id=` + defaultSG.ID + ` organization-default=false
+
+						Then, retry this command:
+						scw instance security-group update security-group-id=` + req.SecurityGroupID + ` organization-default=true stateful=false
+					`),
+				}
+			default:
+				// Unknown error, use default behavior.
+				return nil, resErr
+			}
 		},
 	}
+}
+
+func getDefaultOrganizationSecurityGroup(ctx context.Context) (*instance.SecurityGroup, error) {
+	api := instance.NewAPI(core.ExtractClient(ctx))
+
+	orgID := core.GetOrganizationIdFromContext(ctx)
+	sgList, err := api.ListSecurityGroups(&instance.ListSecurityGroupsRequest{Organization: scw.StringPtr(orgID)}, scw.WithAllPages())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sg := range sgList.SecurityGroups {
+		if sg.OrganizationDefault {
+			return sg, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%s organization doesn't have a default security group", orgID)
 }
 
 func instanceUserDataList() *core.Command {


### PR DESCRIPTION
Add the ability to update the organization default security group.

Worst case (copy and paste) scenariot:
```
$ scw instance security-group update security-group-id=BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB organization-default=true
Your default security group can't be stateful

Details:
You have to make this security group stateless to use it as an organization default.
More info: https://www.scaleway.com/en/docs/how-to-activate-a-stateful-cloud-firewall

Hint:
scw instance security-group update security-group-id=BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB organization-default=true stateful=false


$ scw instance security-group update security-group-id=BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB organization-default=true stateful=false
You cannot have more than one organization default

Details:
You already have an organization default security-group (AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA).

First, you need to set your current organization default security-group as non-default with:
scw instance security-group update security-group-id=AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA organization-default=false

Then, retry this command:
scw instance security-group update security-group-id=BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB organization-default=true stateful=false


$ scw instance security-group update security-group-id=AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA organization-default=false
security-group.id                       AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA
security-group.name                     Default security group
security-group.description              Auto generated security group.
security-group.enable-default-security  true
security-group.inbound-default-policy   accept
security-group.outbound-default-policy  accept
security-group.organization             11111111-1111-1111-1111-111111111111
security-group.organization-default     false
security-group.creation-date            4 years ago
security-group.modification-date        now
security-group.servers.0.id             22222222-2222-1222-2222-222222222222
security-group.servers.0.name           test04
security-group.servers.1.id             33333333-3333-1333-3333-333333333333
security-group.servers.1.name           test03
security-group.servers.2.id             44444444-4444-1444-4444-444444444444
security-group.servers.2.name           test02
security-group.servers.3.id             55555555-5555-1555-5555-555555555555
security-group.servers.3.name           test01
security-group.stateful                 false


$ scw instance security-group update security-group-id=BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB organization-default=true stateful=false
security-group.id                       BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB
security-group.name                     test01
security-group.description
security-group.enable-default-security  true
security-group.inbound-default-policy   accept
security-group.outbound-default-policy  accept
security-group.organization             22222222-2222-1222-2222-222222222222
security-group.organization-default     true
security-group.creation-date            5 days ago
security-group.modification-date        now
security-group.stateful                 false
```