### PR TITLE
fix(secret-manager): Move secret content in doc

### DIFF
--- a/docs/commands/secret.md
+++ b/docs/commands/secret.md
@@ -52,7 +52,7 @@ scw secret secret create [arg=value ...]
 
 Add a given Secret
 ```
-scw secret secret create name=foobar description="$(cat <path/to/your/secret>)"
+scw secret secret create name=foobar description=barfoo
 ```
 
 
@@ -189,7 +189,7 @@ Create a SecretVersion.
 **Usage:**
 
 ```
-scw secret version create [arg=value ...]
+scw secret version create data="$(cat <path/to/your/secret>)" [arg=value ...]
 ```
 
 


### PR DESCRIPTION
The documentation contains a potentially harmful example, setting the secret in the description, instead of the proper data field.