### PR TITLE
fix(core): do not require a config file if required env vars are set

### DIFF
--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -28,7 +28,7 @@ func createClient(ctx context.Context, httpClient *http.Client, buildInfo *Build
 	config, err := scw.LoadConfigFromPath(ExtractConfigPath(ctx))
 	switch {
 	case errIsConfigFileNotFound(err):
-		// no config file wass found -> nop
+		// no config file was found -> nop
 
 	case err != nil:
 		// failed to read the config file -> fail

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -207,6 +208,6 @@ func validateClient(client *scw.Client) error {
 }
 
 func errIsConfigFileNotFound(err error) bool {
-	_, ok := err.(*scw.ConfigFileNotFoundError)
-	return ok
+	var target *scw.ConfigFileNotFoundError
+	return errors.As(err, &target)
 }


### PR DESCRIPTION
## Issue

A regression was introduced in the 2.6.0 release where the CLI will exit with the following error:

```
scaleway-sdk-go: cannot read config file /root/.config/scw/config.yaml: no such file or directory
```

Even though all the required env vars `SCW_ACCESS_KEY`, `SCW_SECRET_KEY`, `SCW_ORGANIZATION_ID`, `SCW_DEFAULT_ORGANIZATION_ID`, `SCW_ZONE` are set.

The same invocation of the CLI used to work fine with the 2.5.x releases


## Proposed Fix

Change the client creation logic to no longer require a configuration file, but instead:

* first load config from env
* if a config file is found, then load it and merge it with the env config


<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix regression where a config file was required even if all required env vars are set
```
