### PR TITLE
fix(instance): fix documentation on server update

### DIFF
--- a/cmd/scw/testdata/test-all-usage-instance-server-update-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-server-update-usage.golden
@@ -19,10 +19,10 @@ EXAMPLES:
     scw instance server update 11111111-1111-1111-1111-111111111111 enable-ipv6=true
 
   Apply the given security group to a given server
-    scw instance server update
+    scw instance server update 11111111-1111-1111-1111-111111111111 security-group-id=11111111-1111-1111-1111-111111111111
 
   Put a given server in the given placement group. Server must be off
-    scw instance server update
+    scw instance server update 11111111-1111-1111-1111-111111111111 placement-group=11111111-1111-1111-1111-111111111111
 
 ARGS:
   server-id                                   UUID of the server

--- a/internal/namespaces/instance/v1/instance_cli.go
+++ b/internal/namespaces/instance/v1/instance_cli.go
@@ -688,11 +688,11 @@ func instanceServerUpdate() *core.Command {
 			},
 			{
 				Short:    "Apply the given security group to a given server",
-				ArgsJSON: `null`,
+				ArgsJSON: `{"security_group_id":"11111111-1111-1111-1111-111111111111","server_id":"11111111-1111-1111-1111-111111111111"}`,
 			},
 			{
 				Short:    "Put a given server in the given placement group. Server must be off",
-				ArgsJSON: `null`,
+				ArgsJSON: `{"placement_group":"11111111-1111-1111-1111-111111111111","server_id":"11111111-1111-1111-1111-111111111111"}`,
 			},
 		},
 	}


### PR DESCRIPTION
before:
```
  Apply the given security group to a given server
    scw instance server update
  Put a given server in the given placement group. Server must be off
    scw instance server update
```

after:
```
  Apply the given security group to a given server
    scw instance server update 11111111-1111-1111-1111-111111111111 security-group-id=11111111-1111-1111-1111-111111111111

  Put a given server in the given placement group. Server must be off
    scw instance server update 11111111-1111-1111-1111-111111111111 placement-group=11111111-1111-1111-1111-111111111111
```