### PR TITLE
fix(init): remove access key prompt

### DIFF
--- a/internal/namespaces/init/init.go
+++ b/internal/namespaces/init/init.go
@@ -149,14 +149,6 @@ Default path for configuration file is based on the following priority order:
 			// Manually prompt for missing args:
 
 			// Credentials
-			if args.AccessKey == "" {
-				_, _ = interactive.Println()
-				args.AccessKey, err = promptAccessKey(ctx)
-				if err != nil {
-					return err
-				}
-			}
-
 			if args.SecretKey == "" {
 				_, _ = interactive.Println()
 				args.SecretKey, err = promptSecret(ctx)
@@ -383,36 +375,6 @@ func promptSecret(ctx context.Context) (string, error) {
 
 	default:
 		return "", fmt.Errorf("invalid secret-key: '%v'", secret)
-	}
-}
-
-func promptAccessKey(ctx context.Context) (string, error) {
-	accessKey, err := interactive.Readline(&interactive.ReadlineConfig{
-		Ctx: ctx,
-		PromptFunc: func(value string) string {
-			accessKey := "access-key"
-			switch {
-			case validation.IsUUID(value):
-				accessKey = terminal.Style(accessKey, color.FgBlue)
-			}
-			return terminal.Style(fmt.Sprintf("Enter a valid %s: ", accessKey), color.Bold)
-		},
-		ValidateFunc: func(s string) error {
-			if validation.IsAccessKey(s) {
-				return nil
-			}
-			return fmt.Errorf("invalid access-key")
-		},
-	})
-	if err != nil {
-		return "", err
-	}
-
-	switch {
-	case validation.IsAccessKey(accessKey):
-		return accessKey, nil
-	default:
-		return "", fmt.Errorf("invalid access-key: '%v'", accessKey)
 	}
 }
 


### PR DESCRIPTION
Access key is fetched from api, starting a prompt to get it from user before is not useful.
```go
			// Get access key
			apiKey, err := account.GetAPIKey(ctx, args.SecretKey)
			if err != nil {
				return "", &core.CliError{
					Err:     err,
					Details: "Failed to retrieve Access Key from the given Secret Key.",
				}
			}

			profile := &scw.Profile{
				AccessKey:             &apiKey.AccessKey,
				SecretKey:             &args.SecretKey,
				DefaultZone:           scw.StringPtr(args.Zone.String()),
				DefaultRegion:         scw.StringPtr(args.Region.String()),
				DefaultOrganizationID: &apiKey.OrganizationID,
				DefaultProjectID:      &apiKey.ProjectID, // An API key is always bound to a project.
			}
```
https://github.com/scaleway/scaleway-cli/blob/master/internal/namespaces/init/init.go#L278-L293