### PR TITLE
feat(core/autocomplete): complete content of args using list verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ scw instance server list
 scw k8s cluster create name=foo version=1.17.4 pools.0.size=3 pools.0.node-type=DEV1-M pools.0.name=default tags.0=tag1 tags.1=tag2
 ```
 
+## Environment
+
+You can configure your config or enable functionalities with environment variables.
+
+Variables to override config are describe in [config documentation](docs/commands/config.md).
+To enable beta features, you can set `SCW_ENABLE_BETA=1` in your environment.
+
 # Reference documentation
 
 | Namespace      | Description                             | Documentation                                                                                           |

--- a/cmd/scw/main.go
+++ b/cmd/scw/main.go
@@ -74,6 +74,7 @@ func main() {
 		Stdout:    colorable.NewColorableStdout(),
 		Stderr:    colorable.NewColorableStderr(),
 		Stdin:     os.Stdin,
+		BetaMode:  BetaMode,
 	})
 
 	os.Exit(exitCode)

--- a/internal/core/autocomplete.go
+++ b/internal/core/autocomplete.go
@@ -401,6 +401,10 @@ func AutoCompleteArgValue(ctx context.Context, cmd *Command, argSpec *ArgSpec, a
 		possibleValues = argSpec.EnumValues
 	}
 
+	if len(possibleValues) == 0 && ExtractBetaMode(ctx) {
+		possibleValues = AutocompleteGetArg(ctx, cmd, argSpec)
+	}
+
 	suggestions := []string(nil)
 	for _, value := range possibleValues {
 		if strings.HasPrefix(value, argValuePrefix) {

--- a/internal/core/autocomplete.go
+++ b/internal/core/autocomplete.go
@@ -291,7 +291,7 @@ func AutoComplete(ctx context.Context, leftWords []string, wordToComplete string
 	}
 
 	// keep track of the completed args
-	completedArgs := make(map[string]struct{})
+	completedArgs := make(map[string]string)
 
 	// keep track of the completed flags
 	completedFlags := make(map[string]struct{})
@@ -307,12 +307,12 @@ func AutoComplete(ctx context.Context, leftWords []string, wordToComplete string
 
 		// handle arg=value
 		case isArg(word):
-			completedArgs[wordKey(word)+"="] = struct{}{}
+			completedArgs[wordKey(word)+"="] = wordValue(word)
 
 		// handle boolean arg
 		default:
 			if _, exist := node.Children[positionalValueNodeID]; exist && i > nodeIndexInWords {
-				completedArgs[word] = struct{}{}
+				completedArgs[word] = ""
 			}
 		}
 	}
@@ -324,7 +324,7 @@ func AutoComplete(ctx context.Context, leftWords []string, wordToComplete string
 			// We try to complete the value of an unknown arg
 			return &AutocompleteResponse{}
 		}
-		suggestions := AutoCompleteArgValue(ctx, argNode.Command, argNode.ArgSpec, argValuePrefix)
+		suggestions := AutoCompleteArgValue(ctx, argNode.Command, argNode.ArgSpec, argValuePrefix, completedArgs)
 
 		// We need to prefix suggestions with the argName to enable the arg value auto-completion.
 		for k, s := range suggestions {
@@ -338,7 +338,7 @@ func AutoComplete(ctx context.Context, leftWords []string, wordToComplete string
 	suggestions := []string(nil)
 	for key, child := range node.Children {
 		if key == positionalValueNodeID {
-			for _, positionalSuggestion := range AutoCompleteArgValue(ctx, child.Command, child.ArgSpec, wordToComplete) {
+			for _, positionalSuggestion := range AutoCompleteArgValue(ctx, child.Command, child.ArgSpec, wordToComplete, completedArgs) {
 				if _, exists := completedArgs[positionalSuggestion]; !exists {
 					suggestions = append(suggestions, positionalSuggestion)
 				}
@@ -380,7 +380,7 @@ func AutoComplete(ctx context.Context, leftWords []string, wordToComplete string
 // AutoCompleteArgValue returns suggestions for a (argument name, argument value prefix) pair.
 // Priority is given to the AutoCompleteFunc from the ArgSpec, if it is set.
 // Otherwise, we use EnumValues from the ArgSpec.
-func AutoCompleteArgValue(ctx context.Context, cmd *Command, argSpec *ArgSpec, argValuePrefix string) []string {
+func AutoCompleteArgValue(ctx context.Context, cmd *Command, argSpec *ArgSpec, argValuePrefix string, completedArgs map[string]string) []string {
 	if argSpec == nil {
 		return nil
 	}
@@ -401,8 +401,10 @@ func AutoCompleteArgValue(ctx context.Context, cmd *Command, argSpec *ArgSpec, a
 		possibleValues = argSpec.EnumValues
 	}
 
+	// Complete arg value using list verb if possible
+	// "instance server get <tab>" completes "server-id" arg with "id" in instance server list
 	if len(possibleValues) == 0 && ExtractBetaMode(ctx) {
-		possibleValues = AutocompleteGetArg(ctx, cmd, argSpec)
+		possibleValues = AutocompleteGetArg(ctx, cmd, argSpec, completedArgs)
 	}
 
 	suggestions := []string(nil)
@@ -426,6 +428,14 @@ func splitArgWord(wordToComplete string) (string, string) {
 
 func wordKey(word string) string {
 	return strings.SplitN(word, "=", 2)[0]
+}
+
+func wordValue(word string) string {
+	words := strings.SplitN(word, "=", 2)
+	if len(words) >= 2 {
+		return words[1]
+	}
+	return ""
 }
 
 func isArg(wordToComplete string) bool {
@@ -464,7 +474,7 @@ func hasPrefix(key, wordToComplete string) bool {
 
 // keySuggestion will suggest the next key available for the map (or array) argument.
 // Keys are suggested in ascending order arg.0, arg.1, arg.2...
-func keySuggestion(key string, completedArg map[string]struct{}, wordToComplete string) []string {
+func keySuggestion(key string, completedArg map[string]string, wordToComplete string) []string {
 	splitKey := strings.Split(key, ".")
 	splitWordToComplete := strings.Split(wordToComplete, ".")
 

--- a/internal/core/autocomplete_utils.go
+++ b/internal/core/autocomplete_utils.go
@@ -2,9 +2,11 @@ package core
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"github.com/scaleway/scaleway-sdk-go/strcase"
 )
 
 func AutocompleteProfileName() AutoCompleteArgFunc {
@@ -27,4 +29,64 @@ func AutocompleteProfileName() AutoCompleteArgFunc {
 		}
 		return res
 	}
+}
+
+// AutocompleteGetArg tries to complete an argument by using the list verb if it exists for the same resource
+// It will search for the same field in the response of the list
+// Field name will be stripped of the resource name (ex: cluster-id -> id)
+func AutocompleteGetArg(ctx context.Context, cmd *Command, argSpec *ArgSpec) []string {
+	commands := ExtractCommands(ctx)
+
+	// The argument we want to find (ex: server-id)
+	argName := argSpec.Name
+	argResource := cmd.Resource
+
+	// if arg name does not start with resource
+	// ex with "scw instance private-nic list server-id=<tab>"
+	// we get server as resource instead of private-nic to find command "scw instance server list"
+	if !strings.HasPrefix(argName, cmd.Resource) {
+		dashIndex := strings.Index(argName, "-")
+		if dashIndex > 0 {
+			argResource = argName[:dashIndex]
+		}
+	}
+
+	// remove resource from arg name (ex: server-id -> id)
+	argName = strings.TrimPrefix(argName, argResource)
+	argName = strings.TrimLeft(argName, "-")
+
+	listCmd, hasList := commands.find(cmd.Namespace, argResource, "list")
+	if !hasList {
+		return nil
+	}
+
+	// Build empty arguments and run command
+	// Has to use interceptor if it exists as ArgsType could be handled by interceptor
+	listCmdArgs := reflect.New(listCmd.ArgsType).Interface()
+	if listCmd.Interceptor == nil {
+		listCmd.Interceptor = func(ctx context.Context, argsI interface{}, runner CommandRunner) (interface{}, error) {
+			return runner(ctx, argsI)
+		}
+	}
+	resp, err := listCmd.Interceptor(ctx, listCmdArgs, listCmd.Run)
+	if err != nil {
+		return nil
+	}
+
+	// As we run the "list" verb instead of using the sdk ListResource, response is already the slice
+	// ex: ListServersResponse -> ListServersResponse.Servers
+	resources := reflect.ValueOf(resp)
+	if resources.Kind() != reflect.Slice {
+		return nil
+	}
+	values := []string(nil)
+	// Let's iterate over the struct in the response slice and get the searched field
+	for i := 0; i < resources.Len(); i++ {
+		resource := resources.Index(i).Elem()
+		resourceField := resource.FieldByName(strcase.ToPublicGoName(argName))
+		if resourceField.Kind() == reflect.String {
+			values = append(values, resourceField.String())
+		}
+	}
+	return values
 }

--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -61,6 +61,9 @@ type BootstrapConfig struct {
 	// Default HTTPClient to use. If not provided it will use a basic http client with a simple retry policy
 	// This client will be used to create SDK client, account call, version checking and telemetry
 	HTTPClient *http.Client
+
+	// Enable beta functionalities
+	BetaMode bool
 }
 
 // Bootstrap is the main entry point. It is directly called from main.
@@ -163,6 +166,7 @@ func Bootstrap(config *BootstrapConfig) (exitCode int, result interface{}, err e
 		command:                     nil, // command is later injected by cobra_utils.go/cobraRun()
 		httpClient:                  httpClient,
 		isClientFromBootstrapConfig: isClientFromBootstrapConfig,
+		betaMode:                    config.BetaMode,
 	}
 	// We make sure OverrideEnv is never nil in meta.
 	if meta.OverrideEnv == nil {

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -31,6 +31,7 @@ type meta struct {
 	result                      interface{}
 	httpClient                  *http.Client
 	isClientFromBootstrapConfig bool
+	betaMode                    bool
 }
 
 type contextKey int
@@ -78,6 +79,10 @@ func ExtractLogger(ctx context.Context) *Logger {
 
 func ExtractBuildInfo(ctx context.Context) *BuildInfo {
 	return extractMeta(ctx).BuildInfo
+}
+
+func ExtractBetaMode(ctx context.Context) bool {
+	return extractMeta(ctx).betaMode
 }
 
 func ExtractEnv(ctx context.Context, envKey string) string {


### PR DESCRIPTION
Keep it as beta for now, could crash completion

Will try to complete arguments using the list verb of the specific resource
Example:
In `instance` namespace, every `server-id` will execute `instance server list` and complete with id fields

In `marketplace image get label=`, it will fetch for `label` using list of current resource `marketplace image list`
