### PR TITLE
feat: enable darwin/arm64 (M1) during build time

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,7 @@ VERSION=$(go run cmd/scw/main.go -o json version | jq -r .version)
 BIN_LINUX="$BIN_DIR/scw-$VERSION-linux-x86_64"
 BIN_LINUX_386="$BIN_DIR/scw-$VERSION-linux-386"
 BIN_DARWIN="$BIN_DIR/scw-$VERSION-darwin-x86_64"
+BIN_DARWIN_ARM64="$BIN_DIR/scw-$VERSION-darwin-arm64"
 BIN_WINDOWS="$BIN_DIR/scw-$VERSION-windows-x86_64.exe"
 BIN_WINDOWS_386="$BIN_DIR/scw-$VERSION-windows-386.exe"
 
@@ -31,11 +32,13 @@ GOOS=linux  GOARCH=386 go build -ldflags "${LDFLAGS[*]}" -o "$BIN_LINUX_386" cmd
 GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS[*]}" -o "$BIN_DARWIN" cmd/scw/main.go
 GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS[*]}" -o "$BIN_WINDOWS" cmd/scw/main.go
 GOOS=windows GOARCH=386 go build -ldflags "${LDFLAGS[*]}" -o "$BIN_WINDOWS_386" cmd/scw/main.go
+GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS[*]}" -o "$BIN_DARWIN_ARM64" cmd/scw/main.go
 
 shasum -a 256 \
   "$BIN_LINUX" \
   "$BIN_LINUX_386" \
   "$BIN_DARWIN" \
+  "$BIN_DARWIN_ARM64" \
   "$BIN_WINDOWS" \
   "$BIN_WINDOWS_386" \
   | sed -e 's#./bin/##' > "$BIN_DIR/SHA256SUMS"

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -215,6 +215,7 @@ async function main() {
     console.log("    attach assets to the release".gray);
     const releaseAssets = [
         `scw-${newVersion}-darwin-x86_64`,
+        `scw-${newVersion}-darwin-arm64`,
         `scw-${newVersion}-linux-x86_64`,
         `scw-${newVersion}-linux-386`,
         `scw-${newVersion}-windows-x86_64.exe`,


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
