### PR TITLE
fix(dns): consistent TTL on records across the devtools

### DIFF
--- a/cmd/scw/testdata/test-all-usage-dns-record-add-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-dns-record-add-usage.golden
@@ -17,7 +17,7 @@ ARGS:
   data                                                 
   [name]                                               
   [priority]                                           
-  ttl=300                                              
+  ttl=3600                                             
   type                                                  (A | AAAA | CNAME | TXT | SRV | TLSA | MX | NS | PTR | CAA | ALIAS | LOC | SSHFP | HINFO | RP | URI | DS | NAPTR)
   [comment]                                            
   [geo-ip-config.matches.{index}.countries.{index}]    

--- a/cmd/scw/testdata/test-all-usage-dns-record-set-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-dns-record-set-usage.golden
@@ -17,7 +17,7 @@ ARGS:
   values.{index}                                       A list of values for replacing the record data. (multiple values cannot be used for all type)
   name                                                 
   [priority]                                           
-  ttl=300                                              
+  ttl=3600                                             
   type                                                  (A | AAAA | CNAME | TXT | SRV | TLSA | MX | NS | PTR | CAA | ALIAS | LOC | SSHFP | HINFO | RP | URI | DS | NAPTR)
   [comment]                                            
   [geo-ip-config.matches.{index}.countries.{index}]    

--- a/docs/commands/dns.md
+++ b/docs/commands/dns.md
@@ -142,7 +142,7 @@ scw dns record add <dns-zone ...> [arg=value ...]
 | data | Required |  |
 | name |  |  |
 | priority |  |  |
-| ttl | Required<br />Default: `300` |  |
+| ttl | Required<br />Default: `3600` |  |
 | type | Required<br />One of: `A`, `AAAA`, `CNAME`, `TXT`, `SRV`, `TLSA`, `MX`, `NS`, `PTR`, `CAA`, `ALIAS`, `LOC`, `SSHFP`, `HINFO`, `RP`, `URI`, `DS`, `NAPTR` |  |
 | comment |  |  |
 | geo-ip-config.matches.{index}.countries.{index} |  |  |
@@ -390,7 +390,7 @@ scw dns record set <dns-zone ...> [arg=value ...]
 | values.{index} | Required | A list of values for replacing the record data. (multiple values cannot be used for all type) |
 | name | Required |  |
 | priority |  |  |
-| ttl | Required<br />Default: `300` |  |
+| ttl | Required<br />Default: `3600` |  |
 | type | Required<br />One of: `A`, `AAAA`, `CNAME`, `TXT`, `SRV`, `TLSA`, `MX`, `NS`, `PTR`, `CAA`, `ALIAS`, `LOC`, `SSHFP`, `HINFO`, `RP`, `URI`, `DS`, `NAPTR` |  |
 | comment |  |  |
 | geo-ip-config.matches.{index}.countries.{index} |  |  |

--- a/internal/namespaces/domain/v2beta1/custom_record_add.go
+++ b/internal/namespaces/domain/v2beta1/custom_record_add.go
@@ -51,7 +51,7 @@ func dnsRecordAddCommand() *core.Command {
 				Required:   true,
 				Deprecated: false,
 				Positional: false,
-				Default:    core.DefaultValueSetter("300"),
+				Default:    core.DefaultValueSetter(defaultTTL),
 			},
 			{
 				Name:       "type",

--- a/internal/namespaces/domain/v2beta1/custom_record_set.go
+++ b/internal/namespaces/domain/v2beta1/custom_record_set.go
@@ -54,7 +54,7 @@ func dnsRecordSetCommand() *core.Command {
 				Required:   true,
 				Deprecated: false,
 				Positional: false,
-				Default:    core.DefaultValueSetter("300"),
+				Default:    core.DefaultValueSetter(defaultTTL),
 			},
 			{
 				Name:       "type",

--- a/internal/namespaces/domain/v2beta1/domain_cli.go
+++ b/internal/namespaces/domain/v2beta1/domain_cli.go
@@ -17,6 +17,8 @@ var (
 	_ = scw.RegionFrPar
 )
 
+const defaultTTL = "3600"
+
 func GetGeneratedCommands() *core.Commands {
 	return core.NewCommands(
 		dnsRoot(),


### PR DESCRIPTION
Closes #2170 

In order to have a consistent behavior across all the devtools, the default TTL on all commands that add/set records is now 3600, as it already is in the terraform provider.