### PR TITLE
Update docker instructions to match v2

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,13 +6,13 @@ The CLI can be used in Docker without any problem.
 
 In order to use it you must mount the scaleway configuration file:
 ```sh
-docker run -it --rm -v $HOME/.config/scw/config.yaml:/.config/scw/config.yaml:ro scaleway/cli
+docker run -it --rm -v $HOME/.config/scw:/.config/scw scaleway/cli:v2.0.0
 ```
 
 If you want to use `scw` instead of `docker run` you can add the following in your `~/.bashrc`:
 ```bash
 scw() {
-    docker run -it --rm -v $HOME/.config/scw/config.yaml:/.config/scw/config.yaml:ro scaleway/cli "$@"
+    docker run -it --rm -v $HOME/.config/scw:/.config/scw scaleway/cli:v2.0.0 "$@"
 }
 export -f scw
 ```
@@ -20,7 +20,7 @@ export -f scw
 Or if you use ZSH, add the following in your `~/.zshrc`:
 ```zsh
 scw() {
-    docker run -it --rm -v $HOME/.config/scw/config.yaml:/.config/scw/config.yaml:ro scaleway/cli $@
+    docker run -it --rm -v $HOME/.config/scw:/.config/scw scaleway/cli:v2.0.0 $@
 }
 ```
 
@@ -44,14 +44,14 @@ complete -F _scw scw
 And in your `~/.bashrc` you can add:
 ```bash
 scw() {
-    docker run -it --rm -v $HOME/.config/scw/config.yaml:/.config/scw/config.yaml:ro scaleway/cli "$@"
+    docker run -it --rm -v $HOME/.config/scw:/.config/scw scaleway/cli:v2.0.0 "$@"
 }
 export -f scw
 
 _scw() {
 	_get_comp_words_by_ref -n = cword words
 
-	output=$(docker run -i --rm -v $HOME/.config/scw/config.yaml:/.config/scw/config.yaml:ro scaleway/cli autocomplete complete bash -- "$COMP_LINE" "$cword" "${words[@]}")
+	output=$(docker run -i --rm -v $HOME/.config/scw:/.config/scw scaleway/cli:v2.0.0 autocomplete complete bash -- "$COMP_LINE" "$cword" "${words[@]}")
 	COMPREPLY=($output)
 	# apply compopt option and ignore failure for older bash versions
 	[[ $COMPREPLY == *= ]] && compopt -o nospace 2> /dev/null || true


### PR DESCRIPTION
Hey 👋 

I tried to use the cli inside a container following the documentation but it seems it doesn't match the v2.

I updated the documentation by adding an explicit tag (maybe too specific? But it the "v2" doesn't seem to exist). I also changed the volume since it doesn't work if you init the configuration within docker 🐳 

WDYT?
