### PR TITLE
docs: fix Arch Linux links and naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Install the latest stable release on macOS using [Homebrew](http://brew.sh):
 brew install scw
 ```
 
-### Archlinux
+### Arch Linux
 
-Install the latest stable release on Archlinux via [AUR](https://aur.archlinux.org/packages/scaleway-cli/).
-For instance with `yay`:
+Install the latest stable release on Arch Linux from [offcial repositories](https://archlinux.org/packages/community/x86_64/scaleway-cli/).
+For instance with `pacman`:
 
 ```sh
-yay -S scaleway-cli
+pacman -S scaleway-cli
 ```
 
 ### Chocolatey


### PR DESCRIPTION
- Update Arch packaging link to [community]. Fix #2318.
- Fix Arch naming. Archlinux -> Arch Linux.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2318

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
