### PR TITLE
fix(autocomplete): complete on fish subprocess

### DIFF
--- a/internal/namespaces/autocomplete/autocomplete.go
+++ b/internal/namespaces/autocomplete/autocomplete.go
@@ -83,7 +83,7 @@ var autocompleteScripts = map[string]autocompleteScript{
 		CompleteFunc: `
 			complete --erase --command scw;
 			complete --command scw --no-files;
-			complete --command scw --arguments '(scw autocomplete complete fish -- (commandline) (commandline --cursor) (commandline --current-token) (commandline --tokenize --cut-at-cursor))';
+			complete --command scw --arguments '(scw autocomplete complete fish -- (commandline) (commandline --cursor) (commandline --current-token) (commandline --current-process --tokenize --cut-at-cursor))';
 		`,
 		CompleteScript: `eval (scw autocomplete script shell=fish)`,
 		ShellConfigurationFile: map[string]string{


### PR DESCRIPTION
This fix will work after fish 3.1, see https://github.com/fish-shell/fish-shell/issues/6214