### PR TITLE
docs: Fix variable substitution in Linux install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ You just have to download the binary compatible with your platform to a director
 VERSION="2.5.1"
 
 # Download the release from github
-sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v$VERSION/scaleway-cli_$VERSION_linux_amd64"
-# Naming changed lately, the url prior to 2.5.1 was https://github.com/scaleway/scaleway-cli/releases/download/v$VERSION/scw-$VERSION-linux-x86_64
+sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v${VERSION}/scaleway-cli_${VERSION}_linux_amd64"
+# Naming changed lately, the url prior to 2.5.1 was https://github.com/scaleway/scaleway-cli/releases/download/v${VERSION}/scw-${VERSION}-linux-x86_64
 
 # Allow executing file as program
 sudo chmod +x /usr/local/bin/scw


### PR DESCRIPTION
- Current variable substitution results in invalid URL in Linux install instructions. The shell takes `$VERSION_linux_amd64` as a variable name, whereas we actually just want `$VERSION`. This wasn't a problem before as the old URL used hyphens.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
