### PR TITLE
chore(test): move from environment to go flags to signal updating

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,8 +3,6 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-OPT_VERBOSE=""
-
 ##
 # Colorize output
 ##
@@ -50,15 +48,10 @@ function usage() {
   exit $1;
 }
 
-SCW_DEBUG="false"
-OPT_UPDATE_GOLDENS="false"
-OPT_UPDATE_CASSETTES="false"
-OPT_RUN_SCOPE=""
-
 ##
 # Parse arguments
 ##
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
   case "$1" in
     -r|-run|--run) # keeping -run as this is the standard Go flag for this
@@ -66,17 +59,17 @@ do
       OPT_RUN_SCOPE="$1"
       ;;
     -u|--update)
-      OPT_UPDATE_GOLDENS="true"
-      OPT_UPDATE_CASSETTES="true"
+      OPT_UPDATE_GOLDENS="-goldens"
+      OPT_UPDATE_CASSETTES="-cassettes"
       ;;
     -g|--update-goldens)
-      OPT_UPDATE_GOLDENS="true"
+      OPT_UPDATE_GOLDENS="-goldens"
       ;;
     -c|--update-cassettes)
-      OPT_UPDATE_CASSETTES="true"
+      OPT_UPDATE_CASSETTES="-cassettes"
       ;;
     -D|--debug)
-      SCW_DEBUG="true"
+      SCW_DEBUG="-debug"
       ;;
 	-h|--help) usage
   esac
@@ -88,9 +81,9 @@ if [[ ${OPT_UPDATE_CASSETTES} ]] ; then
   go clean -testcache
 fi
 
-# Remove golden if thery are being updated, and all tests are being run
-if [[ ${OPT_UPDATE_GOLDENS} == "true" ]] && [[ -z ${OPT_RUN_SCOPE} ]]; then
+# Remove golden if they are being updated, and all tests are being run
+if [[ ${OPT_UPDATE_GOLDENS} ]] && [[ -z ${OPT_RUN_SCOPE} ]]; then
   find . -type f -name "*.golden" -exec rm -f {} \;
 fi
 
-SCW_DEBUG=$SCW_DEBUG CLI_UPDATE_GOLDENS=$OPT_UPDATE_GOLDENS CLI_UPDATE_CASSETTES=$OPT_UPDATE_CASSETTES go test -v $ROOT_DIR/... -timeout 20m -run=$OPT_RUN_SCOPE
+go test -v $ROOT_DIR/... $OPT_UPDATE_CASSETTES $OPT_UPDATE_GOLDENS $SCW_DEBUG -timeout 20m -run=$OPT_RUN_SCOPE


### PR DESCRIPTION
By doing so, we can avoid having developers forgetting about a given environment variable that would update cassettes when not intended to. Using explicit flags avoids those can of mistakes and can be added easily from command line run or from an IDE.

Usage example: https://blog.jbowen.dev/2019/08/using-go-flags-in-tests/