### PR TITLE
fix: allow _ in validArgName

### DIFF
--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -10,7 +10,7 @@ import (
 )
 
 // validArgNameRegex regex to check that args words are lower-case or digit starting and ending with a letter.
-var validArgNameRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+var validArgNameRegex = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
 const emptySliceValue = "none"
 


### PR DESCRIPTION
This PR allow the usage of `_` in argument name. 

This is a problem for example on RDB as it's not possible to create databases or users with `_` via cli even if the RDB API allows it 

```
scw rdb database create scw_test
Invalid argument 'scw_test': arg name must only contain lowercase letters, numbers or dashes
```