### PR TITLE
fix(release): use dots instead of dashes in release assets name version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Download the release from github
-curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2-2-0-darwin-x86_64"
+curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2.2.0-darwin-x86_64"
 
 # Allow executing file as program
 chmod +x /usr/local/bin/scw
@@ -78,7 +78,7 @@ scw init
 
 ```bash
 # Download the release from github
-sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2-2-0-linux-x86_64"
+sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2.2.0-linux-x86_64"
 
 # Allow executing file as program
 sudo chmod +x /usr/local/bin/scw
@@ -89,7 +89,7 @@ scw init
 
 #### Windows
 
-You can download the last release here: https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2-2-0-windows-x86_64.exe<br/>
+You can download the last release here: https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-2.2.0-windows-x86_64.exe<br/>
 [This official guide](https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574%28v%3Doffice.14%29) explains how to add tools to your `PATH`.
 
 <!-- TODO:
@@ -100,7 +100,7 @@ First, download [the `.deb` file](https://github.com/scaleway/scaleway-cli/relea
 
 ```bash
 export ARCH=amd64 # Can be 'amd64', 'arm', 'arm64' or 'i386'
-wget "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-v2-2-0-${ARCH}.deb" -O /tmp/scw.deb
+wget "https://github.com/scaleway/scaleway-cli/releases/download/v2.2.0/scw-v2.2.0-${ARCH}.deb" -O /tmp/scw.deb
 ```
 
 Then, run the installation and remove the `.deb` file:

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -149,7 +149,6 @@ async function main() {
         .filter(semver.valid)
         .sort((a, b) => semver.rcompare(semver.clean(a), semver.clean(b)))[0];
     const lastVersion =  semver.clean(lastSemverTag);
-    const lastVersionWithDash = lastVersion.replace(/\./g, "-");
     console.log(`    Last found release tag was ${lastSemverTag}`.green);
 
     console.log("Listing commit since last release".blue);
@@ -162,7 +161,6 @@ async function main() {
     if (!newVersion) {
         throw new Error(`invalid version`);
     }
-    const newVersionWithDash = newVersion.replace(/\./g, "-");
 
     //
     // Creating release commit
@@ -173,7 +171,6 @@ async function main() {
     changelog.body = externalEditor.edit(changelog.body);
 
     replaceInFile(README_PATH, lastVersion, newVersion);
-    replaceInFile(README_PATH, lastVersionWithDash, newVersionWithDash);
     replaceInFile(CHANGELOG_PATH, "# Changelog", `# Changelog\n\n${changelog.header}\n\n${changelog.body}\n`);
     replaceInFile(GO_VERSION_PATH, /Version = "[^"]*"/, `Version = "v${newVersion}"`);
     console.log(`    Update success`.green);
@@ -217,11 +214,11 @@ async function main() {
 
     console.log("    attach assets to the release".gray);
     const releaseAssets = [
-        `scw-${newVersionWithDash}-darwin-x86_64`,
-        `scw-${newVersionWithDash}-linux-x86_64`,
-        `scw-${newVersionWithDash}-linux-386`,
-        `scw-${newVersionWithDash}-windows-x86_64.exe`,
-        `scw-${newVersionWithDash}-windows-386.exe`,
+        `scw-${newVersion}-darwin-x86_64`,
+        `scw-${newVersion}-linux-x86_64`,
+        `scw-${newVersion}-linux-386`,
+        `scw-${newVersion}-windows-x86_64.exe`,
+        `scw-${newVersion}-windows-386.exe`,
         `SHA256SUMS`,
     ];
     await Promise.all(releaseAssets.map((assetName) => {


### PR DESCRIPTION
Signed-off-by: Patrik Cyvoct <pcyvoct@scaleway.com>

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix: use dots instead of dashes in release assets name version
```
