### PR TITLE
fix(instance): remove hardcoded offers

### DIFF
--- a/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
@@ -36,7 +36,7 @@ EXAMPLES:
 
 ARGS:
   image=ubuntu_jammy                       Image ID or label of the server
-  type=DEV1-S                              Server commercial type (help: https://www.scaleway.com/en/docs/compute/instances/reference-content/choosing-instance-type/)
+  type                                     Server commercial type (help: https://www.scaleway.com/en/docs/compute/instances/reference-content/choosing-instance-type/)
   [name=<generated>]                       Server name
   [root-volume]                            Local root volume of the server
   [additional-volumes.{index}]             Additional local and block volumes attached to your server

--- a/docs/commands/instance.md
+++ b/docs/commands/instance.md
@@ -1709,7 +1709,7 @@ scw instance server create [arg=value ...]
 | Name |   | Description |
 |------|---|-------------|
 | image | Required<br />Default: `ubuntu_jammy` | Image ID or label of the server |
-| type | Required<br />Default: `DEV1-S` | Server commercial type (help: https://www.scaleway.com/en/docs/compute/instances/reference-content/choosing-instance-type/) |
+| type | Required | Server commercial type (help: https://www.scaleway.com/en/docs/compute/instances/reference-content/choosing-instance-type/) |
 | name | Default: `<generated>` | Server name |
 | root-volume |  | Local root volume of the server |
 | additional-volumes.{index} |  | Additional local and block volumes attached to your server |

--- a/internal/namespaces/instance/v1/custom_image_test.go
+++ b/internal/namespaces/instance/v1/custom_image_test.go
@@ -32,7 +32,7 @@ func Test_ImageCreate(t *testing.T) {
 	t.Run("Use additional snapshots", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu_focal root-volume=local:10GB additional-volumes.0=local:10GB -w"),
+			core.ExecStoreBeforeCmd("Server", "scw instance server create type=DEV1-S image=ubuntu_focal root-volume=local:10GB additional-volumes.0=local:10GB -w"),
 			core.ExecStoreBeforeCmd("SnapshotA", `scw instance snapshot create -w name=cli-test-image-create-snapshotA volume-id={{ (index .Server.Volumes "0").ID }}`),
 			core.ExecStoreBeforeCmd("SnapshotB", `scw instance snapshot create -w name=cli-test-image-create-snapshotB volume-id={{ (index .Server.Volumes "1").ID }}`),
 		),

--- a/internal/namespaces/instance/v1/custom_ip_test.go
+++ b/internal/namespaces/instance/v1/custom_ip_test.go
@@ -11,7 +11,7 @@ func Test_IPAttach(t *testing.T) {
 	t.Run("With UUID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true ip=none"),
+			core.ExecStoreBeforeCmd("Server", "scw instance server create type=DEV1-S stopped=true ip=none"),
 			createIP("Ip"),
 		),
 		Cmd: "scw instance ip attach {{ .Ip.Address }} server-id={{ .Server.ID }}",
@@ -28,7 +28,7 @@ func Test_IPAttach(t *testing.T) {
 	t.Run("With IP", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true ip=none"),
+			core.ExecStoreBeforeCmd("Server", "scw instance server create type=DEV1-S stopped=true ip=none"),
 			createIP("Ip"),
 		),
 		Cmd: "scw instance ip attach {{ .Ip.Address }} server-id={{ .Server.ID }}",
@@ -47,7 +47,7 @@ func Test_IPDetach(t *testing.T) {
 	t.Run("With UUID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true ip=none"),
+			core.ExecStoreBeforeCmd("Server", "scw instance server create type=DEV1-S stopped=true ip=none"),
 			createIP("Ip"),
 			core.ExecBeforeCmd("scw instance ip attach {{ .Ip.Address }} server-id={{ .Server.ID }}"),
 		),
@@ -66,7 +66,7 @@ func Test_IPDetach(t *testing.T) {
 	t.Run("With IP", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true ip=none"),
+			core.ExecStoreBeforeCmd("Server", "scw instance server create type=DEV1-S stopped=true ip=none"),
 			createIP("Ip"),
 			core.ExecBeforeCmd("scw instance ip attach {{ .Ip.Address }} server-id={{ .Server.ID }}"),
 		),

--- a/internal/namespaces/instance/v1/custom_placement_group_test.go
+++ b/internal/namespaces/instance/v1/custom_placement_group_test.go
@@ -11,7 +11,7 @@ func Test_GetPlacementGroup(t *testing.T) {
 	t.Run("simple", core.Test(&core.TestConfig{
 		BeforeFunc: core.BeforeFuncCombine(
 			core.ExecStoreBeforeCmd("PlacementGroup", "scw instance placement-group create"),
-			core.ExecStoreBeforeCmd("ServerA", "scw instance server create image=ubuntu_jammy stopped=true placement-group-id={{ .PlacementGroup.PlacementGroup.ID }}"),
+			core.ExecStoreBeforeCmd("ServerA", "scw instance server create type=DEV1-S image=ubuntu_jammy stopped=true placement-group-id={{ .PlacementGroup.PlacementGroup.ID }}"),
 		),
 		Commands: instance.GetCommands(),
 		Cmd:      "scw instance placement-group get {{ .PlacementGroup.PlacementGroup.ID }}",

--- a/internal/namespaces/instance/v1/custom_server_action_test.go
+++ b/internal/namespaces/instance/v1/custom_server_action_test.go
@@ -19,7 +19,7 @@ func Test_ServerTerminate(t *testing.T) {
 
 	t.Run("without IP", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-jammy -w"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-jammy -w")),
 		Cmd:        `scw instance server terminate {{ .Server.ID }}`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -40,7 +40,7 @@ func Test_ServerTerminate(t *testing.T) {
 
 	t.Run("with IP", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-jammy -w"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-jammy -w")),
 		Cmd:        `scw instance server terminate {{ .Server.ID }} with-ip=true`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -61,7 +61,7 @@ func Test_ServerTerminate(t *testing.T) {
 
 	t.Run("without block", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-jammy additional-volumes.0=block:10G -w"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-jammy additional-volumes.0=block:10G -w")),
 		Cmd:        `scw instance server terminate {{ .Server.ID }} with-ip=true with-block=false`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -76,7 +76,7 @@ func Test_ServerTerminate(t *testing.T) {
 
 	t.Run("with block", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-jammy additional-volumes.0=block:10G -w"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-jammy additional-volumes.0=block:10G -w")),
 		Cmd:        `scw instance server terminate {{ .Server.ID }} with-ip=true with-block=true -w`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -103,7 +103,7 @@ func Test_ServerTerminate(t *testing.T) {
 func Test_ServerBackup(t *testing.T) {
 	t.Run("simple", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-jammy"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-jammy")),
 		Cmd:        `scw instance server backup {{ .Server.ID }} name=backup`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -119,7 +119,7 @@ func Test_ServerBackup(t *testing.T) {
 func Test_ServerAction(t *testing.T) {
 	t.Run("manual poweron", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu_jammy"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu_jammy")),
 		Cmd:        `scw instance server action {{ .Server.ID }} action=poweron --wait`,
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),

--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -67,7 +67,6 @@ func serverCreateCommand() *core.Command {
 			{
 				Name:     "type",
 				Short:    "Server commercial type (help: https://www.scaleway.com/en/docs/compute/instances/reference-content/choosing-instance-type/)",
-				Default:  core.DefaultValueSetter("DEV1-S"),
 				Required: true,
 				ValidateFunc: func(_ *core.ArgSpec, _ interface{}) error {
 					// Allow all commercial types

--- a/internal/namespaces/instance/v1/custom_server_create_test.go
+++ b/internal/namespaces/instance/v1/custom_server_create_test.go
@@ -133,10 +133,10 @@ func Test_CreateServer(t *testing.T) {
 		t.Run("valid single local snapshot", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
-				core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu_bionic root-volume=local:20GB stopped=true"),
+				core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu_bionic root-volume=local:20GB stopped=true")),
 				core.ExecStoreBeforeCmd("Snapshot", `scw instance snapshot create volume-id={{ (index .Server.Volumes "0").ID }}`),
 			),
-			Cmd: "scw instance server create image=ubuntu_bionic root-volume=local:{{ .Snapshot.Snapshot.ID }} stopped=true",
+			Cmd: testServerCommand("image=ubuntu_bionic root-volume=local:{{ .Snapshot.Snapshot.ID }} stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -155,10 +155,10 @@ func Test_CreateServer(t *testing.T) {
 		t.Run("valid single local snapshot without image", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
-				core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu_bionic root-volume=local:20GB stopped=true"),
+				core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu_bionic root-volume=local:20GB stopped=true")),
 				core.ExecStoreBeforeCmd("Snapshot", `scw instance snapshot create volume-id={{ (index .Server.Volumes "0").ID }}`),
 			),
-			Cmd: "scw instance server create image=none root-volume=local:{{ .Snapshot.Snapshot.ID }} stopped=true",
+			Cmd: testServerCommand("image=none root-volume=local:{{ .Snapshot.Snapshot.ID }} stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -192,10 +192,10 @@ func Test_CreateServer(t *testing.T) {
 		t.Run("valid double snapshot", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
-				core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu_bionic root-volume=local:20GB stopped=true"),
+				core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu_bionic root-volume=local:20GB stopped=true")),
 				core.ExecStoreBeforeCmd("Snapshot", `scw instance snapshot create unified=true volume-id={{ (index .Server.Volumes "0").ID }}`),
 			),
-			Cmd: "scw instance server create image=ubuntu_bionic root-volume=block:{{ .Snapshot.Snapshot.ID }} additional-volumes.0=local:{{ .Snapshot.Snapshot.ID }} stopped=true",
+			Cmd: testServerCommand("image=ubuntu_bionic root-volume=block:{{ .Snapshot.Snapshot.ID }} additional-volumes.0=local:{{ .Snapshot.Snapshot.ID }} stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -236,7 +236,7 @@ func Test_CreateServer(t *testing.T) {
 			BeforeFunc: core.BeforeFuncCombine(
 				createSbsVolume("Volume", 20),
 			),
-			Cmd: "scw instance server create image=ubuntu_jammy additional-volumes.0={{.Volume.ID}} stopped=true",
+			Cmd: testServerCommand("image=ubuntu_jammy additional-volumes.0={{.Volume.ID}} stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -258,7 +258,7 @@ func Test_CreateServer(t *testing.T) {
 			BeforeFunc: core.BeforeFuncCombine(
 				createSbsVolume("Volume", 20),
 			),
-			Cmd: "scw instance server create image=none root-volume={{.Volume.ID}} stopped=true",
+			Cmd: testServerCommand("image=none root-volume={{.Volume.ID}} stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -277,7 +277,7 @@ func Test_CreateServer(t *testing.T) {
 				instance.GetCommands(),
 				block.GetCommands(),
 			),
-			Cmd: "scw instance server create image=ubuntu_jammy root-volume=sbs:20GB stopped=true",
+			Cmd: testServerCommand("image=ubuntu_jammy root-volume=sbs:20GB stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -296,7 +296,7 @@ func Test_CreateServer(t *testing.T) {
 				instance.GetCommands(),
 				block.GetCommands(),
 			),
-			Cmd: "scw instance server create image=ubuntu_jammy root-volume=sbs:20GB:15000 stopped=true --debug",
+			Cmd: testServerCommand("image=ubuntu_jammy root-volume=sbs:20GB:15000 stopped=true --debug"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -407,7 +407,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("with ipv6 and dynamic ip", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic dynamic-ip-required=true ip=ipv6 -w", // IPv6 is created at runtime
+			Cmd:      testServerCommand("image=ubuntu_bionic dynamic-ip-required=true ip=ipv6 -w"), // IPv6 is created at runtime
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -425,7 +425,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("with ipv6 and ipv4", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic ip=both -w", // IPv6 is created at runtime
+			Cmd:      testServerCommand("image=ubuntu_bionic ip=both -w"), // IPv6 is created at runtime
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {

--- a/internal/namespaces/instance/v1/custom_server_create_test.go
+++ b/internal/namespaces/instance/v1/custom_server_create_test.go
@@ -27,7 +27,7 @@ func Test_CreateServer(t *testing.T) {
 	t.Run("Simple", func(t *testing.T) {
 		t.Run("Default", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_jammy stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_jammy stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckGolden(),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -56,7 +56,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("With name", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic name=yo stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic name=yo stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -70,7 +70,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("With start", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic -w",
+			Cmd:      testServerCommand("image=ubuntu_bionic -w"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -84,7 +84,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("Image UUID", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=f974feac-abae-4365-b988-8ec7d1cec10d stopped=true",
+			Cmd:      testServerCommand("image=f974feac-abae-4365-b988-8ec7d1cec10d stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -98,7 +98,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("Tags", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic tags.0=prod tags.1=blue stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic tags.0=prod tags.1=blue stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -118,7 +118,7 @@ func Test_CreateServer(t *testing.T) {
 	t.Run("Volumes", func(t *testing.T) {
 		t.Run("valid single local volume", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic root-volume=local:20GB stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic root-volume=local:20GB stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -176,7 +176,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("valid double local volumes", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic root-volume=local:10GB additional-volumes.0=l:10G stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic root-volume=local:10GB additional-volumes.0=l:10G stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -214,7 +214,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("valid additional block volumes", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic additional-volumes.0=b:1G additional-volumes.1=b:5G additional-volumes.2=b:10G stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic additional-volumes.0=b:1G additional-volumes.1=b:5G additional-volumes.2=b:10G stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -328,7 +328,7 @@ func Test_CreateServer(t *testing.T) {
 	t.Run("IPs", func(t *testing.T) {
 		t.Run("explicit new IP", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic ip=new stopped=true",
+			Cmd:      testServerCommand("image=ubuntu_bionic ip=new stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -343,7 +343,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("run with dynamic IP", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic ip=dynamic -w", // dynamic IP is created at runtime
+			Cmd:      testServerCommand("image=ubuntu_bionic ip=dynamic -w"), // dynamic IP is created at runtime
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -360,7 +360,7 @@ func Test_CreateServer(t *testing.T) {
 		t.Run("existing IP", core.Test(&core.TestConfig{
 			Commands:   instance.GetCommands(),
 			BeforeFunc: createIP("IP"),
-			Cmd:        "scw instance server create image=ubuntu_bionic ip={{ .IP.Address }} stopped=true",
+			Cmd:        testServerCommand("image=ubuntu_bionic ip={{ .IP.Address }} stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -376,7 +376,7 @@ func Test_CreateServer(t *testing.T) {
 		t.Run("existing IP ID", core.Test(&core.TestConfig{
 			Commands:   instance.GetCommands(),
 			BeforeFunc: createIP("IP"),
-			Cmd:        "scw instance server create image=ubuntu_bionic ip={{ .IP.ID }} stopped=true",
+			Cmd:        testServerCommand("image=ubuntu_bionic ip={{ .IP.ID }} stopped=true"),
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -391,7 +391,7 @@ func Test_CreateServer(t *testing.T) {
 
 		t.Run("with ipv6", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
-			Cmd:      "scw instance server create image=ubuntu_bionic ip=ipv6 dynamic-ip-required=false -w", // IPv6 is created at runtime
+			Cmd:      testServerCommand("image=ubuntu_bionic ip=ipv6 dynamic-ip-required=false -w"), // IPv6 is created at runtime
 			Check: core.TestCheckCombine(
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
@@ -451,7 +451,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	////
 	t.Run("Error: invalid image label", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=macos",
+		Cmd:      testServerCommand("image=macos"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -461,7 +461,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid image UUID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=7a892c1a-bbdc-491f-9974-4008e3708664",
+		Cmd:      testServerCommand("image=7a892c1a-bbdc-491f-9974-4008e3708664"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -487,7 +487,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	////
 	t.Run("Error: invalid total local volumes size: too low 1", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=l:5GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=l:5GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -497,7 +497,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid total local volumes size: too low 2", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=l:5GB additional-volumes.0=block:10GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=l:5GB additional-volumes.0=block:10GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -508,7 +508,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	t.Run("Error: invalid total local volumes size: too low 3", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
 		BeforeFunc: createVolume("Volume", 5, instanceSDK.VolumeVolumeTypeLSSD),
-		Cmd:        "scw instance server create image=ubuntu_jammy root-volume={{ .Volume.ID }}",
+		Cmd:        testServerCommand("image=ubuntu_jammy root-volume={{ .Volume.ID }}"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -518,7 +518,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid total local volumes size: too high 1", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=local:10GB additional-volumes.0=local:20GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=local:10GB additional-volumes.0=local:20GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -528,7 +528,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid total local volumes size: too high 2", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy additional-volumes.0=local:20GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy additional-volumes.0=local:20GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -539,7 +539,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	t.Run("Error: invalid total local volumes size: too high 3", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
 		BeforeFunc: createVolume("Volume", 20, instanceSDK.VolumeVolumeTypeLSSD),
-		Cmd:        "scw instance server create image=ubuntu_jammy root-volume={{ .Volume.ID }} additional-volumes.0=local:10GB",
+		Cmd:        testServerCommand("image=ubuntu_jammy root-volume={{ .Volume.ID }} additional-volumes.0=local:10GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -550,7 +550,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid root volume size", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=local:2GB additional-volumes.0=local:18GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=local:2GB additional-volumes.0=local:18GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -561,7 +561,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	t.Run("Error: disallow existing root volume ID", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
 		BeforeFunc: createVolume("Volume", 20, instanceSDK.VolumeVolumeTypeLSSD),
-		Cmd:        "scw instance server create image=ubuntu_jammy root-volume={{ .Volume.ID }}",
+		Cmd:        testServerCommand("image=ubuntu_jammy root-volume={{ .Volume.ID }}"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -572,7 +572,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid root volume ID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=29da9ad9-e759-4a56-82c8-f0607f93055c",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=29da9ad9-e759-4a56-82c8-f0607f93055c"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -582,8 +582,8 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: already attached additional volume ID", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create name=cli-test image=ubuntu_jammy root-volume=l:10G additional-volumes.0=l:10G stopped=true"),
-		Cmd:        `scw instance server create image=ubuntu_jammy root-volume=l:10G additional-volumes.0={{ (index .Server.Volumes "1").ID }} stopped=true`,
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("name=cli-test image=ubuntu_jammy root-volume=l:10G additional-volumes.0=l:10G stopped=true")),
+		Cmd:        testServerCommand(`image=ubuntu_jammy root-volume=l:10G additional-volumes.0={{ (index .Server.Volumes "1").ID }} stopped=true`),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -594,7 +594,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid root volume format", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=20GB",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=20GB"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -604,7 +604,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid root volume snapshot ID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy root-volume=local:29da9ad9-e759-4a56-82c8-f0607f93055c",
+		Cmd:      testServerCommand("image=ubuntu_jammy root-volume=local:29da9ad9-e759-4a56-82c8-f0607f93055c"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -614,7 +614,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid additional volume snapshot ID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy additional-volumes.0=block:29da9ad9-e759-4a56-82c8-f0607f93055c",
+		Cmd:      testServerCommand("image=ubuntu_jammy additional-volumes.0=block:29da9ad9-e759-4a56-82c8-f0607f93055c"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -627,7 +627,7 @@ func Test_CreateServerErrors(t *testing.T) {
 	////
 	t.Run("Error: not found ip ID", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy ip=23165951-13fd-4a3b-84ed-22c2e96658f2",
+		Cmd:      testServerCommand("image=ubuntu_jammy ip=23165951-13fd-4a3b-84ed-22c2e96658f2"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -636,7 +636,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: forbidden IP", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy ip=51.15.242.82",
+		Cmd:      testServerCommand("image=ubuntu_jammy ip=51.15.242.82"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
@@ -645,7 +645,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid ip", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance server create image=ubuntu_jammy ip=yo",
+		Cmd:      testServerCommand("image=ubuntu_jammy ip=yo"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),

--- a/internal/namespaces/instance/v1/custom_server_test.go
+++ b/internal/namespaces/instance/v1/custom_server_test.go
@@ -338,7 +338,7 @@ func Test_ServerDelete(t *testing.T) {
 
 	t.Run("with multiple IPs", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic ip=both"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic ip=both")),
 		Cmd:        `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=all`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),

--- a/internal/namespaces/instance/v1/custom_server_test.go
+++ b/internal/namespaces/instance/v1/custom_server_test.go
@@ -67,7 +67,7 @@ func Test_ServerVolumeUpdate(t *testing.T) {
 	t.Run("Detach", func(t *testing.T) {
 		t.Run("simple block volume", core.Test(&core.TestConfig{
 			Commands:   instance.GetCommands(),
-			BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+			BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 			Cmd:        `scw instance server detach-volume volume-id={{ (index .Server.Volumes "1").ID }}`,
 			Check: func(t *testing.T, ctx *core.CheckFuncCtx) {
 				t.Helper()
@@ -167,7 +167,7 @@ func Test_ServerUpdateCustom(t *testing.T) {
 		BeforeFunc: core.BeforeFuncCombine(
 			createPlacementGroup("PlacementGroup1"),
 			createPlacementGroup("PlacementGroup2"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic placement-group-id={{ .PlacementGroup1.ID }}"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic placement-group-id={{ .PlacementGroup1.ID }}")),
 		),
 		Cmd: "scw instance server update {{ .Server.ID }} placement-group-id={{ .PlacementGroup2.ID }}",
 		Check: core.TestCheckCombine(
@@ -192,7 +192,7 @@ func Test_ServerUpdateCustom(t *testing.T) {
 		BeforeFunc: core.BeforeFuncCombine(
 			createSecurityGroup("SecurityGroup1"),
 			createSecurityGroup("SecurityGroup2"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic security-group-id={{ .SecurityGroup1.ID }}"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic security-group-id={{ .SecurityGroup1.ID }}")),
 		),
 		Cmd: "scw instance server update {{ .Server.ID }} security-group-id={{ .SecurityGroup2.ID }}",
 		Check: core.TestCheckCombine(
@@ -231,7 +231,7 @@ func Test_ServerUpdateCustom(t *testing.T) {
 
 		t.Run("detach all volumes", core.Test(&core.TestConfig{
 			Commands:   instance.GetCommands(),
-			BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+			BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 			Cmd:        `scw instance server update {{ .Server.ID }} volume-ids=none`,
 			Check: func(t *testing.T, ctx *core.CheckFuncCtx) {
 				t.Helper()
@@ -254,7 +254,7 @@ func Test_ServerDelete(t *testing.T) {
 
 	t.Run("with all volumes", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 		Cmd:        `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=all`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -265,7 +265,7 @@ func Test_ServerDelete(t *testing.T) {
 
 	t.Run("only block volumes", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 		Cmd:        `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=block`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -277,7 +277,7 @@ func Test_ServerDelete(t *testing.T) {
 
 	t.Run("only local volumes", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 		Cmd:        `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=local`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -289,7 +289,7 @@ func Test_ServerDelete(t *testing.T) {
 
 	t.Run("with none volumes", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic additional-volumes.0=block:10G"),
+		BeforeFunc: core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic additional-volumes.0=block:10G")),
 		Cmd:        `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=none`,
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
@@ -315,7 +315,7 @@ func Test_ServerDelete(t *testing.T) {
 		),
 		BeforeFunc: core.BeforeFuncCombine(
 			core.ExecStoreBeforeCmd("BlockVolume", "scw block volume create perf-iops=5000 from-empty.size=10G name=cli-test-server-delete-with-sbs-volumes"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-jammy"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-jammy")),
 			core.ExecBeforeCmd("scw instance server attach-volume server-id={{ .Server.ID }} volume-id={{ .BlockVolume.ID }}"),
 		),
 		Cmd: `scw instance server delete {{ .Server.ID }} with-ip=true with-volumes=all`,

--- a/internal/namespaces/instance/v1/custom_user_data_test.go
+++ b/internal/namespaces/instance/v1/custom_user_data_test.go
@@ -58,7 +58,7 @@ func Test_UserDataFileUpload(t *testing.T) {
 	t.Run("on-cloud-init", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic")),
 			func(ctx *core.BeforeFuncCtx) error {
 				file, _ := os.CreateTemp("", "test")
 				_, _ = file.WriteString(content)
@@ -81,7 +81,7 @@ func Test_UserDataFileUpload(t *testing.T) {
 	t.Run("on-random-key", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
-			core.ExecStoreBeforeCmd("Server", "scw instance server create stopped=true image=ubuntu-bionic"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("stopped=true image=ubuntu-bionic")),
 			func(ctx *core.BeforeFuncCtx) error {
 				file, _ := os.CreateTemp("", "test")
 				_, _ = file.WriteString(content)

--- a/internal/namespaces/instance/v1/helpers_test.go
+++ b/internal/namespaces/instance/v1/helpers_test.go
@@ -18,12 +18,12 @@ import (
 //
 //nolint:unparam
 func createServerBionic(metaKey string) core.BeforeFunc {
-	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create type=DEV1-S stopped=true image=ubuntu-bionic")
+	return core.ExecStoreBeforeCmd(metaKey, testServerCommand("stopped=true image=ubuntu-bionic"))
 }
 
 //nolint:unparam
 func createServer(metaKey string) core.BeforeFunc {
-	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create stopped=true image=ubuntu-jammy")
+	return core.ExecStoreBeforeCmd(metaKey, testServerCommand("stopped=true image=ubuntu-jammy"))
 }
 
 // testServerCommand creates returns a create server command with the instance type and the given arguments

--- a/internal/namespaces/instance/v1/helpers_test.go
+++ b/internal/namespaces/instance/v1/helpers_test.go
@@ -18,12 +18,17 @@ import (
 //
 //nolint:unparam
 func createServerBionic(metaKey string) core.BeforeFunc {
-	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create stopped=true image=ubuntu-bionic")
+	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create type=DEV1-S stopped=true image=ubuntu-bionic")
 }
 
 //nolint:unparam
 func createServer(metaKey string) core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(metaKey, "scw instance server create stopped=true image=ubuntu-jammy")
+}
+
+// testServerCommand creates returns a create server command with the instance type and the given arguments
+func testServerCommand(params string) string {
+	return "scw instance server create type=DEV1-S " + params
 }
 
 // createServer creates a stopped ubuntu-bionic server and

--- a/internal/namespaces/instance/v1/instance_cli_test.go
+++ b/internal/namespaces/instance/v1/instance_cli_test.go
@@ -138,7 +138,7 @@ func Test_ServerUpdate(t *testing.T) {
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
 			createPlacementGroup("PlacementGroup"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-bionic placement-group-id={{ .PlacementGroup.ID }} stopped=true"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-bionic placement-group-id={{ .PlacementGroup.ID }} stopped=true")),
 		),
 		Cmd: `scw instance server update {{ .Server.ID }} placement-group-id=none`,
 		Check: core.TestCheckCombine(
@@ -159,7 +159,7 @@ func Test_ServerUpdate(t *testing.T) {
 		Commands: instance.GetCommands(),
 		BeforeFunc: core.BeforeFuncCombine(
 			createPlacementGroup("PlacementGroup"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-bionic placement-group-id={{ .PlacementGroup.ID }} stopped=true"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-bionic placement-group-id={{ .PlacementGroup.ID }} stopped=true")),
 		),
 		Cmd: `scw instance server update {{ .Server.ID }} placement-group-id={{ .PlacementGroup.ID }}`,
 		Check: core.TestCheckCombine(
@@ -184,7 +184,7 @@ func Test_ServerUpdate(t *testing.T) {
 		BeforeFunc: core.BeforeFuncCombine(
 			createPlacementGroup("PlacementGroup1"),
 			createPlacementGroup("PlacementGroup2"),
-			core.ExecStoreBeforeCmd("Server", "scw instance server create image=ubuntu-bionic placement-group-id={{ .PlacementGroup1.ID }} stopped=true"),
+			core.ExecStoreBeforeCmd("Server", testServerCommand("image=ubuntu-bionic placement-group-id={{ .PlacementGroup1.ID }} stopped=true")),
 		),
 		Cmd: `scw instance server update {{ .Server.ID }} placement-group-id={{ .PlacementGroup2.ID }}`,
 		Check: core.TestCheckCombine(

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-total-local-volumes-size-too-low2.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-total-local-volumes-size-too-low2.cassette.yaml
@@ -2,82 +2,6 @@
 version: 1
 interactions:
 - request:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1183"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 13:02:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ac3c614-a344-4d88-b24c-e609e2470bb8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
-      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cb01f4c-9cd0-4032-8ce6-325c458df811
-    method: GET
-  response:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
-      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 13:02:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e717737-2563-4945-a118-fcaf79257a29
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
@@ -87,52 +11,55 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      167772160}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 36.1496, "hourly_price": 0.04952,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      209715200}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
       4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -141,16 +68,17 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
       300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      104857600}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
       12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -159,25 +87,26 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
       20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
       68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -186,26 +115,27 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
@@ -213,43 +143,46 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 576.262, "hourly_price": 0.7894,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000,
+      "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
       5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 296.672, "hourly_price": 0.4064,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 149.066, "hourly_price": 0.2042,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      524288000}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -258,26 +191,28 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 1220.122, "hourly_price": 1.6714,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000,
+      "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
       10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      314572800}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
@@ -285,17 +220,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram":
+      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
@@ -303,16 +239,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
       100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth":
+      3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}, "block_bandwidth":
+      3355443200}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -321,17 +258,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
       "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
@@ -339,16 +277,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -357,16 +296,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -375,34 +315,36 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -411,16 +353,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -429,16 +372,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -447,16 +391,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -465,16 +410,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -483,16 +429,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -501,38 +448,40 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
+      530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth":
+      3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}, "block_bandwidth":
+      419430400}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
@@ -545,52 +494,55 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      167772160}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 36.1496, "hourly_price": 0.04952,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      209715200}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
       4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -599,16 +551,17 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
       300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      104857600}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
       12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -617,25 +570,26 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
       20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
       68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -644,26 +598,27 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
@@ -671,43 +626,46 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 576.262, "hourly_price": 0.7894,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000,
+      "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
       5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 296.672, "hourly_price": 0.4064,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 149.066, "hourly_price": 0.2042,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      524288000}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -716,26 +674,28 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 1220.122, "hourly_price": 1.6714,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000,
+      "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
       10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      314572800}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
@@ -743,17 +703,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram":
+      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
@@ -761,16 +722,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
       100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth":
+      3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}, "block_bandwidth":
+      3355443200}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -779,17 +741,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
       "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
@@ -797,16 +760,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -815,16 +779,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -833,34 +798,36 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -869,16 +836,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -887,16 +855,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -905,16 +874,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -923,16 +893,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -941,16 +912,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -959,108 +931,139 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth":
+      3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}, "block_bandwidth":
+      419430400}}}'
+    headers:
+      Content-Length:
+      - "39559"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Oct 2024 12:36:56 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4119b01b-94e4-49e9-98a5-ae1e03c95bd3
+      X-Total-Count:
+      - "69"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}, "PRO2-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
       6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
       3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "38026"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 13:02:35 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c34b4eba-aa3d-4819-89f9-3ea4f9df0ad9
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
       700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      700000000}]}, "block_bandwidth": 262144000}, "PRO2-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
       350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      350000000}]}, "block_bandwidth": 131072000}, "RENDER-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 907.098, "hourly_price": 1.2426,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
+      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 3.3507, "hourly_price": 0.00459,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      52428800}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
@@ -1069,17 +1072,18 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
       400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      41943040}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth":
+      300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 300000000}]}, "block_bandwidth":
+      41943040}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
       2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -1088,17 +1092,18 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      41943040}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6,
+      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
@@ -1106,18 +1111,19 @@ interactions:
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
       200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 11.3515, "hourly_price": 0.01555,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2,
+      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
       false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
@@ -1125,37 +1131,38 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
       "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
       250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}, "block_bandwidth":
+      41943040}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      300000000000, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 86.9138, "hourly_price": 0.11906,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      41943040}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
@@ -1163,60 +1170,90 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
       1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}, "block_bandwidth":
+      41943040}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+    body: '{"servers": {"POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}, "PRO2-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
       700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      700000000}]}, "block_bandwidth": 262144000}, "PRO2-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
       350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      350000000}]}, "block_bandwidth": 131072000}, "RENDER-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 907.098, "hourly_price": 1.2426,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
+      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 3.3507, "hourly_price": 0.00459,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      52428800}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
@@ -1225,17 +1262,18 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
       400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      41943040}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth":
+      300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 300000000}]}, "block_bandwidth":
+      41943040}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
       2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -1244,17 +1282,18 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      41943040}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6,
+      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
@@ -1262,18 +1301,19 @@ interactions:
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
       200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 11.3515, "hourly_price": 0.01555,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2,
+      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
       false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
@@ -1281,37 +1321,38 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
       "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
       250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}, "block_bandwidth":
+      41943040}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      300000000000, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 86.9138, "hourly_price": 0.11906,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      41943040}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
@@ -1319,21 +1360,22 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
       1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}, "block_bandwidth":
+      41943040}}}'
     headers:
       Content-Length:
-      - "12534"
+      - "15351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 13:02:35 GMT
+      - Thu, 24 Oct 2024 12:36:56 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1341,9 +1383,115 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7984b2ea-b0ca-4f1d-b56d-640b1440fe28
+      - cd9cfe4e-267a-4aad-a095-b431b1a1be04
       X-Total-Count:
-      - "66"
+      - "69"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Oct 2024 12:36:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a4c538c-a58c-4200-93a9-db4de92841e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
+    method: GET
+  response:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 24 Oct 2024 12:36:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af112116-eaab-4fd6-8904-2d6e28340838
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/namespaces/lb/v1/helper_test.go
+++ b/internal/namespaces/lb/v1/helper_test.go
@@ -27,21 +27,21 @@ func deleteLB() core.AfterFunc {
 func createInstance() core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(
 		"Instance",
-		"scw instance server create stopped=true image=ubuntu_focal",
+		"scw instance server create type=DEV1-S stopped=true image=ubuntu_focal",
 	)
 }
 
 func createRunningInstance() core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(
 		"Instance",
-		"scw instance server create image=ubuntu_bionic -w",
+		"scw instance server create type=DEV1-S image=ubuntu_bionic -w",
 	)
 }
 
 func createRunningInstanceWithTag() core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(
 		"Instance",
-		"scw instance server create image=ubuntu_bionic tags.0=foo -w",
+		"scw instance server create type=DEV1-S image=ubuntu_bionic tags.0=foo -w",
 	)
 }
 

--- a/internal/namespaces/vpc/v2/helper_test.go
+++ b/internal/namespaces/vpc/v2/helper_test.go
@@ -7,7 +7,7 @@ import (
 func createInstance() core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(
 		"Instance",
-		"scw instance server create stopped=true image=ubuntu_focal",
+		"scw instance server create type=DEV1-S stopped=true image=ubuntu_focal",
 	)
 }
 


### PR DESCRIPTION
DEV1-S is not available in certain AZ, we remove the default type instead of changing every time Scaleway change its hardware