### PR TITLE
fix: bump linter 1.48.0 and remplace "io/ioutil". 

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,4 +11,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
+          version: v1.48.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine as builder
+FROM golang:1.19-alpine as builder
 
 ENV BUILD_IN_DOCKER true
 ARG VERSION

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -48,7 +48,7 @@ func GetAPIKey(ctx context.Context, secretKey string) (*Token, error) {
 	}
 
 	token := &LoginResponse{}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/args/marshal.go
+++ b/internal/args/marshal.go
@@ -94,10 +94,10 @@ func RegisterMarshalFunc(i interface{}, marshalFunc MarshalFunc) {
 // It will take care of pointers resolution, nested structs, etc.
 //
 // If this function is called with:
-//  - a marshalable value: [ "${keys.join(.)}=${marshaledValue}" ]
-//  - a go struct: [ "${keys.join(.)}.field1=${marshaledField1}", ... ]
-//  - a go map: [ "${keys.join(.)}.key1=${marshaledValue1}", ... ]
-//  - a go slice: [ "${keys.join(.)}.0=${marshaledValue0}", ... ]
+//   - a marshal-able value: [ "${keys.join(.)}=${marshaledValue}" ]
+//   - a go struct: [ "${keys.join(.)}.field1=${marshaledField1}", ... ]
+//   - a go map: [ "${keys.join(.)}.key1=${marshaledValue1}", ... ]
+//   - a go slice: [ "${keys.join(.)}.0=${marshaledValue0}", ... ]
 //
 // src: the value to marshal
 // keys: the parent keys used by recursion (nil on first level)

--- a/internal/core/arg_file_content.go
+++ b/internal/core/arg_file_content.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -27,13 +27,13 @@ func loadArgsFileContent(cmd *Command, cmdArgs interface{}) error {
 		for _, v := range fieldValues {
 			switch i := v.Interface().(type) {
 			case io.Reader:
-				b, err := ioutil.ReadAll(i)
+				b, err := io.ReadAll(i)
 				if err != nil {
 					return fmt.Errorf("could not read argument: %s", err)
 				}
 
 				if strings.HasPrefix(string(b), "@") {
-					content, err := ioutil.ReadFile(string(b)[1:])
+					content, err := os.ReadFile(string(b)[1:])
 					if err != nil {
 						return fmt.Errorf("could not open requested file: %s", err)
 					}
@@ -42,7 +42,7 @@ func loadArgsFileContent(cmd *Command, cmdArgs interface{}) error {
 				}
 			case *string:
 				if strings.HasPrefix(*i, "@") {
-					content, err := ioutil.ReadFile((*i)[1:])
+					content, err := os.ReadFile((*i)[1:])
 					if err != nil {
 						return fmt.Errorf("could not open requested file: %s", err)
 					}
@@ -50,7 +50,7 @@ func loadArgsFileContent(cmd *Command, cmdArgs interface{}) error {
 				}
 			case string:
 				if strings.HasPrefix(i, "@") {
-					content, err := ioutil.ReadFile(i[1:])
+					content, err := os.ReadFile(i[1:])
 					if err != nil {
 						return fmt.Errorf("could not open requested file: %s", err)
 					}

--- a/internal/core/autocomplete.go
+++ b/internal/core/autocomplete.go
@@ -112,7 +112,7 @@ func NewAutoCompleteCommandNode() *AutoCompleteNode {
 	}
 }
 
-// NewArgAutoCompleteNode creates a new node corresponding to a command argument.
+// NewAutoCompleteArgNode creates a new node corresponding to a command argument.
 // These nodes are leaf nodes.
 func NewAutoCompleteArgNode(cmd *Command, argSpec *ArgSpec) *AutoCompleteNode {
 	return &AutoCompleteNode{
@@ -123,11 +123,11 @@ func NewAutoCompleteArgNode(cmd *Command, argSpec *ArgSpec) *AutoCompleteNode {
 	}
 }
 
-// NewFlagAutoCompleteNode returns a node representing a Flag.
+// NewAutoCompleteFlagNode returns a node representing a Flag.
 // It creates the children node with possible values if they exist.
 // It sets parent.children as children of the lowest nodes:
-//  the lowest node is the flag if it has no possible value ;
-//  or the lowest nodes are the possible values if the exist.
+// the lowest node is the flag if it has no possible value ;
+// or the lowest nodes are the possible values if the exist.
 func NewAutoCompleteFlagNode(parent *AutoCompleteNode, flagSpec *FlagSpec) *AutoCompleteNode {
 	node := &AutoCompleteNode{
 		Children: make(map[string]*AutoCompleteNode),

--- a/internal/core/build_info.go
+++ b/internal/core/build_info.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -111,7 +111,7 @@ func getLatestVersion(client *http.Client) (*version.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/command_interceptor.go
+++ b/internal/core/command_interceptor.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -127,7 +127,7 @@ func sdkStdTypeInterceptor(ctx context.Context, args interface{}, runner Command
 	switch sdkValue := res.(type) {
 	case *scw.File:
 		ExtractLogger(ctx).Debug("Intercepting scw.File type, rendering as string")
-		fileContent, err := ioutil.ReadAll(sdkValue.Content)
+		fileContent, err := io.ReadAll(sdkValue.Content)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/testing.go
+++ b/internal/core/testing.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -330,7 +329,7 @@ func Test(config *TestConfig) func(t *testing.T) {
 		}
 
 		if config.TmpHomeDir {
-			dir, err := ioutil.TempDir(os.TempDir(), "scw")
+			dir, err := os.MkdirTemp(os.TempDir(), "scw")
 			require.NoError(t, err)
 			defer func() {
 				err = os.RemoveAll(dir)
@@ -582,10 +581,10 @@ func TestCheckGolden() TestCheck {
 		// In order to avoid diff in goldens we set all timestamp to the same date
 		if *UpdateGoldens {
 			require.NoError(t, os.MkdirAll(path.Dir(goldenPath), 0755))
-			require.NoError(t, ioutil.WriteFile(goldenPath, []byte(actual), 0644)) //nolint:gosec
+			require.NoError(t, os.WriteFile(goldenPath, []byte(actual), 0644)) //nolint:gosec
 		}
 
-		expected, err := ioutil.ReadFile(goldenPath)
+		expected, err := os.ReadFile(goldenPath)
 		require.NoError(t, err, "expected to find golden file %s", goldenPath)
 		assert.Equal(t, string(expected), actual)
 	}

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -29,7 +29,7 @@ type tplResource struct {
 
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 
-// GenerateDocs Generate markdown documentation for a given list of commands
+// GenerateDocs generates markdown documentation for a given list of commands
 func GenerateDocs(commands *core.Commands, outDir string) error {
 	// Prepare data that will be sent to template engine
 	data := &tplData{

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -3,7 +3,7 @@ package docgen
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -29,7 +29,7 @@ type tplResource struct {
 
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 
-// Generate markdown documentation for a given list of commands
+// GenerateDocs Generate markdown documentation for a given list of commands
 func GenerateDocs(commands *core.Commands, outDir string) error {
 	// Prepare data that will be sent to template engine
 	data := &tplData{
@@ -77,7 +77,7 @@ func GenerateDocs(commands *core.Commands, outDir string) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(path.Join(outDir, name+".md"), []byte(namespaceDoc), 0600)
+		err = os.WriteFile(path.Join(outDir, name+".md"), []byte(namespaceDoc), 0600)
 		if err != nil {
 			return err
 		}

--- a/internal/namespaces/account/v2alpha1/custom.go
+++ b/internal/namespaces/account/v2alpha1/custom.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -47,7 +46,7 @@ func InitRun(ctx context.Context, argsI interface{}) (i interface{}, e error) {
 		relativePath := path.Join(".ssh", keyName)
 		filename := path.Join(core.ExtractUserHomeDir(ctx), relativePath)
 		shortenedFilename = "~/" + relativePath
-		localSSHKeyContent, err = ioutil.ReadFile(filename)
+		localSSHKeyContent, err = os.ReadFile(filename)
 		// If we managed to load an ssh key, let's stop there
 		if err == nil {
 			break

--- a/internal/namespaces/account/v2alpha1/custom_test.go
+++ b/internal/namespaces/account/v2alpha1/custom_test.go
@@ -1,7 +1,6 @@
 package account
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -23,7 +22,7 @@ func Test_initCommand(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				err = ioutil.WriteFile(pathToPublicKey, []byte(content), 0644)
+				err = os.WriteFile(pathToPublicKey, []byte(content), 0644)
 				return err
 			}
 			return err

--- a/internal/namespaces/autocomplete/autocomplete.go
+++ b/internal/namespaces/autocomplete/autocomplete.go
@@ -3,7 +3,7 @@ package autocomplete
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -197,7 +197,7 @@ func InstallCommandRun(ctx context.Context, argsI interface{}) (i interface{}, e
 	}
 
 	// Early exit if eval line is already present in the shell configuration.
-	shellConfigurationFileContent, err := ioutil.ReadAll(f)
+	shellConfigurationFileContent, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/namespaces/baremetal/v1/baremetal_cli_test.go
+++ b/internal/namespaces/baremetal/v1/baremetal_cli_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 // Server
-
 func Test_ListServer(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: GetCommands(),

--- a/internal/namespaces/baremetal/v1/baremetal_cli_test.go
+++ b/internal/namespaces/baremetal/v1/baremetal_cli_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
 
-//
 // Server
-//
+
 func Test_ListServer(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: GetCommands(),

--- a/internal/namespaces/baremetal/v1/helpers_test.go
+++ b/internal/namespaces/baremetal/v1/helpers_test.go
@@ -16,7 +16,8 @@ func createServer(metaKey string) core.BeforeFunc {
 
 // deleteServer deletes a server
 // previously registered in the context Meta at metaKey.
-// nolint:unparam
+//
+//nolint:unparam
 func deleteServer(metaKey string) core.AfterFunc {
 	return core.ExecAfterCmd("scw baremetal server delete zone=nl-ams-1 {{ ." + metaKey + ".ID }}")
 }

--- a/internal/namespaces/config/commands.go
+++ b/internal/namespaces/config/commands.go
@@ -510,9 +510,8 @@ func configResetCommand() *core.Command {
 	}
 }
 
-//
 // Helper functions
-//
+
 func getProfileValue(profile *scw.Profile, fieldName string) (interface{}, error) {
 	field, err := getProfileField(profile, fieldName)
 	if err != nil {

--- a/internal/namespaces/config/commands.go
+++ b/internal/namespaces/config/commands.go
@@ -511,7 +511,6 @@ func configResetCommand() *core.Command {
 }
 
 // Helper functions
-
 func getProfileValue(profile *scw.Profile, fieldName string) (interface{}, error) {
 	field, err := getProfileField(profile, fieldName)
 	if err != nil {

--- a/internal/namespaces/feedback/issue.go
+++ b/internal/namespaces/feedback/issue.go
@@ -92,11 +92,11 @@ func (i issue) openInBrowser(ctx context.Context) error {
 
 	switch runtime.GOOS {
 	case linux:
-		openCmd = exec.Command("xdg-open", i.getURL()) // nolint:gosec
+		openCmd = exec.Command("xdg-open", i.getURL()) //nolint:gosec
 	case windows:
-		openCmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", i.getURL()) // nolint:gosec
+		openCmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", i.getURL()) //nolint:gosec
 	case darwin:
-		openCmd = exec.Command("open", i.getURL()) // nolint:gosec
+		openCmd = exec.Command("open", i.getURL()) //nolint:gosec
 	default:
 		return fmt.Errorf("unsupported platform")
 	}

--- a/internal/namespaces/init/custom_init_autocomplete_test.go
+++ b/internal/namespaces/init/custom_init_autocomplete_test.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -62,7 +61,7 @@ eval "$(scw autocomplete script shell=zsh)"
 						}
 						homeDir := ctx.OverrideEnv["HOME"]
 						filePath := path.Join(homeDir, ".zshrc")
-						fileContent, err := ioutil.ReadFile(filePath)
+						fileContent, err := os.ReadFile(filePath)
 						require.NoError(t, err)
 						require.Equal(t, evalLine, string(fileContent))
 					},
@@ -111,7 +110,7 @@ eval (scw autocomplete script shell=fish)
 						}
 						homeDir := ctx.OverrideEnv["HOME"]
 						filePath := path.Join(homeDir, ".config", "fish", "config.fish")
-						fileContent, err := ioutil.ReadFile(filePath)
+						fileContent, err := os.ReadFile(filePath)
 						require.NoError(t, err)
 						require.Equal(t, evalLine, string(fileContent))
 					},
@@ -154,7 +153,7 @@ eval "$(scw autocomplete script shell=bash)"
 						default:
 							t.Fatalf("unsupported OS")
 						}
-						fileContent, err := ioutil.ReadFile(filePath)
+						fileContent, err := os.ReadFile(filePath)
 						if err != nil {
 							require.NoError(t, err)
 						}

--- a/internal/namespaces/init/custom_init_ssh_test.go
+++ b/internal/namespaces/init/custom_init_ssh_test.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,7 +26,7 @@ func setUpSSHKeyLocallyWithKeyName(key string, name string) core.BeforeFunc {
 		}
 
 		// Write the configuration file
-		err = ioutil.WriteFile(keyPath, []byte(key), 0600)
+		err = os.WriteFile(keyPath, []byte(key), 0600)
 		if err != nil {
 			return err
 		}

--- a/internal/namespaces/instance/v1/custom_image.go
+++ b/internal/namespaces/instance/v1/custom_image.go
@@ -252,7 +252,8 @@ func imageListBuilder(c *core.Command) *core.Command {
 }
 
 // imageDeleteBuilder override delete command to:
-//  - add a with-snapshots parameter
+
+// - add a with-snapshots parameter
 func imageDeleteBuilder(c *core.Command) *core.Command {
 	type customDeleteImageRequest struct {
 		*instance.DeleteImageRequest

--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -488,7 +488,6 @@ func buildVolumes(api *instance.API, zone scw.Zone, serverName, rootVolume strin
 // A valid volume format is either
 // - a "creation" format: ^((local|l|block|b):)?\d+GB?$ (size is handled by go-humanize, so other sizes are supported)
 // - a UUID format
-//
 func buildVolumeTemplate(api *instance.API, zone scw.Zone, flagV string) (*instance.VolumeServerTemplate, error) {
 	parts := strings.Split(strings.TrimSpace(flagV), ":")
 

--- a/internal/namespaces/instance/v1/custom_user_data_test.go
+++ b/internal/namespaces/instance/v1/custom_user_data_test.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -60,7 +59,7 @@ func Test_UserDataFileUpload(t *testing.T) {
 		BeforeFunc: core.BeforeFuncCombine(
 			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic"),
 			func(ctx *core.BeforeFuncCtx) error {
-				file, _ := ioutil.TempFile("", "test")
+				file, _ := os.CreateTemp("", "test")
 				_, _ = file.WriteString(content)
 				ctx.Meta["filePath"] = file.Name()
 				return nil
@@ -83,7 +82,7 @@ func Test_UserDataFileUpload(t *testing.T) {
 		BeforeFunc: core.BeforeFuncCombine(
 			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic"),
 			func(ctx *core.BeforeFuncCtx) error {
-				file, _ := ioutil.TempFile("", "test")
+				file, _ := os.CreateTemp("", "test")
 				_, _ = file.WriteString(content)
 				ctx.Meta["filePath"] = file.Name()
 				return nil

--- a/internal/namespaces/instance/v1/helpers_test.go
+++ b/internal/namespaces/instance/v1/helpers_test.go
@@ -14,7 +14,8 @@ import (
 
 // createServer creates a stopped ubuntu-bionic server and
 // register it in the context Meta at metaKey.
-// nolint:unparam
+//
+//nolint:unparam
 func createServer(metaKey string) core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create stopped=true image=ubuntu-bionic")
 }
@@ -27,7 +28,8 @@ func startServer(metaKey string) core.BeforeFunc {
 
 // deleteServer deletes a server and its attached IP and volumes
 // previously registered in the context Meta at metaKey.
-// nolint:unparam
+//
+//nolint:unparam
 func deleteServer(metaKey string) core.AfterFunc {
 	return func(ctx *core.AfterFuncCtx) error {
 		server := ctx.Meta[metaKey].(*instance.Server)
@@ -47,7 +49,8 @@ func deleteServer(metaKey string) core.AfterFunc {
 
 // createVolume creates a volume of the given size and type and
 // register it in the context Meta at metaKey.
-// nolint:unparam
+//
+//nolint:unparam
 func createVolume(metaKey string, sizeInGb int, volumeType instance.VolumeVolumeType) core.BeforeFunc {
 	return func(ctx *core.BeforeFuncCtx) error {
 		cmd := fmt.Sprintf("scw instance volume create name=cli-test size=%dGB volume-type=%s", sizeInGb, volumeType)

--- a/internal/namespaces/instance/v1/instance_cli_test.go
+++ b/internal/namespaces/instance/v1/instance_cli_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//
 // Server
-//
+
 func Test_ListServer(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: GetCommands(),
@@ -36,9 +35,7 @@ func Test_GetServer(t *testing.T) {
 	}))
 }
 
-//
 // Volume
-//
 func Test_CreateVolume(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: GetCommands(),
@@ -202,9 +199,7 @@ func Test_ServerUpdate(t *testing.T) {
 	}))
 }
 
-//
 // Snapshot
-//
 func Test_SnapshotCreate(t *testing.T) {
 	t.Run("simple", core.Test(&core.TestConfig{
 		Commands:   GetCommands(),

--- a/internal/namespaces/instance/v1/instance_cli_test.go
+++ b/internal/namespaces/instance/v1/instance_cli_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 // Server
-
 func Test_ListServer(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: GetCommands(),

--- a/internal/namespaces/k8s/v1/custom_kubeconfig_helpers.go
+++ b/internal/namespaces/k8s/v1/custom_kubeconfig_helpers.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -38,7 +37,7 @@ func getKubeconfigPath(ctx context.Context) (string, error) {
 
 func openAndUnmarshalKubeconfig(kubeconfigPath string) (*api.Config, error) {
 	// getting the existing file
-	file, err := ioutil.ReadFile(kubeconfigPath)
+	file, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -59,5 +58,5 @@ func marshalAndWriteKubeconfig(kubeconfig *api.Config, kubeconfigPath string) er
 		return err
 	}
 
-	return ioutil.WriteFile(kubeconfigPath, newKubeconfig, 0600)
+	return os.WriteFile(kubeconfigPath, newKubeconfig, 0600)
 }

--- a/internal/namespaces/k8s/v1/custom_kubeconfig_install_test.go
+++ b/internal/namespaces/k8s/v1/custom_kubeconfig_install_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -92,7 +91,7 @@ y7JHcXauRKI7bxgOugSep2d0lhYxJl65CPOCllawcu70Ds34MKi3XkCe20I=
 // testIfKubeconfigInFile checks if the given kubeconfig is in the given file
 // it test if the user, cluster and context of the kubeconfig file are in the given file
 func testIfKubeconfigInFile(t *testing.T, filePath string, suffix string, kubeconfig api.Config) {
-	kubeconfigBytes, err := ioutil.ReadFile(filePath)
+	kubeconfigBytes, err := os.ReadFile(filePath)
 	assert.Nil(t, err)
 	var existingKubeconfig api.Config
 	err = yaml.Unmarshal(kubeconfigBytes, &existingKubeconfig)

--- a/internal/namespaces/k8s/v1/custom_kubeconfig_uninstall_test.go
+++ b/internal/namespaces/k8s/v1/custom_kubeconfig_uninstall_test.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -16,7 +15,7 @@ import (
 // testIfKubeconfigNotInFile checks if the given kubeconfig is not in the given file
 // it test if the user, cluster and context of the kubeconfig file are not in the given file
 func testIfKubeconfigNotInFile(t *testing.T, filePath string, suffix string, kubeconfig api.Config) {
-	kubeconfigBytes, err := ioutil.ReadFile(filePath)
+	kubeconfigBytes, err := os.ReadFile(filePath)
 	assert.Nil(t, err)
 	var existingKubeconfig k8s.Kubeconfig
 	err = yaml.Unmarshal(kubeconfigBytes, &existingKubeconfig)

--- a/internal/namespaces/k8s/v1/helpers_test.go
+++ b/internal/namespaces/k8s/v1/helpers_test.go
@@ -2,7 +2,7 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -112,7 +112,7 @@ func createClusterAndWaitAndKubeconfigAndPopulateFile(metaKey string, kubeconfig
 		}
 
 		ctx.Meta[kubeconfigMetaKey] = kubeconfig
-		err = ioutil.WriteFile(file, content, 0644)
+		err = os.WriteFile(file, content, 0644)
 		return err
 	}
 }
@@ -142,7 +142,7 @@ func createClusterAndWaitAndKubeconfigAndPopulateFileAndInstall(metaKey string, 
 		}
 
 		ctx.Meta[kubeconfigMetaKey] = kubeconfig
-		err = ioutil.WriteFile(file, content, 0644)
+		err = os.WriteFile(file, content, 0644)
 		if err != nil {
 			return err
 		}

--- a/internal/namespaces/object/v1/custom_config_install.go
+++ b/internal/namespaces/object/v1/custom_config_install.go
@@ -3,7 +3,6 @@ package object
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -100,7 +99,7 @@ func configInstallCommand() *core.Command {
 			}
 
 			// Write the configuration file
-			err = ioutil.WriteFile(configPath, []byte(newConfig), 0600)
+			err = os.WriteFile(configPath, []byte(newConfig), 0600)
 			if err != nil {
 				return "", err
 			}

--- a/internal/namespaces/registry/v1/custom_docker_helper_test.go
+++ b/internal/namespaces/registry/v1/custom_docker_helper_test.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -24,7 +23,7 @@ func TestRegistryInstallDockerHelperCommand(t *testing.T) {
 		Cmd:        "scw registry install-docker-helper path={{ .HOME }}",
 		Check: func(t *testing.T, ctx *core.CheckFuncCtx) {
 			scriptPath := path.Join(ctx.Meta["HOME"].(string), "docker-credential-scw")
-			scriptContent, err := ioutil.ReadFile(scriptPath)
+			scriptContent, err := os.ReadFile(scriptPath)
 			require.NoError(t, err)
 			assert.Equal(t, "#!/bin/sh\nscw registry docker-helper \"$@\"\n", string(scriptContent))
 			stats, err := os.Stat(scriptPath)
@@ -32,7 +31,7 @@ func TestRegistryInstallDockerHelperCommand(t *testing.T) {
 			assert.Equal(t, os.FileMode(0755), stats.Mode())
 
 			dockerConfigPath := path.Join(ctx.Meta["HOME"].(string), ".docker", "config.json")
-			dockerConfigContent, err := ioutil.ReadFile(dockerConfigPath)
+			dockerConfigContent, err := os.ReadFile(dockerConfigPath)
 			require.NoError(t, err)
 			assert.Equal(t, "{\n  \"credHelpers\": {\n    \"rg.fr-par.scw.cloud\": \"scw\",\n    \"rg.nl-ams.scw.cloud\": \"scw\",\n    \"rg.pl-waw.scw.cloud\": \"scw\"\n  }\n}\n", string(dockerConfigContent))
 		},
@@ -50,7 +49,7 @@ func TestRegistryInstallDockerHelperCommand(t *testing.T) {
 		Cmd:        "scw -p profile01 registry install-docker-helper path={{ .HOME }}",
 		Check: func(t *testing.T, ctx *core.CheckFuncCtx) {
 			scriptPath := path.Join(ctx.Meta["HOME"].(string), "docker-credential-scw")
-			scriptContent, err := ioutil.ReadFile(scriptPath)
+			scriptContent, err := os.ReadFile(scriptPath)
 			require.NoError(t, err)
 			assert.Equal(t, "#!/bin/sh\nPROFILE_NAME=\"profile01\"\nif [[ ! -z \"$SCW_PROFILE\" ]]\nthen \n\tPROFILE_NAME=\"$SCW_PROFILE\"\nfi\nscw --profile $PROFILE_NAME registry docker-helper \"$@\"\n", string(scriptContent))
 		},

--- a/internal/namespaces/registry/v1/custom_login.go
+++ b/internal/namespaces/registry/v1/custom_login.go
@@ -50,7 +50,7 @@ func registryLoginRun(ctx context.Context, argsI interface{}) (i interface{}, e 
 	}
 
 	cmdArgs := []string{"login", "-u", "scaleway", "--password-stdin", endpoint}
-	cmd := exec.Command(args.Program, cmdArgs...) // nolint:gosec
+	cmd := exec.Command(args.Program, cmdArgs...) //nolint:gosec
 	cmd.Stdin = bytes.NewBufferString(secretKey)
 	exitCode, err := core.ExecCmd(ctx, cmd)
 

--- a/internal/namespaces/registry/v1/custom_login_test.go
+++ b/internal/namespaces/registry/v1/custom_login_test.go
@@ -1,7 +1,7 @@
 package registry
 
 import (
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -21,7 +21,7 @@ func Test_Login(t *testing.T) {
 		),
 		OverrideExec: func(ctx *core.ExecFuncCtx, cmd *exec.Cmd) (exitCode int, err error) {
 			assert.Equal(t, "docker login -u scaleway --password-stdin rg.fr-par.scw.cloud", strings.Join(cmd.Args, " "))
-			stdin, err := ioutil.ReadAll(cmd.Stdin)
+			stdin, err := io.ReadAll(cmd.Stdin)
 			secret, _ := ctx.Client.GetSecretKey()
 			require.NoError(t, err)
 			assert.Equal(t, secret, string(stdin))
@@ -37,7 +37,7 @@ func Test_Login(t *testing.T) {
 		),
 		OverrideExec: func(ctx *core.ExecFuncCtx, cmd *exec.Cmd) (exitCode int, err error) {
 			assert.Equal(t, "podman login -u scaleway --password-stdin rg.fr-par.scw.cloud", strings.Join(cmd.Args, " "))
-			stdin, err := ioutil.ReadAll(cmd.Stdin)
+			stdin, err := io.ReadAll(cmd.Stdin)
 			secret, _ := ctx.Client.GetSecretKey()
 			require.NoError(t, err)
 			assert.Equal(t, secret, string(stdin))

--- a/internal/namespaces/registry/v1/custom_logout.go
+++ b/internal/namespaces/registry/v1/custom_logout.go
@@ -42,7 +42,7 @@ func registryLogoutRun(ctx context.Context, argsI interface{}) (i interface{}, e
 	endpoint := endpointPrefix + region + endpointSuffix
 
 	cmdArgs := []string{"logout", endpoint}
-	cmd := exec.Command(args.Program, cmdArgs...) // nolint:gosec
+	cmd := exec.Command(args.Program, cmdArgs...) //nolint:gosec
 	exitCode, err := core.ExecCmd(ctx, cmd)
 
 	if err != nil {

--- a/internal/namespaces/registry/v1/helpers_docker.go
+++ b/internal/namespaces/registry/v1/helpers_docker.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -65,7 +65,7 @@ func setupDockerConfigFile(ctx context.Context, registries []string, binaryName 
 
 	dockerConfig := map[string]interface{}{}
 
-	dockerConfigRaw, err := ioutil.ReadAll(f)
+	dockerConfigRaw, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/internal/tabwriter/tabwriter.go
+++ b/internal/tabwriter/tabwriter.go
@@ -23,7 +23,7 @@ import (
 // The text itself is stored in a separate buffer; cell only describes the
 // segment's size in bytes, its width in runes, and whether it's an htab
 // ('\t') terminated cell.
-//
+
 type cell struct {
 	size  int  // cell size in bytes
 	width int  // cell width in runes
@@ -87,7 +87,6 @@ type cell struct {
 // The Writer must buffer input internally, because proper spacing
 // of one line may depend on the cells in future lines. Clients must
 // call Flush when done calling Write.
-//
 type Writer struct {
 	// configuration
 	output   io.Writer
@@ -220,7 +219,6 @@ const (
 //			(for correct-looking results, tabwidth must correspond
 //			to the tab width in the viewer displaying the result)
 //	flags		formatting control
-//
 func (b *Writer) Init(output io.Writer, minwidth, tabwidth, padding int, padchar byte, flags uint) *Writer {
 	if minwidth < 0 || tabwidth < 0 || padding < 0 {
 		panic("negative minwidth, tabwidth, or padding")
@@ -363,7 +361,6 @@ func (b *Writer) writeLines(pos0 int, line0, line1 int) (pos int) {
 // is the buffer position corresponding to the beginning of line0.
 // Returns the buffer position corresponding to the beginning of
 // line1 and an error, if any.
-//
 func (b *Writer) format(pos0 int, line0, line1 int) (pos int) {
 	pos = pos0
 	column := len(b.widths)
@@ -440,7 +437,6 @@ func (b *Writer) updateWidth() {
 // width one for formatting purposes.
 //
 // The value 0xff was chosen because it cannot appear in a valid UTF-8 sequence.
-//
 const Escape = '\xff'
 
 // Start escaped mode.
@@ -461,7 +457,6 @@ func (b *Writer) startEscape(ch byte) {
 // is assumed to be zero for formatting purposes; if it was an HTML entity,
 // its width is assumed to be one. In all other cases, the width is the
 // unicode width of the text.
-//
 func (b *Writer) endEscape() {
 	switch b.endChar {
 	case Escape:
@@ -483,7 +478,6 @@ func (b *Writer) endEscape() {
 
 // Terminate the current cell by adding it to the list of cells of the
 // current line. Returns the number of cells in that line.
-//
 func (b *Writer) terminateCell(htab bool) int {
 	b.cell.htab = htab
 	line := &b.lines[len(b.lines)-1]
@@ -545,7 +539,6 @@ var hbar = []byte("---\n")
 // Write writes buf to the writer b.
 // The only errors returned are ones encountered
 // while writing to the underlying output stream.
-//
 func (b *Writer) Write(buf []byte) (n int, err error) {
 	defer b.handlePanic(&err, "Write")
 
@@ -633,7 +626,6 @@ func (b *Writer) Write(buf []byte) (n int, err error) {
 
 // NewWriter allocates and initializes a new tabwriter.Writer.
 // The parameters are the same as for the Init function.
-//
 func NewWriter(output io.Writer, minwidth, tabwidth, padding int, padchar byte, flags uint) *Writer {
 	return new(Writer).Init(output, minwidth, tabwidth, padding, padchar, flags)
 }

--- a/internal/tabwriter/tabwriter_test.go
+++ b/internal/tabwriter/tabwriter_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -695,7 +694,7 @@ func BenchmarkTable(b *testing.B) {
 				b.Run("new", func(b *testing.B) {
 					b.ReportAllocs()
 					for i := 0; i < b.N; i++ {
-						w := NewWriter(ioutil.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
+						w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 						// Write the line h times.
 						for j := 0; j < h; j++ {
 							w.Write(line)
@@ -706,7 +705,7 @@ func BenchmarkTable(b *testing.B) {
 
 				b.Run("reuse", func(b *testing.B) {
 					b.ReportAllocs()
-					w := NewWriter(ioutil.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
+					w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 					for i := 0; i < b.N; i++ {
 						// Write the line h times.
 						for j := 0; j < h; j++ {
@@ -727,7 +726,7 @@ func BenchmarkPyramid(b *testing.B) {
 		b.Run(fmt.Sprintf("%d", x), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				w := NewWriter(ioutil.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
+				w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 				// Write increasing prefixes of that line.
 				for j := 0; j < x; j++ {
 					w.Write(line[:j*2])
@@ -749,7 +748,7 @@ func BenchmarkRagged(b *testing.B) {
 		b.Run(fmt.Sprintf("%d", h), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				w := NewWriter(ioutil.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
+				w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 				// Write the lines in turn h times.
 				for j := 0; j < h; j++ {
 					w.Write(lines[j%len(lines)])
@@ -777,7 +776,7 @@ lines
 func BenchmarkCode(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		w := NewWriter(ioutil.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
+		w := NewWriter(io.Discard, 4, 4, 1, ' ', 0) // no particular reason for these settings
 		// The code is small, so it's reasonable for the tabwriter user
 		// to write it all at once, or buffer the writes.
 		w.Write([]byte(codeSnippet))


### PR DESCRIPTION
Error: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
