### PR TITLE
feat(iot): add human marshallers for enums

### DIFF
--- a/internal/namespaces/iot/v1beta1/custom.go
+++ b/internal/namespaces/iot/v1beta1/custom.go
@@ -2,10 +2,16 @@ package iot
 
 import (
 	"github.com/scaleway/scaleway-cli/internal/core"
+	"github.com/scaleway/scaleway-cli/internal/human"
+	iot "github.com/scaleway/scaleway-sdk-go/api/iot/v1beta1"
 )
 
 func GetCommands() *core.Commands {
 	cmds := GetGeneratedCommands()
+
+	human.RegisterMarshalerFunc(iot.HubStatus(0), human.EnumMarshalFunc(hubStatusMarshalSpecs))
+	human.RegisterMarshalerFunc(iot.DeviceMessageFiltersPolicy(0), human.EnumMarshalFunc(deviceMessageFiltersPolicyMarshalSpecs))
+	human.RegisterMarshalerFunc(iot.DeviceStatus(0), human.EnumMarshalFunc(deviceStatusMarshalSpecs))
 
 	return cmds
 }

--- a/internal/namespaces/iot/v1beta1/custom_device.go
+++ b/internal/namespaces/iot/v1beta1/custom_device.go
@@ -1,0 +1,20 @@
+package iot
+
+import (
+	"github.com/fatih/color"
+	"github.com/scaleway/scaleway-cli/internal/human"
+	iot "github.com/scaleway/scaleway-sdk-go/api/iot/v1beta1"
+)
+
+var (
+	deviceMessageFiltersPolicyMarshalSpecs = human.EnumMarshalSpecs{
+		iot.DeviceMessageFiltersPolicyAccept: &human.EnumMarshalSpec{Attribute: color.FgGreen, Value: "accept"},
+		iot.DeviceMessageFiltersPolicyReject: &human.EnumMarshalSpec{Attribute: color.FgRed, Value: "reject"},
+	}
+
+	deviceStatusMarshalSpecs = human.EnumMarshalSpecs{
+		iot.DeviceStatusEnabled:  &human.EnumMarshalSpec{Attribute: color.FgGreen, Value: "enabled"},
+		iot.DeviceStatusDisabled: &human.EnumMarshalSpec{Attribute: color.FgRed, Value: "disabled"},
+		iot.DeviceStatusError:    &human.EnumMarshalSpec{Attribute: color.FgRed, Value: "error"},
+	}
+)

--- a/internal/namespaces/iot/v1beta1/custom_hub.go
+++ b/internal/namespaces/iot/v1beta1/custom_hub.go
@@ -1,0 +1,17 @@
+package iot
+
+import (
+	"github.com/fatih/color"
+	"github.com/scaleway/scaleway-cli/internal/human"
+	iot "github.com/scaleway/scaleway-sdk-go/api/iot/v1beta1"
+)
+
+var (
+	hubStatusMarshalSpecs = human.EnumMarshalSpecs{
+		iot.HubStatusDisabled:  &human.EnumMarshalSpec{Attribute: color.FgRed, Value: "disabled"},
+		iot.HubStatusDisabling: &human.EnumMarshalSpec{Attribute: color.FgBlue, Value: "disabling"},
+		iot.HubStatusEnabling:  &human.EnumMarshalSpec{Attribute: color.FgBlue, Value: "enabling"},
+		iot.HubStatusError:     &human.EnumMarshalSpec{Attribute: color.FgRed, Value: "error"},
+		iot.HubStatusReady:     &human.EnumMarshalSpec{Attribute: color.FgGreen, Value: "ready"},
+	}
+)


### PR DESCRIPTION
- HubStatus,
- DeviceMessageFiltersPolicy
- DeviceStatus

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/v2/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
