### PR TITLE
fix(main): print error before stacktrace on panic

### DIFF
--- a/cmd/scw/main.go
+++ b/cmd/scw/main.go
@@ -35,6 +35,7 @@ var (
 func cleanup(buildInfo *core.BuildInfo) {
 	if err := recover(); err != nil {
 		fmt.Println(sentry.ErrorBanner)
+		fmt.Println(err)
 		fmt.Println("stacktrace from panic: \n" + string(debug.Stack()))
 
 		// This will send an anonymous report on Scaleway's sentry.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
