### PR TITLE
feat(autocomplete): cache in arg completion instead of shell

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,38 @@
+package cache
+
+import "strings"
+
+type Cache struct {
+	m map[string]interface{}
+}
+
+func New() *Cache {
+	return &Cache{
+		m: map[string]interface{}{},
+	}
+}
+
+func (c *Cache) Set(cmd string, resp interface{}) {
+	if c == nil {
+		return
+	}
+	c.m[cmd] = resp
+}
+
+func (c *Cache) Get(cmd string) interface{} {
+	if c == nil {
+		return nil
+	}
+	return c.m[cmd]
+}
+
+func (c *Cache) Update(namespace string) {
+	if c == nil {
+		return
+	}
+	for k := range c.m {
+		if strings.HasPrefix(k, namespace) {
+			delete(c.m, k)
+		}
+	}
+}


### PR DESCRIPTION
Previously, the quick cache feature would cache shell suggestions.
Writing
```
>>> f
        function
        fip
        ...
```
Would cache results, meaning you could not get completion when changing your word
```
>>> inst
       <nothing>
```

I just added quickly a package to cache listing requests used in completion, this is very efficient when using shell.
Cache invalidate if using any other commands of this namespace, this is not perfect but it works quite well for now to avoid spamming requests and lagging out terminal.