### PR TITLE
fix(baremetal): check that install status is not nil before installwait

### DIFF
--- a/internal/namespaces/baremetal/v1/custom_server.go
+++ b/internal/namespaces/baremetal/v1/custom_server.go
@@ -57,6 +57,10 @@ func serverWaitCommand() *core.Command {
 					Details: fmt.Sprintf("server %s is in %s status", server.ID, server.Status),
 				}
 			}
+			if server.Install == nil {
+				return server, nil
+			}
+
 			logger.Debugf("server reached a stable delivery status. Will now starting to wait for server to reach a stable installation status")
 			server, err = api.WaitForServerInstall(&baremetal.WaitForServerInstallRequest{
 				ServerID:      argsI.(*serverWaitRequest).ServerID,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/v2/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
