### PR TITLE
feat(core): deprecate an argument

### DIFF
--- a/cmd/scw/testdata/test-all-usage-account-ssh-key-add-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-account-ssh-key-add-usage.golden
@@ -13,7 +13,7 @@ ARGS:
   [name]              The name of the SSH key
   public-key          SSH public key. Currently ssh-rsa, ssh-dss (DSA), ssh-ed25519 and ecdsa keys with NIST curves are supported
   [project-id]        Project owning the resource
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
 
 FLAGS:
   -h, --help   help for add

--- a/cmd/scw/testdata/test-all-usage-baremetal-server-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-baremetal-server-create-usage.golden
@@ -21,7 +21,7 @@ ARGS:
   [install.os-id]                 
   [install.hostname]              
   [install.ssh-key-ids.{index}]   
-  [organization-id]               Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]               Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]                 Zone to target. If none is passed will use default zone from the config (fr-par-2)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-image-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-image-create-usage.golden
@@ -22,7 +22,7 @@ ARGS:
   [additional-snapshots.{key}.organization-id]   Organization ID that own the additional snapshot
   [project-id]                                   Project ID of the image
   [public]                                       True to create a public image
-  [organization-id]                              Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]                              Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]                                Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-ip-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-ip-create-usage.golden
@@ -19,7 +19,7 @@ ARGS:
   [project-id]        The project ID the IP is reserved in
   [server]            UUID of the server you want to attach the IP to
   [tags.{index}]      An array of keywords you want to tag this IP with
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]     Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-placement-group-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-placement-group-create-usage.golden
@@ -29,7 +29,7 @@ ARGS:
   [project-id]         Project ID of the placement group
   [policy-mode]        The operating mode of the placement group (optional | enforced)
   [policy-type]        The policy type of the placement group (max_availability | low_latency)
-  [organization-id]    Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]    Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]      Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-security-group-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-security-group-create-usage.golden
@@ -30,7 +30,7 @@ ARGS:
   [stateful=true]                    Whether the security group is stateful or not
   [inbound-default-policy=accept]    Default policy for inbound rules (accept | drop)
   [outbound-default-policy=accept]   Default policy for outbound rules (accept | drop)
-  [organization-id]                  Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]                  Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]                    Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
@@ -36,9 +36,11 @@ ARGS:
   [placement-group-id]           The placement group ID in witch the server has to be created
   [bootscript-id]                The bootscript ID to use, if empty the local boot will be used
   [cloud-init]                   The cloud-init script to use
-  [organization-id]              Organization ID to use. If none is passed will use default organization ID from the config
-  [project-id]                   Project ID to use. If none is passed will use default project ID from the config
+  [project-id]                   Project ID to use. If none is passed the default project ID will be used
   [zone=fr-par-1]                Zone to target. If none is passed will use default zone from the config
+
+DEPRECATED ARGS:
+  [organization-id]   Please use project-id instead
 
 FLAGS:
   -h, --help   help for create

--- a/cmd/scw/testdata/test-all-usage-instance-snapshot-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-snapshot-create-usage.golden
@@ -19,7 +19,7 @@ ARGS:
   [name=<generated>]   Name of the snapshot
   volume-id            UUID of the volume
   [project-id]         Project ID of the snapshot
-  [organization-id]    Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]    Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]      Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-instance-volume-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-volume-create-usage.golden
@@ -22,7 +22,7 @@ ARGS:
   [size]              The volume disk size
   [base-volume]       The ID of the volume on which this volume will be based
   [base-snapshot]     The ID of the snapshot on which this volume will be based
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
   [zone=fr-par-1]     Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-iot-hub-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-iot-hub-create-usage.golden
@@ -10,7 +10,7 @@ ARGS:
   product-plan=plan_shared   Hub feature set (plan_unknown | plan_shared | plan_dedicated | plan_ha)
   [disable-events]           Disable Hub events (default false)
   [events-topic-prefix]      Hub events topic prefix (default '$SCW/events')
-  [organization-id]          Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]          Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]            Region to target. If none is passed will use default region from the config (fr-par)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-iot-network-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-iot-network-create-usage.golden
@@ -10,7 +10,7 @@ ARGS:
   type                Type of network to connect with (unknown | sigfox | rest)
   hub-id              Hub ID to connect the Network to
   topic-prefix        Topic prefix for the Network
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]     Region to target. If none is passed will use default region from the config (fr-par)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-k8s-cluster-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-k8s-cluster-create-usage.golden
@@ -44,7 +44,7 @@ ARGS:
   [auto-upgrade.maintenance-window.day]                 The day of the week for the maintenance window (any | monday | tuesday | wednesday | thursday | friday | saturday | sunday)
   [feature-gates.{index}]                               List of feature gates to enable
   [admission-plugins.{index}]                           List of admission plugins to enable
-  [organization-id]                                     Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]                                     Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]                                       Region to target. If none is passed will use default region from the config (fr-par | nl-ams)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-lbip-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-lbip-create-usage.golden
@@ -8,7 +8,7 @@ USAGE:
 ARGS:
   [project-id]        Assign the resource to a project ID
   [reverse]           Reverse domain name
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]     Region to target. If none is passed will use default region from the config (fr-par | nl-ams)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-lblb-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-lblb-create-usage.golden
@@ -13,7 +13,7 @@ ARGS:
   [tags.{index}]              List of keyword
   [type=LB-S]                 Load balancer offer type (LB-S | LB-GP-M | LB-GP-L)
   [ssl-compatibility-level]    (ssl_compatibility_level_unknown | ssl_compatibility_level_intermediate | ssl_compatibility_level_modern | ssl_compatibility_level_old)
-  [organization-id]           Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]           Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]             Region to target. If none is passed will use default region from the config (fr-par | nl-ams)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-rdb-instance-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-rdb-instance-create-usage.golden
@@ -16,7 +16,7 @@ ARGS:
   [tags.{index}]                  Tags to apply to the instance
   [init-settings.{index}.name]    
   [init-settings.{index}.value]   
-  [organization-id]               Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]               Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]                 Region to target. If none is passed will use default region from the config (fr-par | nl-ams)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-registry-namespace-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-registry-namespace-create-usage.golden
@@ -10,7 +10,7 @@ ARGS:
   [description]       Define a description
   [project-id]        Assign the namespace to a project ID
   [is-public]         Define the default visibility policy
-  [organization-id]   Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]   Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]     Region to target. If none is passed will use default region from the config (fr-par | nl-ams)
 
 FLAGS:

--- a/cmd/scw/testdata/test-all-usage-vpc-private-network-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-vpc-private-network-create-usage.golden
@@ -6,7 +6,7 @@ USAGE:
   scw vpc private-network create [arg=value ...]
 
 ARGS:
-  [project-id]       Project ID to use. If none is passed will use default project ID from the config
+  [project-id]       Project ID to use. If none is passed the default project ID will be used
   name=<generated>   The name of the private network
   [tags.{index}]     The private networks tags
   [zone=fr-par-1]    Zone to target. If none is passed will use default zone from the config (fr-par-1 | nl-ams-1)

--- a/internal/core/arg_specs.go
+++ b/internal/core/arg_specs.go
@@ -84,6 +84,10 @@ type ArgSpec struct {
 
 	// Only one argument of the same OneOfGroup could be specified
 	OneOfGroup string
+
+	// Deprecated is used to flag an argument as deprecated.
+	// Use the short field to indicate migration tips for users.
+	Deprecated bool
 }
 
 func (a *ArgSpec) Prefix() string {
@@ -156,23 +160,36 @@ func RegionArgSpec(regions ...scw.Region) *ArgSpec {
 func ProjectIDArgSpec() *ArgSpec {
 	return &ArgSpec{
 		Name:         "project-id",
-		Short:        "Project ID to use. If none is passed will use default project ID from the config",
+		Short:        "Project ID to use. If none is passed the default project ID will be used",
 		ValidateFunc: ValidateProjectID(),
 	}
 }
 
-func OrganizationIDArgSpec() *ArgSpec {
+// TODO: Remove me and:
+// - use OrganizationIDDeprecatedArgSpec in the generator
+// - stop using renameOrganizationIDArgSpec and renameProjectIDArgSpec for these use-cases
+func OrganizationArgSpec() *ArgSpec {
 	return &ArgSpec{
-		Name:         "organization-id",
-		Short:        "Organization ID to use. If none is passed will use default organization ID from the config",
+		Name:         "organization",
+		Short:        "Organization ID to use. If none is passed the default organization ID will be used",
 		ValidateFunc: ValidateOrganizationID(),
 	}
 }
 
-func OrganizationArgSpec() *ArgSpec {
+
+func OrganizationIDArgSpec() *ArgSpec {
 	return &ArgSpec{
-		Name:         "organization",
-		Short:        "Organization ID to use. If none is passed will use default organization ID from the config",
+		Name:         "organization-id",
+		Short:        "Organization ID to use. If none is passed the default organization ID will be used",
 		ValidateFunc: ValidateOrganizationID(),
+	}
+}
+
+func OrganizationIDDeprecatedArgSpec() *ArgSpec {
+	return &ArgSpec{
+		Name:         "organization-id",
+		Short:        "Please use project-id instead",
+		ValidateFunc: ValidateOrganizationID(),
+		Deprecated:   true,
 	}
 }

--- a/internal/core/arg_specs.go
+++ b/internal/core/arg_specs.go
@@ -176,7 +176,6 @@ func OrganizationArgSpec() *ArgSpec {
 	}
 }
 
-
 func OrganizationIDArgSpec() *ArgSpec {
 	return &ArgSpec{
 		Name:         "organization-id",

--- a/internal/core/autocomplete.go
+++ b/internal/core/autocomplete.go
@@ -217,6 +217,11 @@ func BuildAutoCompleteTree(commands *Commands) *AutoCompleteNode {
 
 		// We consider ArgSpecs as leaf in the autocomplete tree.
 		for _, argSpec := range cmd.ArgSpecs {
+			if argSpec.Deprecated {
+				// Do not autocomplete deprecated arguments.
+				continue
+			}
+
 			if argSpec.Positional {
 				node.Children[positionalValueNodeID] = NewAutoCompleteArgNode(cmd, argSpec)
 				continue

--- a/internal/core/cobra_builder.go
+++ b/internal/core/cobra_builder.go
@@ -97,7 +97,11 @@ func (b *cobraBuilder) hydrateCobra(cobraCmd *cobra.Command, cmd *Command) {
 	}
 
 	if cmd.ArgsType != nil {
-		cobraCmd.Annotations["UsageArgs"] = buildUsageArgs(b.ctx, cmd)
+		cobraCmd.Annotations["UsageArgs"] = buildUsageArgs(b.ctx, cmd, false)
+	}
+
+	if cmd.ArgSpecs != nil {
+		cobraCmd.Annotations["UsageDeprecatedArgs"] = buildUsageArgs(b.ctx, cmd, true)
 	}
 
 	if cmd.Examples != nil {
@@ -139,7 +143,10 @@ EXAMPLES:
 {{.Annotations.Examples}}{{end}}{{if .Annotations.UsageArgs}}
 
 ARGS:
-{{.Annotations.UsageArgs}}{{end}}{{if .HasAvailableSubCommands}}
+{{.Annotations.UsageArgs}}{{end}}{{if .Annotations.UsageDeprecatedArgs}}
+
+DEPRECATED ARGS:
+{{.Annotations.UsageDeprecatedArgs}}{{end}}{{if .HasAvailableSubCommands}}
 
 AVAILABLE COMMANDS:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{if .Short}}{{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}

--- a/internal/core/cobra_usage_builder.go
+++ b/internal/core/cobra_usage_builder.go
@@ -18,12 +18,21 @@ const (
 )
 
 // buildUsageArgs builds usage args string.
+// If deprecated is true, true only deprecated argSpecs will be considered.
 // This string will be used by cobra usage template.
-func buildUsageArgs(ctx context.Context, cmd *Command) string {
+func buildUsageArgs(ctx context.Context, cmd *Command, deprecated bool) string {
 	var argsBuffer bytes.Buffer
 	tw := tabwriter.NewWriter(&argsBuffer, 0, 0, 3, ' ', 0)
 
-	err := _buildUsageArgs(ctx, tw, cmd.ArgSpecs)
+	// Filter deprecated argSpecs.
+	argSpecs := ArgSpecs(nil)
+	for _, argSpec := range cmd.ArgSpecs {
+		if argSpec.Deprecated == deprecated {
+			argSpecs = append(argSpecs, argSpec)
+		}
+	}
+
+	err := _buildUsageArgs(ctx, tw, argSpecs)
 	if err != nil {
 		// TODO: decide how to handle this error
 		err = fmt.Errorf("building %v: %v", cmd.getPath(), err)

--- a/internal/core/cobra_usage_builder_test.go
+++ b/internal/core/cobra_usage_builder_test.go
@@ -76,7 +76,7 @@ func Test_buildUsageArgs(t *testing.T) {
 				Short: "Additional volume name",
 			},
 		},
-	})
+	}, false)
 
 	assert.Equal(t, want, got)
 }

--- a/internal/core/cobra_utils.go
+++ b/internal/core/cobra_utils.go
@@ -128,7 +128,7 @@ func run(ctx context.Context, cobraCmd *cobra.Command, cmd *Command, rawArgs []s
 	if cmd.ValidateFunc != nil {
 		validateFunc = cmd.ValidateFunc
 	}
-	err = validateFunc(cmd, cmdArgs, rawArgs)
+	err = validateFunc(ctx, cmd, cmdArgs, rawArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,9 @@ Relative time error: %s
 	case *args.UnknownArgError, *args.InvalidArgNameError:
 		argNames := []string(nil)
 		for _, argSpec := range cmd.ArgSpecs {
-			argNames = append(argNames, argSpec.Name)
+			if !argSpec.Deprecated {
+				argNames = append(argNames, argSpec.Name)
+			}
 		}
 
 		return &CliError{

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -124,6 +124,9 @@ func newTemplate() *template.Template {
 		},
 		"arg_spec_flag": func(arg *core.ArgSpec) string {
 			parts := []string(nil)
+			if arg.Deprecated {
+				parts = append(parts, "Deprecated")
+			}
 			if arg.Required {
 				parts = append(parts, "Required")
 			}
@@ -135,6 +138,13 @@ func newTemplate() *template.Template {
 				parts = append(parts, fmt.Sprintf("One of: `%s`", strings.Join(arg.EnumValues, "`, `")))
 			}
 			return strings.Join(parts, "<br />")
+		},
+		"arg_spec_name": func(arg *core.ArgSpec) string {
+			res := arg.Name
+			if arg.Deprecated {
+				res = "~~" + arg.Name + "~~"
+			}
+			return res
 		},
 		"default": func(defaultValue string, value string) string {
 			if value == "" {

--- a/internal/docgen/tpl.go
+++ b/internal/docgen/tpl.go
@@ -49,7 +49,7 @@ const tplStr = `
 | Name |   | Description |
 |------|---|-------------|
 {{ range $arg := .Cmd.ArgSpecs -}}
-| {{ $arg.Name }} | {{ arg_spec_flag $arg }} | {{ $arg.Short }} |
+| {{ arg_spec_name $arg }} | {{ arg_spec_flag $arg }} | {{ $arg.Short }} |
 {{ end -}}
 {{- end -}}
 {{- if .Cmd.Examples }}

--- a/internal/e2e/testdata/test-human-create-usage.golden
+++ b/internal/e2e/testdata/test-human-create-usage.golden
@@ -20,7 +20,7 @@ ARGS:
   [eyes-color]                (unknown | amber | blue | brown | gray | green | hazel | red | violet)
   [name]                     
   [project-id]               
-  [organization-id]          Organization ID to use. If none is passed will use default organization ID from the config
+  [organization-id]          Organization ID to use. If none is passed the default organization ID will be used
   [region=fr-par]            Region to target. If none is passed will use default region from the config (fr-par)
 
 FLAGS:

--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -21,7 +21,6 @@ import (
 // TODO: Add cloud-init
 type instanceCreateServerRequest struct {
 	Zone              scw.Zone
-	OrganizationID    *string
 	ProjectID         *string
 	Image             string
 	Type              string
@@ -36,6 +35,9 @@ type instanceCreateServerRequest struct {
 	PlacementGroupID  string
 	BootscriptID      string
 	CloudInit         string
+
+	// Deprecated, use project-id instead
+	OrganizationID *string
 }
 
 // TODO: Remove all error uppercase and punctuations when [APIGW-1367] will be done
@@ -106,9 +108,9 @@ func serverCreateCommand() *core.Command {
 				Name:  "cloud-init",
 				Short: "The cloud-init script to use",
 			},
-			core.OrganizationIDArgSpec(),
 			core.ProjectIDArgSpec(),
 			core.ZoneArgSpec(),
+			core.OrganizationIDDeprecatedArgSpec(),
 		},
 		Run:      instanceServerCreateRun,
 		WaitFunc: instanceWaitServerCreateRun(),


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

## Description

This PR introduces the handling of deprecated arguments with the example of the `organization-id` field of `scw instance server create`:
- Add a `Deprecated bool` argument to `core.ArgSpec`
- Add a new `DEPRECATED ARGS` for deprecated args in the command usage.
- Ignore deprecated arguments in autocomplete
- Print a warning when a deprecated argument is used: `The argument 'organization-id' is deprecated, more info with: scw instance server create --help`

The addition of the `project-id` field is already done in #1410, I will rebase on this one when it will be merged.

## Next Steps

Update the generator to fill the  `core.ArgSpec.Depreacred` field.

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/v2/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Handle deprecated arguments
```
