### PR TITLE
feat(core): add support for composite tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/alecthomas/assert v1.0.0
+	github.com/briandowns/spinner v1.19.0
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/chzyer/readline v1.5.1
 	github.com/containerd/console v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrD
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
+github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/c-bata/go-prompt v0.2.5 h1:3zg6PecEywxNn0xiqcXHD96fkbxghD+gdB2tbsYfl+Y=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
@@ -26,6 +28,7 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/etdub/goparsetime v0.0.0-20160315173935-ea17b0ac3318 h1:iguwbR+9xsizl84VMHU47I4OOWYSex1HZRotEoqziWQ=
 github.com/etdub/goparsetime v0.0.0-20160315173935-ea17b0ac3318/go.mod h1:O/QFFckzvu1KpS1AOuQGgi6ErznEF8nZZVNDDMXlDP4=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
@@ -47,6 +50,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubernetes-client/go-base v0.0.0-20190205182333-3d0e39759d98 h1:ZMIkOkl/Bg5H4EJI7zbjVXAo4rV0QJOGz2U5A0xUmZU=
 github.com/kubernetes-client/go-base v0.0.0-20190205182333-3d0e39759d98/go.mod h1:HPlr4uJEfrxar3JUY9cmXs3oooPjTLO6nEaEAIt5LI8=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/internal/tasks/loader.go
+++ b/internal/tasks/loader.go
@@ -1,0 +1,26 @@
+package tasks
+
+import (
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+// Loader will print loading activity to the terminal
+type Loader struct {
+	spinner *spinner.Spinner
+}
+
+func setupLoader() *Loader {
+	return &Loader{
+		spinner.New(spinner.CharSets[11], 100*time.Millisecond),
+	}
+}
+
+func (l *Loader) Start() {
+	l.spinner.Start()
+}
+
+func (l *Loader) Stop() {
+	l.spinner.Stop()
+}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -8,11 +8,15 @@ import (
 	"github.com/briandowns/spinner"
 )
 
-type Task func(interface{}) (interface{}, error)
+type Task func(args interface{}) (nextArgs interface{}, err error)
+type TaskWithCleanup func(args interface{}) (nextArgs interface{}, cleanUpArgs interface{}, err error)
+type CleanUpTask func(cleanUpArgs interface{}) error
 
 type taskInfo struct {
-	Name     string
-	function Task
+	Name          string
+	function      TaskWithCleanup
+	cleanFunction CleanUpTask
+	cleanUpArgs   interface{}
 }
 
 type Tasks struct {
@@ -25,9 +29,39 @@ func Begin() *Tasks {
 
 func (ts *Tasks) Add(name string, task Task) {
 	ts.tasks = append(ts.tasks, taskInfo{
-		Name:     name,
-		function: task,
+		Name: name,
+		function: func(i interface{}) (passedData interface{}, cleanUpData interface{}, err error) {
+			passedData, err = task(i)
+			return
+		},
 	})
+}
+
+func (ts *Tasks) AddWithCleanUp(name string, task TaskWithCleanup, clean CleanUpTask) {
+	ts.tasks = append(ts.tasks, taskInfo{
+		Name:          name,
+		function:      task,
+		cleanFunction: clean,
+	})
+}
+
+// Cleanup execute all tasks cleanup function before failed one in reverse order
+func (ts *Tasks) Cleanup(failed int) {
+	totalTasks := len(ts.tasks)
+
+	i := failed - 1
+	for ; i >= 0; i -= 1 {
+		task := ts.tasks[i]
+
+		if task.cleanFunction != nil {
+			fmt.Printf("[%d/%d] Cleaning task %q\n", i+1, totalTasks, task.Name)
+
+			err := task.cleanFunction(task.cleanUpArgs)
+			if err != nil {
+				fmt.Printf("task %d failed to cleanup: %s", i+1, err.Error())
+			}
+		}
+	}
 }
 
 func (ts *Tasks) Execute(data interface{}) (interface{}, error) {
@@ -36,14 +70,19 @@ func (ts *Tasks) Execute(data interface{}) (interface{}, error) {
 	rand.Seed(time.Now().UnixNano())
 	spin := spinner.New(spinner.CharSets[rand.Int()%37], 100*time.Millisecond)
 
-	for i, task := range ts.tasks {
+	for i := range ts.tasks {
+		task := &ts.tasks[i]
 		fmt.Printf("[%d/%d] %s\n", i+1, totalTasks, task.Name)
 		spin.Start()
-		data, err = task.function(data)
+
+		data, task.cleanUpArgs, err = task.function(data)
 		if err != nil {
 			spin.Stop()
-			return nil, fmt.Errorf("task [%d/%d] failed: %w", i, totalTasks, err)
+			fmt.Println("task failed, cleaning up created resources")
+			ts.Cleanup(i)
+			return nil, fmt.Errorf("task %d %q failed: %w", i+1, task.Name, err)
 		}
+
 		spin.Stop()
 	}
 

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -75,13 +75,13 @@ func (ts *Tasks) Cleanup(ctx context.Context, failed int) {
 				fmt.Printf("task %d failed to cleanup: %s\n", i+1, err.Error())
 			}
 			loader.Stop()
-
-			select {
-			case <-cancelableCtx.Done():
-				fmt.Println("cleanup has been cancelled")
-				return
-			default:
-			}
+		}
+		
+		select {
+		case <-cancelableCtx.Done():
+			fmt.Println("cleanup has been cancelled")
+			return
+		default:
 		}
 	}
 }

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -1,0 +1,51 @@
+package tasks
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+type Task func(interface{}) (interface{}, error)
+
+type taskInfo struct {
+	Name     string
+	function Task
+}
+
+type Tasks struct {
+	tasks []taskInfo
+}
+
+func Begin() *Tasks {
+	return &Tasks{}
+}
+
+func (ts *Tasks) Add(name string, task Task) {
+	ts.tasks = append(ts.tasks, taskInfo{
+		Name:     name,
+		function: task,
+	})
+}
+
+func (ts *Tasks) Execute(data interface{}) (interface{}, error) {
+	var err error
+	totalTasks := len(ts.tasks)
+	rand.Seed(time.Now().UnixNano())
+	spin := spinner.New(spinner.CharSets[rand.Int()%37], 100*time.Millisecond)
+
+	for i, task := range ts.tasks {
+		fmt.Printf("[%d/%d] %s\n", i+1, totalTasks, task.Name)
+		spin.Start()
+		data, err = task.function(data)
+		if err != nil {
+			spin.Stop()
+			return nil, fmt.Errorf("task [%d/%d] failed: %w", i, totalTasks, err)
+		}
+		spin.Stop()
+	}
+
+	return data, nil
+}

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -40,6 +41,9 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestCleanupOnContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Cannot send signal on windows")
+	}
 	ts := tasks.Begin()
 
 	clean := 0

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -14,22 +14,22 @@ func TestCleanup(t *testing.T) {
 
 	clean := 0
 
-	tasks.AddWithCleanUp(ts, "Task 1", func(_ interface{}) (interface{}, string, error) {
+	tasks.AddWithCleanUp(ts, "Task 1", func(context.Context, interface{}) (interface{}, string, error) {
 		return nil, "", nil
-	}, func(string) error {
-		clean += 1
+	}, func(context.Context, string) error {
+		clean++
 		return nil
 	})
-	tasks.AddWithCleanUp(ts, "Task 2", func(_ interface{}) (interface{}, string, error) {
+	tasks.AddWithCleanUp(ts, "Task 2", func(context.Context, interface{}) (interface{}, string, error) {
 		return nil, "", nil
-	}, func(string) error {
-		clean += 1
+	}, func(context.Context, string) error {
+		clean++
 		return nil
 	})
-	tasks.AddWithCleanUp(ts, "Task 3", func(_ interface{}) (interface{}, string, error) {
+	tasks.AddWithCleanUp(ts, "Task 3", func(context.Context, interface{}) (interface{}, string, error) {
 		return nil, "", fmt.Errorf("fail")
-	}, func(string) error {
-		clean += 1
+	}, func(context.Context, string) error {
+		clean++
 		return nil
 	})
 	_, err := ts.Execute(context.Background(), nil)
@@ -43,25 +43,32 @@ func TestCleanupOnContext(t *testing.T) {
 	clean := 0
 	ctx, cancel := context.WithCancel(context.Background())
 
-	tasks.AddWithCleanUp(ts, "Task 1", func(_ interface{}) (interface{}, string, error) {
-		return nil, "", nil
-	}, func(string) error {
-		clean += 1
-		return nil
-	})
-	tasks.AddWithCleanUp(ts, "Task 2", func(_ interface{}) (interface{}, string, error) {
-		return nil, "", nil
-	}, func(string) error {
-		clean += 1
-		return nil
-	})
-	tasks.AddWithCleanUp(ts, "Task 3", func(_ interface{}) (interface{}, string, error) {
-		cancel()
-		return nil, "", nil
-	}, func(string) error {
-		clean += 1
-		return nil
-	})
+	tasks.AddWithCleanUp(ts, "Task 1",
+		func(context.Context, interface{}) (interface{}, string, error) {
+			return nil, "", nil
+		}, func(context.Context, string) error {
+			clean++
+			return nil
+		},
+	)
+	tasks.AddWithCleanUp(ts, "Task 2",
+		func(context.Context, interface{}) (interface{}, string, error) {
+			return nil, "", nil
+		}, func(context.Context, string) error {
+			clean++
+			return nil
+		},
+	)
+	tasks.AddWithCleanUp(ts, "Task 3",
+		func(context.Context, interface{}) (interface{}, string, error) {
+			cancel()
+			return nil, "", nil
+		}, func(context.Context, string) error {
+			clean++
+			return nil
+		},
+	)
+
 	_, err := ts.Execute(ctx, nil)
 	assert.NotNil(t, err)
 	assert.Equal(t, clean, 3, "3 task cleanup should have been executed")

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -1,0 +1,68 @@
+package tasks_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/scaleway/scaleway-cli/v2/internal/tasks"
+)
+
+func TestCleanup(t *testing.T) {
+	ts := tasks.Begin()
+
+	clean := 0
+
+	tasks.AddWithCleanUp(ts, "Task 1", func(_ interface{}) (interface{}, string, error) {
+		return nil, "", nil
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	tasks.AddWithCleanUp(ts, "Task 2", func(_ interface{}) (interface{}, string, error) {
+		return nil, "", nil
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	tasks.AddWithCleanUp(ts, "Task 3", func(_ interface{}) (interface{}, string, error) {
+		return nil, "", fmt.Errorf("fail")
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	_, err := ts.Execute(context.Background(), nil)
+	assert.NotNil(t, err, "Execute should return error after cleanup")
+	assert.Equal(t, clean, 2, "2 task cleanup should have been executed")
+}
+
+func TestCleanupOnContext(t *testing.T) {
+	ts := tasks.Begin()
+
+	clean := 0
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tasks.AddWithCleanUp(ts, "Task 1", func(_ interface{}) (interface{}, string, error) {
+		return nil, "", nil
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	tasks.AddWithCleanUp(ts, "Task 2", func(_ interface{}) (interface{}, string, error) {
+		return nil, "", nil
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	tasks.AddWithCleanUp(ts, "Task 3", func(_ interface{}) (interface{}, string, error) {
+		cancel()
+		return nil, "", nil
+	}, func(string) error {
+		clean += 1
+		return nil
+	})
+	_, err := ts.Execute(ctx, nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, clean, 3, "3 task cleanup should have been executed")
+}


### PR DESCRIPTION
This is an helper library that allows to split a command in tasks and print the execution to the user, this also provides a way to cleanup after a failed task

Usage:
```go
ts := tasks.Begin()
ts.AddWithCleanUp("Creating container namespace", func(i interface{}) (interface{}, interface{}, error) {
	time.Sleep(time.Second)
	return i, "data", nil
}, func(i interface{}) error {
	// i == "data"
	fmt.Println("clean " + i.(string)
	return nil
})
ts.Add("Creating container", func(i interface{}) (interface{}, error) {
	time.Sleep(time.Second * 2)
	return i, fmt.Errorf("error")
})
ts.Add("Pushing image", func(i interface{}) (interface{}, error) {
	time.Sleep(time.Second * 3)
	return i, nil
})
ts.Add("Deploying", func(i interface{}) (interface{}, error) {
	time.Sleep(time.Second * 3)
	return i, nil
})
```

Result:
```
[1/4] Creating container namespace
[2/4] Creating container
<cool interactive loading spinner>
```
then
```
[1/4] Creating container namespace
[2/4] Creating container
task failed, cleaning up created resources
[1/4] Cleaning task "Creating container namespace"
clean data
Task 2 "Creating container" failed: error
```
