### PR TITLE
fix(core): remove default help command

### DIFF
--- a/cmd/scw/testdata/test-main-usage-usage.golden
+++ b/cmd/scw/testdata/test-main-usage-usage.golden
@@ -33,7 +33,6 @@ AVAILABLE COMMANDS:
   version       Display cli version
   vpc           VPC API
   vpc-gw        VPC Public Gateway API
-  help          Help about any command
 
 FLAGS:
   -c, --config string    The path to the config file

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scaleway/scaleway-cli/v2/internal/interactive"
 	"github.com/scaleway/scaleway-sdk-go/logger"
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -207,6 +208,7 @@ func Bootstrap(config *BootstrapConfig) (exitCode int, result interface{}, err e
 	rootCmd.PersistentFlags().StringVarP(&outputFlag, "output", "o", "human", "Output format: json or human, see 'scw help output' for more info")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "Enable debug mode")
 	rootCmd.SetArgs(config.Args[1:])
+	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	err = rootCmd.Execute()
 
 	if err != nil {


### PR DESCRIPTION
default help command was generated and documented but it was shadowed by the help namespace