### PR TITLE
doc: fix wrong image path and remove mention of the v2 branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 `scaleway-cli` is Apache 2.0 licensed and accepts contributions via GitHub.
 This document will cover how to contribute to the project and report issues.
 
-<p align="center"><img width="50%" src="docs/static_files/cli-artwork.png" /></p>
+<p align="center"><img width="50%" src="../docs/static_files/cli-artwork.png" /></p>
 
 ## Topics
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ To submit code:
 - Create a topic branch from where you want to base your work (usually master)
 - Add tests to cover contributed code
 - Push your commit(s) to your topic branch on your fork
-- Open a pull request against `scaleway-cli` `v2` branch that follows [PR guidelines](#pull-request-guidelines)
+- Open a pull request against `scaleway-cli` `master` branch that follows [PR guidelines](#pull-request-guidelines)
 
 The [maintainers](MAINTAINERS.md) of `scaleway-cli` use a "Let's Get This Merged" (LGTM) message in the pull request to note that the commits are ready to merge.
 After one or more maintainer states LGTM, we will merge.
@@ -73,9 +73,7 @@ The goal of the following guidelines is to have Pull Requests (PRs) that are fai
 - **Please, keep us updated.**
   We will try our best to merge your PR, but please notice that PRs may be closed after 30 days of inactivity.
 
-Your pull request should be rebased against the current `v2` branch. Please do not merge
-the current `v2` branch in with your topic branch, nor use the Update Branch button provided
-by GitHub on the pull request page.
+Your pull request should be rebased against the `master` branch.
 
 Keep in mind only the **pull request title** will be used as commit message as we stash all commits on merge.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 <!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
 Relates OR Closes #0000
 
-Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/v2/CHANGELOG.md):
+Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
 <!--
 If the change is not user facing, just write "NONE" in the release-note block below.
 -->


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/v2/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
