### PR TITLE
test(qa): add a duplicated command test

### DIFF
--- a/cmd/scw-qa/main.go
+++ b/cmd/scw-qa/main.go
@@ -2,26 +2,34 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/fatih/color"
 	"github.com/scaleway/scaleway-cli/internal/namespaces"
 	"github.com/scaleway/scaleway-cli/internal/qa"
+	"github.com/scaleway/scaleway-cli/internal/tabwriter"
+	"github.com/scaleway/scaleway-cli/internal/terminal"
 )
 
 func main() {
 	commands := namespaces.GetCommands()
 	errors := qa.LintCommands(commands)
 
+	fmt.Println(terminal.Style("Errors:", color.Bold))
+	for _, err := range errors {
+		fmt.Printf("%v\n", err)
+	}
+
 	errorCounts := map[string]int{}
 	for _, err := range errors {
 		errorCounts[fmt.Sprintf("%T", err)]++
 	}
 
-	fmt.Printf("Errors:\n")
-	for _, err := range errors {
-		fmt.Printf("%v\n", err)
-	}
-	fmt.Printf("\nSummary:\n")
+	fmt.Println(terminal.Style("\nSummary:", color.Bold))
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	for key, count := range errorCounts {
-		fmt.Printf("%s: %d\n", key, count)
+		_, _ = fmt.Fprintf(w, "%s\t%d\n", strings.TrimPrefix(key, "*qa."), count)
 	}
+	_ = w.Flush()
 }

--- a/internal/qa/qa.go
+++ b/internal/qa/qa.go
@@ -226,7 +226,7 @@ func testDuplicatedCommandError(commands *core.Commands) []interface{} {
 	for _, command := range commands.GetAll() {
 		key := command.Namespace + "_" + command.Resource + "_" + command.Verb
 
-		if uniqueness[key] == true {
+		if uniqueness[key] {
 			errors = append(errors, &DuplicatedCommandError{Command: command})
 			continue
 		}

--- a/internal/qa/qa.go
+++ b/internal/qa/qa.go
@@ -141,7 +141,7 @@ type DifferentLocalizationForNamespaceError struct {
 }
 
 func (err DifferentLocalizationForNamespaceError) Error() string {
-	return fmt.Sprintf("different localization for '%v', '%v': %v, %v",
+	return fmt.Sprintf("different localization for commands '%v', '%v': %v, %v",
 		err.Command1.GetCommandLine(), err.Command2.GetCommandLine(), err.ArgNames1, err.ArgNames2)
 }
 
@@ -215,7 +215,7 @@ type DuplicatedCommandError struct {
 }
 
 func (err DuplicatedCommandError) Error() string {
-	return fmt.Sprintf("duplicated command: 'scw %s %s %s'", err.Command.Namespace, err.Command.Resource, err.Command.Verb)
+	return fmt.Sprintf("duplicated command '%s'", err.Command.GetCommandLine())
 }
 
 // testDuplicatedCommandError testes that there is no duplicate command.
@@ -224,7 +224,7 @@ func testDuplicatedCommandError(commands *core.Commands) []interface{} {
 	uniqueness := make(map[string]bool)
 
 	for _, command := range commands.GetAll() {
-		key := command.Namespace + "_" + command.Resource + "_" + command.Verb
+		key := command.GetCommandLine()
 
 		if uniqueness[key] {
 			errors = append(errors, &DuplicatedCommandError{Command: command})


### PR DESCRIPTION
Example:
```
Errors:
short must be present for command 'marketplace image'
[...]

Summary:
DuplicatedCommandError                  1
ShortMustBePresentError                 1
DifferentLocalizationForNamespaceError  22
```