### PR TITLE
fix(server_create): pass down error on bad image label

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -231,7 +231,7 @@ func instanceServerCreateRun(ctx context.Context, argsI interface{}) (i interfac
 			CommercialType: serverReq.CommercialType,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("bad image label '%s' for %s", args.Image, serverReq.CommercialType)
+			return nil, err
 		}
 		serverReq.Image = imageID
 	default:

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-image-label.golden
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-image-label.golden
@@ -1,7 +1,7 @@
 🎲🎲🎲 EXIT CODE: 1 🎲🎲🎲
 🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-Bad image label 'macos' for DEV1-S
+Scaleway-sdk-go: couldn't find a matching image for the given label (macos), zone (fr-par-1) and commercial type (DEV1-S)
 🟥🟥🟥 JSON STDERR 🟥🟥🟥
 {
-  "error": "bad image label 'macos' for DEV1-S"
+  "error": "scaleway-sdk-go: couldn't find a matching image for the given label (macos), zone (fr-par-1) and commercial type (DEV1-S)"
 }

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-instance-type.golden
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-instance-type.golden
@@ -1,7 +1,7 @@
 🎲🎲🎲 EXIT CODE: 1 🎲🎲🎲
 🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-Bad image label 'ubuntu_bionic' for MACBOOK1-S
+Scaleway-sdk-go: couldn't find a matching image for the given label (ubuntu_bionic), zone (fr-par-1) and commercial type (MACBOOK1-S): couldn't find compatible local image for this image version (47d38b1a-71a9-4f29-80bc-2dbb7bda7f9f)
 🟥🟥🟥 JSON STDERR 🟥🟥🟥
 {
-  "error": "bad image label 'ubuntu_bionic' for MACBOOK1-S"
+  "error": "scaleway-sdk-go: couldn't find a matching image for the given label (ubuntu_bionic), zone (fr-par-1) and commercial type (MACBOOK1-S): couldn't find compatible local image for this image version (47d38b1a-71a9-4f29-80bc-2dbb7bda7f9f)"
 }


### PR DESCRIPTION
Pass down error to get better messages
Instead of `Bad image label 'ubuntu_focalzz' for GP1-S`

You could get
- `scaleway-sdk-go: couldn't find a matching image for the given label (ubuntu_focalzz), zone (fr-par-2) and commercial type (GP1-S)`
- `scaleway-sdk-go: denied authentication: API key does not exist`