### PR TITLE
Fix readme download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ You just have to download the binary compatible with your platform to a director
 
 ```bash
 # Check out the latest release available on github <https://github.com/scaleway/scaleway-cli/releases/latest>
-VERSION="2.4.0"
+VERSION="2.5.1"
 
 # Download the release from github
-sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v$VERSION/scw-$VERSION-linux-x86_64"
+sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v$VERSION/scaleway-cli_$VERSION_linux_amd64"
+# Naming changed lately, the url prior to 2.5.1 was https://github.com/scaleway/scaleway-cli/releases/download/v$VERSION/scw-$VERSION-linux-x86_64
 
 # Allow executing file as program
 sudo chmod +x /usr/local/bin/scw


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->
This PR is about changing the download url in the readme for what seems to be the new binaries naming convention.


```release-note
NONE
```
