### PR TITLE
doc: add sudo to chmod command during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Download the release from github 
-sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.0.0-beta.1/scw-v2.0.0-beta.1-darwin-x86_64"
+curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.0.0-beta.1/scw-v2.0.0-beta.1-darwin-x86_64"
 
 # Allow executing file as program
 chmod +x /usr/local/bin/scw
@@ -86,7 +86,7 @@ scw init
 sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.0.0-beta.1/scw-v2.0.0-beta.1-linux-x86_64"
 
 # Allow executing file as program
-chmod +x /usr/local/bin/scw
+sudo chmod +x /usr/local/bin/scw
 
 # Init the CLI
 scw init


### PR DESCRIPTION
Since we download the binary with sudo, we need sudo to chmod +x it.

---
From a fellow Scaleway member 🤓