### PR TITLE
log: more accurate status Instance API

### DIFF
--- a/internal/namespaces/instance/v1/custom_server.go
+++ b/internal/namespaces/instance/v1/custom_server.go
@@ -875,7 +875,7 @@ func getRunServerAction(action instance.ServerAction) core.CommandRunner {
 			ServerID: args.ServerID,
 			Action:   action,
 		})
-		return &core.SuccessResult{Message: fmt.Sprintf("%s successful for the server", action)}, err
+		return &core.SuccessResult{Message: fmt.Sprintf("%s successfully started for the server", action)}, err
 	}
 }
 


### PR DESCRIPTION
Currently the CLI says 'Poweroff successful for the server' where really the instance is power*ing* off, the transient state is not explicit at all.
This gets really annoying when trying to delete an Instance and the CLI replies "Instance should be powered off".

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
