### PR TITLE
fix: remove default hint on resource exired error

### DIFF
--- a/internal/core/error.go
+++ b/internal/core/error.go
@@ -172,8 +172,6 @@ func sdkResourceExpiredHumanMarshallFunc() human.MarshalerFunc {
 		switch resourceName := resourceExpiredError.Resource; resourceName {
 		case "account_token":
 			hint = "Try to generate a new token here https://console.scaleway.com/account/credentials"
-		default:
-			hint = "Try to re-create the expired resource"
 		}
 
 		return human.Marshal(&CliError{


### PR DESCRIPTION
This hint does not make sense in many cases for example when backup are expired