### PR TITLE
fix(args): rework slices

### DIFF
--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -7,7 +7,7 @@ import (
 )
 
 // validArgNameRegex regex to check that args words are lower-case or digit starting and ending with a letter.
-var validArgNameRegex = regexp.MustCompile("^([a-z][a-z0-9-]*)(\\.[a-z0-9-]*)*$")
+var validArgNameRegex = regexp.MustCompile(`^([a-z][a-z0-9-]*)(\.[a-z0-9-]*)*$`)
 
 // RawArgs allows to retrieve a simple []string using UnmarshalStruct()
 type RawArgs []string

--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// validKeyRegex regex to check that args key are lower-case or digit starting and ending with a letter.
-var validKeyRegex = regexp.MustCompile("^([a-z][a-z0-9-]*)(\\.[a-z0-9-]*)*$")
+// validArgNameRegex regex to check that args words are lower-case or digit starting and ending with a letter.
+var validArgNameRegex = regexp.MustCompile("^([a-z][a-z0-9-]*)(\\.[a-z0-9-]*)*$")
 
 // RawArgs allows to retrieve a simple []string using UnmarshalStruct()
 type RawArgs []string

--- a/internal/args/errors.go
+++ b/internal/args/errors.go
@@ -1,9 +1,0 @@
-package args
-
-import (
-	"fmt"
-)
-
-func duplicateArgumentError(argName string) error {
-	return fmt.Errorf("duplicate argument '%v='", argName)
-}

--- a/internal/args/unmarshal.go
+++ b/internal/args/unmarshal.go
@@ -2,13 +2,12 @@ package args
 
 // unmarshal.go helps with the conversion of
 // CLI arguments represented as strings
-// into CLI arguments represented as go data.
+// into CLI arguments represented as Go data.
 
 import (
 	"fmt"
 	"io"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -41,10 +40,10 @@ var unmarshalFuncs = map[reflect.Type]UnmarshalFunc{
 	},
 }
 
-// UnmarshalStruct parse args like ["arg1=1", "arg2=2"] to a go structure using reflection.
+// UnmarshalStruct parse args like ["arg1=1", "arg2=2"] to a Go structure using reflection.
 //
 // args: slice of args passed through the command line
-// data: go structure to fill
+// data: Go structure to fill
 func UnmarshalStruct(args []string, data interface{}) error {
 
 	// First check if we want to retrieve a simple []string
@@ -63,36 +62,32 @@ func UnmarshalStruct(args []string, data interface{}) error {
 
 	// Map arg names to their values.
 	// ["arg1=1", "arg2=2", "arg3"] => {"arg1": "1", "arg2": "2", "arg3":"" }
-	keyValues := SplitRaw(args)
+	argsSlice := SplitRaw(args)
 
-	processedKeys := make(map[string]bool)
+	processedArgNames := make(map[string]bool)
 
 	// Loop through all arguments
-	for _, kv := range keyValues {
-		key, value := kv[0], kv[1]
+	for _, kv := range argsSlice {
+		argName, argValue := kv[0], kv[1]
 
-		// Make sure argument key case is correct.
-		// We enforce this check to avoid not well formatted key to work by "accident"
-		// as we use ToCamel on the key later on.
-		if !validKeyRegex.MatchString(key) {
-			return fmt.Errorf("invalid argument with name %s: argument must only contain lowercase letter and dash", key)
+		// Make sure argument name is correct.
+		// We enforce this check to avoid not well formatted argument name to work by "accident"
+		// as we use ToPublicGoName on the argument name later on.
+		if !validArgNameRegex.MatchString(argName) {
+			return fmt.Errorf("invalid argument '%s': must only contain lowercase letter, number or dash", argName)
 		}
 
-		fieldType, err := findFieldType(dest.Type(), strings.Split(key, "."))
-		if err != nil {
-			return fmt.Errorf("unknown argument with name %s", key)
+		if !fieldExist(dest.Type(), strings.Split(argName, ".")) {
+			return fmt.Errorf("unknown argument '%s'", argName)
 		}
 
-		if fieldType.Kind() != reflect.Slice {
-			if processedKeys[key] {
-				return duplicateArgumentError(key)
-			}
-
-			processedKeys[key] = true
+		if processedArgNames[argName] {
+			return fmt.Errorf("duplicate argument '%s'", argName)
 		}
+		processedArgNames[argName] = true
 
 		// Set will recursively found the correct field to set.
-		err = set(dest, strings.Split(key, "."), value)
+		err := set(dest, strings.Split(argName, "."), argValue)
 		if err != nil {
 			return err
 		}
@@ -101,31 +96,31 @@ func UnmarshalStruct(args []string, data interface{}) error {
 	return nil
 }
 
-func findFieldType(t reflect.Type, keys []string) (reflect.Type, error) {
+func fieldExist(t reflect.Type, argNameWords []string) bool {
 
 	switch {
-	case len(keys) == 0:
-		return t, nil
+	case len(argNameWords) == 0:
+		return true
 
 	case t.Kind() == reflect.Ptr:
-		return findFieldType(t.Elem(), keys)
+		return fieldExist(t.Elem(), argNameWords)
 
 	case t.Kind() == reflect.Slice || t.Kind() == reflect.Map:
-		return findFieldType(t.Elem(), keys[1:])
+		return fieldExist(t.Elem(), argNameWords[1:])
 
 	case t.Kind() == reflect.Struct:
-		field, exists := t.FieldByName(strcase.ToPublicGoName(keys[0]))
+		field, exists := t.FieldByName(strcase.ToPublicGoName(argNameWords[0]))
 		if !exists {
-			return nil, fmt.Errorf("struct doesn't have field named '%v'", keys[0])
+			return false
 		}
-		return findFieldType(field.Type, keys[1:])
+		return fieldExist(field.Type, argNameWords[1:])
 
 	default:
-		return nil, fmt.Errorf("cannot determine type for %v", keys)
+		return false
 	}
 }
 
-// UnmarshalValue unmarshals a single value, not the key.
+// UnmarshalValue unmarshals a single value into the data interface.
 // While UnmarshalStruct will convert an argument list like ["arg1=1", "arg2=2"] to a go struct,
 // UnmarshalValue will only unmarshal a single arg value ( right part of the `=` ).
 func UnmarshalValue(argValue string, data interface{}) error {
@@ -163,22 +158,22 @@ func RegisterUnmarshalFunc(i interface{}, unmarshalFunc UnmarshalFunc) {
 }
 
 // set sets a (sub)value of a data structure.
-// It uses reflection to go as deep as necessary into the data struct, following the keys passed.
+// It uses reflection to go as deep as necessary into the data struct, following the arg name passed.
 //
 // dest: the structure to be completed
-// keys: the left part of the key-value pair, represented as a slice of keys and subkeys
+// argNameWords: the argument name to set
 // value: the value to be set, represented as a string
 //
-// Example: keys ["contacts", "0", "address", "city"] will set value city for your first contact in your phone book.
-func set(dest reflect.Value, keys []string, value string) error {
+// Example: argNameWords ["contacts", "0", "address", "city"] will set value city for your first contact in your phone book.
+func set(dest reflect.Value, argNameWords []string, value string) error {
 
 	// If dest has a custom unmarshaller, we use it.
 	// dest can either implement Unmarshaller
 	// or have an UnmarshalFunc() registered.
 	if isUnmarshalableValue(dest) {
-		if len(keys) != 0 {
-			// Trying to unamarshal a nested field inside a unmarshalable type
-			return fmt.Errorf("cannot set nested field %s for unmashalable type %T", strings.Join(keys, "."), dest.Interface())
+		if len(argNameWords) != 0 {
+			// Trying to unmarshal a nested field inside an unmarshalable type
+			return fmt.Errorf("cannot set nested field %s for unmarshalable type %T", strings.Join(argNameWords, "."), dest.Interface())
 		}
 
 		for dest.Kind() == reflect.Ptr {
@@ -190,70 +185,95 @@ func set(dest reflect.Value, keys []string, value string) error {
 
 	switch dest.Kind() {
 	case reflect.Ptr:
-		// If type is a pointer we create a new Value and call set with the pointer.Elem()
-		newValue := reflect.New(dest.Type().Elem())
-		dest.Set(newValue)
-		return set(newValue.Elem(), keys, value)
+		// If type is a nil pointer we create a new Value. NB: maps and slices are pointers.
+		if dest.IsNil() {
+			dest.Set(reflect.New(dest.Type().Elem()))
+		}
+
+		// Call set with the pointer.Elem()
+		return set(dest.Elem(), argNameWords, value)
 
 	case reflect.Slice:
 		// If type is a slice:
-		// We check if keys[0] is an number to handle cases like keys.0.value=12
-		isIndex := regexp.MustCompile("^\\d+$")
-		if len(keys) > 0 && isIndex.MatchString(keys[0]) {
-			index, _ := strconv.Atoi(keys[0])
-			// If key is an number we make sure array is big enough to access the correct index.
-			if index >= dest.Len() {
-				diffLen := index - dest.Len() + 1
-				// To make the slice bigger we create a fake slice of diffLen size and we append it.
-				dest.Set(reflect.AppendSlice(dest, reflect.MakeSlice(dest.Type(), diffLen, diffLen)))
-			}
+		// We check if argNameWords[0] is an number to handle cases like keys.0.value=12
 
-			// Recursively call set without the index key
-			return set(dest.Index(index), keys[1:], value)
+		// We cannot handle slice without an index notation.
+		if len(argNameWords) == 0 {
+			return fmt.Errorf("missing index on the array")
 		}
 
-		// We can't handle nested message in a slice without index notation.
-		if len(keys) > 0 {
-			return fmt.Errorf("cannot handle nested struct without a slice index")
+		// Make sure index is a positive integer.
+		index, err := strconv.ParseUint(argNameWords[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid index: '%s' is not a positive integer", argNameWords[0])
 		}
 
-		// We create a new value call set and append it to the slice
-		newValue := reflect.New(dest.Type().Elem())
-		err := set(newValue.Elem(), keys, value)
-		dest.Set(reflect.Append(dest, newValue.Elem()))
-		return err
+		// Make sure array is big enough to access the correct index.
+		diff := int(index) - dest.Len()
+		switch {
+		case diff > 2:
+			return fmt.Errorf("missing indices in the array: trying to set array at index %d before indices %v", index, missingIndices(int(index), dest.Len()))
+		case diff == 1:
+			return fmt.Errorf("missing index in the array: trying to set array at index %d before index %d", index, index-1)
+		case diff == 0:
+			// Append one element to our slice.
+			dest.Set(reflect.AppendSlice(dest, reflect.MakeSlice(dest.Type(), 1, 1)))
+		case diff < 0:
+			// Element already exist at current index.
+		}
+
+		// Recursively call set without the index word
+		return set(dest.Index(int(index)), argNameWords[1:], value)
 
 	case reflect.Map:
 		// If map is nil we create it.
 		if dest.IsNil() {
 			dest.Set(reflect.MakeMap(dest.Type()))
 		}
-		if len(keys) == 0 {
+		if len(argNameWords) == 0 {
 			return fmt.Errorf("cannot handle map with no subkey, value '%v'", value)
 		}
 		// Create a new value call set and add result in the map
 		newValue := reflect.New(dest.Type().Elem())
-		err := set(newValue.Elem(), keys[1:], value)
-		dest.SetMapIndex(reflect.ValueOf(keys[0]), newValue.Elem())
+		err := set(newValue.Elem(), argNameWords[1:], value)
+		dest.SetMapIndex(reflect.ValueOf(argNameWords[0]), newValue.Elem())
 		return err
 
 	case reflect.Struct:
-		if len(keys) == 0 {
+		if len(argNameWords) == 0 {
 			return fmt.Errorf("cannot unmarshal a struct %T with not field name", dest.Interface())
 		}
 
 		// try to find the correct field in the struct.
-		fieldName := strcase.ToPublicGoName(keys[0])
+		fieldName := strcase.ToPublicGoName(argNameWords[0])
 		field := dest.FieldByName(fieldName)
 		if !field.IsValid() {
-			return fmt.Errorf("unknown argument with name %s", keys[0])
+			return fmt.Errorf("unknown argument with name %s", argNameWords[0])
 		}
 		// Set the value of the field
-		return set(field, keys[1:], value)
+		return set(field, argNameWords[1:], value)
 
-	default:
-		return fmt.Errorf("don't know how to unmarshal type %T", dest.Interface())
 	}
+	return fmt.Errorf("don't know how to unmarshal type %T", dest.Interface())
+}
+
+// missingIndices returns a string of all the missing indices between index and length.
+// e.g.: missingIndices(index=5, length=0) should return "3,2,1,0"
+// e.g.: missingIndices(index=5, length=2) should return "3,2"
+// e.g.: missingIndices(index=99999, length=0) should return "99998,99997,99996,99995,99994,99993,99992,99991,99990,..."
+func missingIndices(index, length int) string {
+	s := ""
+	for i := index - 1; i >= length; i-- {
+		if s != "" {
+			s += ","
+		}
+		if index-i == 10 {
+			s += "..."
+			break
+		}
+		s += strconv.Itoa(i)
+	}
+	return s
 }
 
 // unmarshalScalar handles unmarshaling from a string to a scalar type .
@@ -315,9 +335,13 @@ func isUnmarshalableValue(dest reflect.Value) bool {
 
 	_, isUnmarshaller := interface_.(Unmarshaller)
 	_, hasUnmarshalFunc := unmarshalFuncs[dest.Type()]
-	_, isScalar := scalarKinds[dest.Kind()]
 
-	return isUnmarshaller || hasUnmarshalFunc || isScalar
+	return isUnmarshaller || hasUnmarshalFunc || isScalar(dest)
+}
+
+func isScalar(dest reflect.Value) bool {
+	_, isScalar := scalarKinds[dest.Kind()]
+	return isScalar
 }
 
 func unmarshalValue(value string, dest reflect.Value) error {

--- a/internal/args/unmarshal.go
+++ b/internal/args/unmarshal.go
@@ -263,18 +263,15 @@ func set(dest reflect.Value, argNameWords []string, value string) error {
 // e.g.: missingIndices(index=5, length=2) should return "2,3"
 // e.g.: missingIndices(index=99999, length=0) should return "0,1,2,3,4,5,6,7,8,9,..."
 func missingIndices(index, length int) string {
-	s := ""
+	s := []string(nil)
 	for i := length; i < index; i++ {
-		if s != "" {
-			s += ","
-		}
 		if i-length == 10 {
-			s += "..."
+			s = append(s, "...")
 			break
 		}
-		s += strconv.Itoa(i)
+		s = append(s, strconv.Itoa(i))
 	}
-	return s
+	return strings.Join(s, ",")
 }
 
 // unmarshalScalar handles unmarshaling from a string to a scalar type .

--- a/internal/args/unmarshal_test.go
+++ b/internal/args/unmarshal_test.go
@@ -123,7 +123,7 @@ func TestUnmarshalStruct(t *testing.T) {
 			"strings.5=2",
 		},
 		expected: &Slice{},
-		error:    "missing indices in the array: trying to set array at index 5 before indices 4,3,2,1,0",
+		error:    "missing indices in the array: trying to set array at index 5 before indices 0,1,2,3,4",
 	}))
 
 	t.Run("missing-slice-indices-overflow", run(TestCase{
@@ -131,7 +131,7 @@ func TestUnmarshalStruct(t *testing.T) {
 			"strings.99999=2",
 		},
 		expected: &Slice{},
-		error:    "missing indices in the array: trying to set array at index 99999 before indices 99998,99997,99996,99995,99994,99993,99992,99991,99990,...",
+		error:    "missing indices in the array: trying to set array at index 99999 before indices 0,1,2,3,4,5,6,7,8,9,...",
 	}))
 
 	t.Run("duplicate-slice-index", run(TestCase{

--- a/internal/e2e/testdata/test-human-list-simple.stdout.golden
+++ b/internal/e2e/testdata/test-human-list-simple.stdout.golden
@@ -1,4 +1,4 @@
 ID                                    ORGANIZATION ID                       CREATED AT  UPDATED AT  HEIGHT  SHOE SIZE  ALTITUDE IN METER  ALTITUDE IN MILLIMETER  FINGERS COUNT  HAIR COUNT  IS HAPPY  EYES COLOR  STATUS   REGION
 0194fdc2-fa2f-fcc0-41d3-ff12045b73c8  11111111-1111-1111-1111-111111111111  now         now         0       0          0                  0                       0              0           false     unknown     stopped  fr-par
-39465185-0fd4-a178-892e-e285ece15114  11111111-1111-1111-1111-111111111111  now         now         0       0          0                  0                       0              0           false     unknown     stopped  fr-par
 62a5eee8-2abd-f44a-2d0b-75fb180daf48  11111111-1111-1111-1111-111111111111  now         now         0       0          0                  0                       0              0           false     unknown     stopped  fr-par
+39465185-0fd4-a178-892e-e285ece15114  11111111-1111-1111-1111-111111111111  now         now         0       0          0                  0                       0              0           false     unknown     stopped  fr-par

--- a/internal/namespaces/instance/v1/command_server_create.go
+++ b/internal/namespaces/instance/v1/command_server_create.go
@@ -305,15 +305,13 @@ func createInitialVolumeMap(api *instance.API, organizationID string, argsVolume
 	var volumes []*instance.VolumeTemplate
 
 	for _, v := range argsVolumes {
-		for _, flagV := range strings.Split(v, ",") {
-			flagV = strings.TrimSpace(flagV)
-			vt, err := buildVolumeTemplate(api, organizationID, flagV)
-			if err != nil {
-				return nil, err
-			}
-
-			volumes = append(volumes, vt)
+		flagV := strings.TrimSpace(v)
+		vt, err := buildVolumeTemplate(api, organizationID, flagV)
+		if err != nil {
+			return nil, err
 		}
+
+		volumes = append(volumes, vt)
 	}
 
 	return volumes, nil
@@ -321,10 +319,7 @@ func createInitialVolumeMap(api *instance.API, organizationID string, argsVolume
 
 // buildVolumeTemplate creates a instance.VolumeTemplate from a 'volumes' argument item.
 //
-// Volumes definition could be:
-// - multiple arguments (eg: volumes="l:20GB" volumes="b:100GB")
-// - a single argument representing an array (eg: volumes="l:20GB, b:100GB")
-// - a mix (eg: volumes="l:10GB, local:10GB" volumes="b:100GB")
+// Volumes definition must be through multiple arguments (eg: volumes.0="l:20GB" volumes.1="b:100GB")
 //
 // A valid volume format is either
 // - a "creation" format: ^((local|l|block|b):)?\d+GB?$ (size is handled by go-humanize, so other sizes are supported)


### PR DESCRIPTION
Today it is not very explicit for a user because he can use 3 methods to fill slice:

```
slice.0=a -slice.1=b
slice=a -slice=b
slice=a,b (In custom commands like create server)
```


This PRs does:

- [x] Remove comma notation (in create server)
- [x] Remove support for slice without index (throw error)
- [x] Remove support for auto-filling slice on missing index and return  an error instead
- [x] Fix a bug that recreated a new slice for each index, which destroyed all previous elements in the slice