### PR TITLE
fix(object): mc: change generated Signature Version from v2 to v4

### DIFF
--- a/internal/namespaces/object/v1/s3configfile.go
+++ b/internal/namespaces/object/v1/s3configfile.go
@@ -150,7 +150,7 @@ func (c s3config) getConfigFile(tool s3tool) (core.RawResult, error) {
 					URL:       "https://s3." + c.Region.String() + ".scw.cloud",
 					AccessKey: c.AccessKey,
 					SecretKey: c.SecretKey,
-					API:       "S3v2",
+					API:       "S3v4",
 				},
 			},
 		}

--- a/internal/namespaces/object/v1/testdata/test-config-get-default-mc.golden
+++ b/internal/namespaces/object/v1/testdata/test-config-get-default-mc.golden
@@ -1,5 +1,5 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-{"version":"9","hosts":{"scaleway":{"url":"https://s3.fr-par.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v2"}}}
+{"version":"9","hosts":{"scaleway":{"url":"https://s3.fr-par.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v4"}}}
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
-{"version":"9","hosts":{"scaleway":{"url":"https://s3.fr-par.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v2"}}}
+{"version":"9","hosts":{"scaleway":{"url":"https://s3.fr-par.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v4"}}}

--- a/internal/namespaces/object/v1/testdata/test-config-get-with-region-mc.golden
+++ b/internal/namespaces/object/v1/testdata/test-config-get-with-region-mc.golden
@@ -1,5 +1,5 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-{"version":"9","hosts":{"scaleway":{"url":"https://s3.nl-ams.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v2"}}}
+{"version":"9","hosts":{"scaleway":{"url":"https://s3.nl-ams.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v4"}}}
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
-{"version":"9","hosts":{"scaleway":{"url":"https://s3.nl-ams.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v2"}}}
+{"version":"9","hosts":{"scaleway":{"url":"https://s3.nl-ams.scw.cloud","accessKey":"SCWXXXXXXXXXXXXXXXXX","secretKey":"11111111-1111-1111-1111-111111111111","api":"S3v4"}}}


### PR DESCRIPTION
Before this change, using "mc" to generate a pre-sign URL using for uploading an object would not work. After manually updating the config from S3v2 to S3v4 all good now.

Command I used is:

```bash
mc share upload scaleway/my-bucket/test.png
```

Before the change it would generate a URL like this, and it doesn't work:

```bash
$ mc share upload scaleway/my-test-bucket/test.png
URL: https://s3.fr-par.scw.cloud/my-test-bucket/test.png
Expire: 7 days 0 hours 0 minutes 0 seconds
Share: curl https://s3.fr-par.scw.cloud/my-test-bucket/ -F signature=jE27Ptr/IkDJcP60ZqA7jJD7RnE= -F bucket=my-test-bucket -F policy=eyJleHBpcmF0aW9uIjoiMxAyMC0xMS0xOVQxMTo0OTo1Mi4xMloi2CJjb25kaXRpb25zIjpbWyJlcSIsIiRidWNrZXQiLCJkYW5sb24tc3RhZ2luZy1sb2dvLXVwbG9hZHMiXSxbImVxIiwiJGtleSIsInRlc3QucG5nIl1dfQ== -F AWSAccessKeyId=SCW3BBT57A1CZEXJD2T5 -F key=test.png -F file=@<FILE>
$
```

After the change it would generate a URL like this, and it works:

```bash
$ mc share upload scaleway/my-test-bucket/test.png
URL: https://s3.fr-par.scw.cloud/my-test-bucket/test.png
Expire: 7 days 0 hours 0 minutes 0 seconds
Share: curl https://s3.fr-par.scw.cloud/my-test-bucket/ -F bucket=my-test-bucket -F policy=eyJleHBpcmF0aW9uIjoiMjAyMC0xMS0xOVQxMTo1MzowMC42NzJaIiwiY29uZGl0aW9ucyI6W1siZXEiLCIkYnVja2V0IiwiZGFubG9uLXN0YWdpbmctbG9nby11cGxvYWRzIl0sWyJlcSIsIiRrZXkiLCJ0ZXN0LnBuZyJdLFsiZXEiLCIkeC1hbXotZGF0ZSIsIjIwMjAxMTEyVDxxNTMwMVoiXSxbImVxIiwiJHgtYW16LWFsZ29yaXRobSIsIkFXUzQtSE1BQy1TSEEyNTYiXSxbImVxIiwiJHgtYW16LWNyZWRlbnRpYWwiLCJTQ1dOQkJUNTdBRUNaRVhKRDJUWi8yMDIwMTExMi9mci1wYXIvczMvYXdzNF9yZXF1ZXN0Il1dfQ== -F x-amz-algorithm=AWS4-HMAC-SHA256 -F x-amz-credential=SCWXBBT51AECZEXJD2TZ/20201112/fr-par/s3/aws4_request -F x-amz-date=20201112T115301Z -F x-amz-signature=2eed2818b8fa1e833b12fab3b09c88987c6ba6be81786f9e94fac1c464b342f2 -F key=test.png -F file=@<FILE>
$
```

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update generated mc config to have Signature Version v4
```
