### PR TITLE
feat: check for api key expiration date

### DIFF
--- a/internal/core/bootstrap.go
+++ b/internal/core/bootstrap.go
@@ -216,9 +216,10 @@ func Bootstrap(config *BootstrapConfig) (exitCode int, result interface{}, err e
 		}
 	}
 
-	// Check CLI new version when exiting the bootstrap
+	// Run checks after command has been executed
 	defer func() { // if we plan to remove defer, do not forget logger is not set until cobra pre init func
-		config.BuildInfo.checkVersion(ctx)
+		// Check CLI new version and api key expiration date
+		runAfterCommandChecks(ctx, config.BuildInfo.checkVersion, checkAPIKey)
 	}()
 
 	if !config.DisableAliases {

--- a/internal/core/build_info.go
+++ b/internal/core/build_info.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,11 +33,10 @@ func (b *BuildInfo) MarshalJSON() ([]byte, error) {
 }
 
 const (
-	scwDisableCheckVersionEnv        = "SCW_DISABLE_CHECK_VERSION"
-	latestGithubReleaseURL           = "https://api.github.com/repos/scaleway/scaleway-cli/releases/latest"
-	latestVersionUpdateFileLocalName = "latest-cli-version"
-	latestVersionRequestTimeout      = 1 * time.Second
-	userAgentPrefix                  = "scaleway-cli"
+	scwDisableCheckVersionEnv   = "SCW_DISABLE_CHECK_VERSION"
+	latestGithubReleaseURL      = "https://api.github.com/repos/scaleway/scaleway-cli/releases/latest"
+	latestVersionRequestTimeout = 1 * time.Second
+	userAgentPrefix             = "scaleway-cli"
 )
 
 // IsRelease returns true when the version of the CLI is an official release:
@@ -57,25 +54,8 @@ func (b *BuildInfo) GetUserAgent() string {
 }
 
 func (b *BuildInfo) checkVersion(ctx context.Context) {
-	cmd := extractMeta(ctx).command
-	cmdDisableCheckVersion := cmd != nil && cmd.DisableVersionCheck
-	if !b.IsRelease() || ExtractEnv(ctx, scwDisableCheckVersionEnv) == "true" || cmdDisableCheckVersion {
+	if !b.IsRelease() || ExtractEnv(ctx, scwDisableCheckVersionEnv) == "true" {
 		ExtractLogger(ctx).Debug("skipping check version")
-		return
-	}
-
-	latestVersionUpdateFilePath := getLatestVersionUpdateFilePath(ExtractCacheDir(ctx))
-
-	// do nothing if last refresh at during the last 24h
-	if wasFileModifiedLast24h(latestVersionUpdateFilePath) {
-		ExtractLogger(ctx).Debug("version was already checked during past 24 hours")
-		return
-	}
-
-	// do nothing if we cannot create the file
-	err := createAndCloseFile(latestVersionUpdateFilePath)
-	if err != nil {
-		ExtractLogger(ctx).Debug(err.Error())
 		return
 	}
 
@@ -87,14 +67,10 @@ func (b *BuildInfo) checkVersion(ctx context.Context) {
 	}
 
 	if b.Version.LessThan(latestVersion) {
-		ExtractLogger(ctx).Warningf("a new version of scw is available (%s), beware that you are currently running %s\n", latestVersion, b.Version)
+		ExtractLogger(ctx).Warningf("A new version of scw is available (%s), beware that you are currently running %s\n", latestVersion, b.Version)
 	} else {
 		ExtractLogger(ctx).Debugf("version is up to date (%s)\n", b.Version)
 	}
-}
-
-func getLatestVersionUpdateFilePath(cacheDir string) string {
-	return filepath.Join(cacheDir, latestVersionUpdateFileLocalName)
 }
 
 // getLatestVersion attempt to read the latest version of the remote file at latestVersionFileURL.
@@ -128,30 +104,4 @@ func getLatestVersion(client *http.Client) (*version.Version, error) {
 	}
 
 	return version.NewSemver(strings.TrimPrefix(jsonBody.TagName, "v"))
-}
-
-// wasFileModifiedLast24h checks whether the file has been updated during last 24 hours.
-func wasFileModifiedLast24h(path string) bool {
-	stat, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-
-	yesterday := time.Now().AddDate(0, 0, -1)
-	lastUpdate := stat.ModTime()
-	return lastUpdate.After(yesterday)
-}
-
-// createAndCloseFile creates a file and closes it. It returns true on succeed, false on failure.
-func createAndCloseFile(path string) error {
-	err := os.MkdirAll(filepath.Dir(path), 0700)
-	if err != nil {
-		return fmt.Errorf("failed creating path %s: %s", path, err)
-	}
-	newFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
-	if err != nil {
-		return fmt.Errorf("failed creating file %s: %s", path, err)
-	}
-
-	return newFile.Close()
 }

--- a/internal/core/build_info_test.go
+++ b/internal/core/build_info_test.go
@@ -33,7 +33,7 @@ func Test_CheckVersion(t *testing.T) {
 		Cmd: "scw plop",
 		Check: TestCheckCombine(
 			func(t *testing.T, ctx *CheckFuncCtx) {
-				assert.Equal(t, "a new version of scw is available (2.5.4), beware that you are currently running 1.20.0\n", ctx.LogBuffer)
+				assert.Equal(t, "A new version of scw is available (2.5.4), beware that you are currently running 1.20.0\n", ctx.LogBuffer)
 			},
 		),
 		TmpHomeDir: true,
@@ -85,7 +85,7 @@ func Test_CheckVersion(t *testing.T) {
 		Cmd: "scw plop",
 		Check: TestCheckCombine(
 			func(t *testing.T, ctx *CheckFuncCtx) {
-				assert.Contains(t, ctx.LogBuffer, "a new version of scw is available (2.5.4), beware that you are currently running 1.0.0\n")
+				assert.Contains(t, ctx.LogBuffer, "A new version of scw is available (2.5.4), beware that you are currently running 1.0.0\n")
 			},
 		),
 		TmpHomeDir: true,

--- a/internal/core/checks.go
+++ b/internal/core/checks.go
@@ -92,7 +92,7 @@ func checkAPIKey(ctx context.Context) {
 	apiKey, err := api.GetAPIKey(&iam.GetAPIKeyRequest{
 		AccessKey: accessKey,
 	})
-	if err != nil {
+	if err != nil || apiKey.ExpiresAt == nil {
 		return
 	}
 	now := time.Now()

--- a/internal/core/checks.go
+++ b/internal/core/checks.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+)
+
+var (
+	apiKeyExpireTime        = 24 * time.Hour
+	lastChecksFileLocalName = "last-cli-checks"
+)
+
+type AfterCommandCheckFunc func(ctx context.Context)
+
+// wasFileModifiedLast24h checks whether the file has been updated during last 24 hours.
+func wasFileModifiedLast24h(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	lastUpdate := stat.ModTime()
+	return lastUpdate.After(yesterday)
+}
+
+func getLatestVersionUpdateFilePath(cacheDir string) string {
+	return filepath.Join(cacheDir, lastChecksFileLocalName)
+}
+
+// createAndCloseFile creates a file and closes it. It returns true on succeed, false on failure.
+func createAndCloseFile(path string) error {
+	err := os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil {
+		return fmt.Errorf("failed creating path %s: %s", path, err)
+	}
+	newFile, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("failed creating file %s: %s", path, err)
+	}
+
+	return newFile.Close()
+}
+
+// runAfterCommandChecks execute checks after a command has been executed
+// skipped if command has disabled checks or was executed in the last 24 hours
+func runAfterCommandChecks(ctx context.Context, checkFuncs ...AfterCommandCheckFunc) {
+	cmd := extractMeta(ctx).command
+	cmdDisableCheck := cmd != nil && cmd.DisableAfterChecks
+	if cmdDisableCheck {
+		ExtractLogger(ctx).Debug("skipping after command checks")
+		return
+	}
+
+	lastChecksFilePath := getLatestVersionUpdateFilePath(ExtractCacheDir(ctx))
+
+	// do nothing if last refresh at during the last 24h
+	if wasFileModifiedLast24h(lastChecksFilePath) {
+		ExtractLogger(ctx).Debug("version was already checked during past 24 hours")
+		return
+	}
+
+	// do nothing if we cannot create the file
+	err := createAndCloseFile(lastChecksFilePath)
+	if err != nil {
+		ExtractLogger(ctx).Debug(err.Error())
+		return
+	}
+
+	for _, checkFunc := range checkFuncs {
+		checkFunc(ctx)
+	}
+}
+
+// Check if API Key is about to expire
+func checkAPIKey(ctx context.Context) {
+	client := ExtractClient(ctx)
+	if client == nil {
+		return
+	}
+	accessKey, exists := client.GetAccessKey()
+	if !exists {
+		return
+	}
+
+	api := iam.NewAPI(client)
+	apiKey, err := api.GetAPIKey(&iam.GetAPIKeyRequest{
+		AccessKey: accessKey,
+	})
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	if apiKey.ExpiresAt.Before(now.Add(apiKeyExpireTime)) {
+		expiresIn := apiKey.ExpiresAt.Sub(now).Truncate(time.Second).String()
+		ExtractLogger(ctx).Warningf("Current api key expires in %s\n", expiresIn)
+	}
+}

--- a/internal/core/checks_test.go
+++ b/internal/core/checks_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func TestCheckAPIKey(t *testing.T) {
+	testCommands := NewCommands(
+		&Command{
+			Namespace: "test",
+			ArgSpecs:  ArgSpecs{},
+			ArgsType:  reflect.TypeOf(testType{}),
+			Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {
+				// Test command reload the client so the profile used is the edited one
+				return "", ReloadClient(ctx)
+			},
+		})
+	metadataKey := "ApiKey"
+
+	t.Run("basic", Test(&TestConfig{
+		Commands:   testCommands,
+		TmpHomeDir: true,
+		BeforeFunc: func(ctx *BeforeFuncCtx) error {
+			api := iam.NewAPI(ctx.Client)
+			accessKey, exists := ctx.Client.GetAccessKey()
+			if !exists {
+				return fmt.Errorf("missing access-key")
+			}
+
+			apiKey, err := api.GetAPIKey(&iam.GetAPIKeyRequest{
+				AccessKey: accessKey,
+			})
+			if err != nil {
+				return err
+			}
+			expiresAt := time.Now().Add(time.Hour)
+			apiKey, err = api.CreateAPIKey(&iam.CreateAPIKeyRequest{
+				ApplicationID: apiKey.ApplicationID,
+				UserID:        apiKey.UserID,
+				ExpiresAt:     &expiresAt,
+				Description:   "test-cli-TestCheckAPIKey",
+			})
+			if err != nil {
+				return err
+			}
+			if !*UpdateCassettes {
+				apiKey.AccessKey = "SCWXXXXXXXXXXXXXXXXX"
+			}
+
+			ctx.Meta[metadataKey] = apiKey
+			cfg := &scw.Config{
+				Profile: scw.Profile{
+					AccessKey: &apiKey.AccessKey,
+					SecretKey: apiKey.SecretKey,
+				},
+			}
+			configPath := filepath.Join(ctx.OverrideEnv["HOME"], ".config", "scw", "config.yaml")
+
+			return cfg.SaveTo(configPath)
+		},
+		Cmd: "scw test",
+		Check: TestCheckCombine(
+			TestCheckExitCode(0),
+			func(t *testing.T, ctx *CheckFuncCtx) {
+				assert.True(t, strings.HasPrefix(ctx.LogBuffer, "Current api key expires in"))
+			},
+		),
+		AfterFunc: func(ctx *AfterFuncCtx) error {
+			return iam.NewAPI(ctx.Client).DeleteAPIKey(&iam.DeleteAPIKeyRequest{
+				AccessKey: ctx.Meta[metadataKey].(*iam.APIKey).AccessKey,
+			})
+		},
+	}))
+}

--- a/internal/core/cobra_utils_test.go
+++ b/internal/core/cobra_utils_test.go
@@ -125,14 +125,6 @@ Relative time error: unknown unit in duration: "R"
 }
 
 func Test_RawArgs(t *testing.T) {
-	t.Run("Simple", Test(&TestConfig{
-		Commands: testGetCommands(),
-		Cmd:      "scw test raw-args -- blabla",
-		Check: TestCheckCombine(
-			TestCheckExitCode(0),
-			TestCheckStdout("blabla\n"),
-		),
-	}))
 	t.Run("Multiple", Test(&TestConfig{
 		Commands: testGetCommands(),
 		Cmd:      "scw test raw-args -- blabla foo bar",

--- a/internal/core/cobra_utils_test.go
+++ b/internal/core/cobra_utils_test.go
@@ -125,6 +125,14 @@ Relative time error: unknown unit in duration: "R"
 }
 
 func Test_RawArgs(t *testing.T) {
+	t.Run("Simple", Test(&TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test raw-args -- blabla",
+		Check: TestCheckCombine(
+			TestCheckExitCode(0),
+			TestCheckStdout("blabla\n"),
+		),
+	}))
 	t.Run("Multiple", Test(&TestConfig{
 		Commands: testGetCommands(),
 		Cmd:      "scw test raw-args -- blabla foo bar",

--- a/internal/core/command.go
+++ b/internal/core/command.go
@@ -35,8 +35,8 @@ type Command struct {
 	// DisableTelemetry disable telemetry for the command.
 	DisableTelemetry bool
 
-	// DisableVersionCheck disable the version check to avoid superfluous message
-	DisableVersionCheck bool
+	// DisableAfterChecks disable checks that run after the command to avoid superfluous message
+	DisableAfterChecks bool
 
 	// Hidden hides the command form usage and auto-complete.
 	Hidden bool

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -191,11 +191,6 @@ func ExtractCliConfigPath(ctx context.Context) string {
 func ReloadClient(ctx context.Context) error {
 	var err error
 	meta := extractMeta(ctx)
-	// if client is from bootstrap we are probably running test
-	// if we reload the client we loose the cassette recorder
-	if meta.isClientFromBootstrapConfig {
-		return nil
-	}
 	meta.Client, err = createClient(ctx, meta.httpClient, meta.BuildInfo, ExtractProfileName(ctx))
 	return err
 }

--- a/internal/core/testdata/test-check-api-key-basic.cassette.yaml
+++ b/internal/core/testdata/test-check-api-key-basic.cassette.yaml
@@ -1,0 +1,131 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"access_key":"SCWQN1ZYHWPFGJD28Q70","secret_key":null,"description":"iam","created_at":"2022-08-22T09:13:42.922733Z","updated_at":"2022-10-20T08:29:52.752429Z","expires_at":null,"default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","editable":true,"creation_ip":"51.159.73.9","user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    headers:
+      Content-Length:
+      - "332"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 21 Apr 2023 08:49:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 634498cb-4310-4fde-bb42-5837a80a83e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b","expires_at":"2023-04-21T11:49:57.648653377+02:00","default_project_id":null,"description":"test-cli-TestCheckAPIKey"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys
+    method: POST
+  response:
+    body: '{"access_key":"SCWSSR032HM4AQTGK4XM","secret_key":"11111111-1111-1111-1111-111111111111","description":"test-cli-TestCheckAPIKey","created_at":"2023-04-21T08:49:57.791116Z","updated_at":"2023-04-21T08:49:57.791116Z","expires_at":"2023-04-21T09:49:57.648653Z","default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","editable":true,"creation_ip":"51.159.73.9","user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    headers:
+      Content-Length:
+      - "412"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 21 Apr 2023 08:49:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f05522cd-b4c9-4abf-9b7a-f044d242210e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) scaleway-cli/0.0.0+test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"access_key":"SCWSSR032HM4AQTGK4XM","secret_key":null,"description":"test-cli-TestCheckAPIKey","created_at":"2023-04-21T08:49:57.791116Z","updated_at":"2023-04-21T08:49:57.791116Z","expires_at":"2023-04-21T09:49:57.648653Z","default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","editable":true,"creation_ip":"51.159.73.9","user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 21 Apr 2023 08:49:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9820373b-2b5d-4282-a0ed-00b2c4b95961
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 21 Apr 2023 08:49:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56eb4536-35a7-46de-8bba-a05f3bc0aaf7
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/internal/core/testdata/test-check-api-key-basic.golden
+++ b/internal/core/testdata/test-check-api-key-basic.golden
@@ -1,0 +1,5 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+-
+🟩🟩🟩 JSON STDOUT 🟩🟩🟩
+""

--- a/internal/core/testing.go
+++ b/internal/core/testing.go
@@ -18,8 +18,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/dnaeon/go-vcr/cassette"
-	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/hashicorp/go-version"
 	args "github.com/scaleway/scaleway-cli/v2/internal/args"
 	"github.com/scaleway/scaleway-cli/v2/internal/human"
@@ -684,46 +682,6 @@ var regTimestamp = regexp.MustCompile(`(\d+-\d+-\d+T\d+:\d+:\d+\.\d+Z)`)
 // uniformTimestamps replaces all timestamp to the date "1970-01-01T00:00:00.0Z"
 func uniformTimestamps(input string) string {
 	return regTimestamp.ReplaceAllString(input, "1970-01-01T00:00:00.0Z")
-}
-
-// getHTTPRecoder creates a new httpClient that records all HTTP requests in a cassette.
-// This cassette is then replayed whenever tests are executed again. This means that once the
-// requests are recorded in the cassette, no more real HTTP request must be made to run the tests.
-//
-// It is important to call add a `defer cleanup()` so the given cassette files are correctly
-// closed and saved after the requests.
-func getHTTPRecoder(t *testing.T, update bool) (client *http.Client, cleanup func(), err error) {
-	recorderMode := recorder.ModeReplaying
-	if update {
-		recorderMode = recorder.ModeRecording
-	}
-
-	// Setup recorder and scw client
-	r, err := recorder.NewAsMode(getTestFilePath(t, ".cassette"), recorderMode, &SocketPassthroughTransport{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Add a filter which removes Authorization headers from all requests:
-	r.AddFilter(func(i *cassette.Interaction) error {
-		delete(i.Request.Headers, "x-auth-token")
-		delete(i.Request.Headers, "X-Auth-Token")
-		i.Request.URL = regexp.MustCompile("organization_id=[0-9a-f-]{36}").ReplaceAllString(i.Request.URL, "organization_id=11111111-1111-1111-1111-111111111111")
-		i.Request.URL = regexp.MustCompile(`api\.scaleway\.com/account/v1/tokens/[0-9a-f-]{36}`).ReplaceAllString(i.Request.URL, "api.scaleway.com/account/v1/tokens/11111111-1111-1111-1111-111111111111")
-		return nil
-	})
-
-	r.SetMatcher(func(r *http.Request, i cassette.Request) bool {
-		if r.URL.Host == "//./pipe/docker_engine" {
-			r.URL.Host = "/var/run/docker.sock"
-		}
-
-		return cassette.DefaultMatcher(r, i)
-	})
-
-	return &http.Client{Transport: &retryableHTTPTransport{transport: r}}, func() {
-		assert.NoError(t, r.Stop()) // Make sure recorder is stopped once done with it
-	}, nil
 }
 
 func validateJSONGolden(t *testing.T, jsonStdout, jsonStderr *bytes.Buffer) {

--- a/internal/core/testing_recorder.go
+++ b/internal/core/testing_recorder.go
@@ -1,0 +1,66 @@
+package core
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
+)
+
+func cassetteRequestFilter(i *cassette.Interaction) error {
+	delete(i.Request.Headers, "x-auth-token")
+	delete(i.Request.Headers, "X-Auth-Token")
+	i.Request.URL = regexp.MustCompile("organization_id=[0-9a-f-]{36}").ReplaceAllString(i.Request.URL, "organization_id=11111111-1111-1111-1111-111111111111")
+	i.Request.URL = regexp.MustCompile(`api\.scaleway\.com/account/v1/tokens/[0-9a-f-]{36}`).ReplaceAllString(i.Request.URL, "api.scaleway.com/account/v1/tokens/11111111-1111-1111-1111-111111111111")
+	i.Request.URL = regexp.MustCompile(`api\.scaleway\.com/iam/v1alpha1/api-keys/SCW[0-9A-Z]{17}`).ReplaceAllString(i.Request.URL, "api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX")
+
+	return nil
+}
+
+func cassetteResponseFilter(i *cassette.Interaction) error {
+	i.Response.Body = regexp.MustCompile(`"secret_key":"[0-9a-f-]{36}"`).ReplaceAllString(i.Response.Body, `"secret_key":"11111111-1111-1111-1111-111111111111"`)
+
+	return nil
+}
+
+func cassetteMatcher(r *http.Request, i cassette.Request) bool {
+	if r.URL.Host == "//./pipe/docker_engine" {
+		r.URL.Host = "/var/run/docker.sock"
+	}
+
+	return cassette.DefaultMatcher(r, i)
+}
+
+// getHTTPRecoder creates a new httpClient that records all HTTP requests in a cassette.
+// This cassette is then replayed whenever tests are executed again. This means that once the
+// requests are recorded in the cassette, no more real HTTP request must be made to run the tests.
+//
+// It is important to call add a `defer cleanup()` so the given cassette files are correctly
+// closed and saved after the requests.
+func getHTTPRecoder(t *testing.T, update bool) (client *http.Client, cleanup func(), err error) {
+	recorderMode := recorder.ModeReplaying
+	if update {
+		recorderMode = recorder.ModeRecording
+	}
+
+	// Setup recorder and scw client
+	r, err := recorder.NewAsMode(getTestFilePath(t, ".cassette"), recorderMode, &SocketPassthroughTransport{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add a filter which removes Authorization headers from all requests:
+	r.AddFilter(cassetteRequestFilter)
+
+	// Remove secrets from response
+	r.AddSaveFilter(cassetteResponseFilter)
+
+	r.SetMatcher(cassetteMatcher)
+
+	return &http.Client{Transport: &retryableHTTPTransport{transport: r}}, func() {
+		assert.NoError(t, r.Stop()) // Make sure recorder is stopped once done with it
+	}, nil
+}

--- a/internal/namespaces/autocomplete/autocomplete.go
+++ b/internal/namespaces/autocomplete/autocomplete.go
@@ -29,7 +29,7 @@ func GetCommands() *core.Commands {
 	)
 
 	for _, cmd := range cmds.GetAll() {
-		cmd.DisableVersionCheck = true
+		cmd.DisableAfterChecks = true
 	}
 
 	return cmds

--- a/internal/namespaces/init/testdata/test-init-ssh-key-registered.cassette.yaml
+++ b/internal/namespaces/init/testdata/test-init-ssh-key-registered.cassette.yaml
@@ -3,19 +3,19 @@ version: 1
 interactions:
 - request:
     body: '{"name":"test-cli-KeyRegistered","public_key":"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICd8ZxAm9mXQsRHhQ5iADEJuO+Ai8EbXMI7TIlsh9jbE
-      foobar@foobar","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a"}'
+      foobar@foobar","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/iam/v1alpha1/ssh-keys
     method: POST
   response:
-    body: '{"id":"b5031816-c15a-4b0a-945d-e22b60228077","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
+    body: '{"id":"21ea18df-6e8d-4808-a80a-602a292eda69","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
       AAAAC3NzaC1lZDI1NTE5AAAAICd8ZxAm9mXQsRHhQ5iADEJuO+Ai8EbXMI7TIlsh9jbE foobar@foobar","fingerprint":"256
-      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.370383Z","updated_at":"2023-02-20T14:47:54.370383Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false}'
+      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-04-21T09:10:01.614443Z","updated_at":"2023-04-21T09:10:01.614443Z","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","disabled":false}'
     headers:
       Content-Length:
       - "499"
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Feb 2023 14:47:54 GMT
+      - Fri, 21 Apr 2023 09:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e7c379f-9bc5-4649-a4d3-ea4e392d5f39
+      - 28fb38c2-dbfe-4eb3-bf15-572a2c7eaa74
     status: 200 OK
     code: 200
     duration: ""
@@ -43,20 +43,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
     method: GET
   response:
-    body: '{"access_key":"SCWXXXXXXXXXXXXXXXXX","secret_key":null,"description":"default","created_at":"2023-02-08T13:37:42.867291Z","updated_at":"2023-02-08T13:37:42.867291Z","expires_at":null,"default_project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","editable":true,"creation_ip":"195.154.228.158","user_id":"284d6fc3-6cf7-485b-bd32-efa92c2335d9"}'
+    body: '{"access_key":"SCWQN1ZYHWPFGJD28Q70","secret_key":null,"description":"iam","created_at":"2022-08-22T09:13:42.922733Z","updated_at":"2022-10-20T08:29:52.752429Z","expires_at":null,"default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","editable":true,"creation_ip":"51.159.73.9","user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
     headers:
       Content-Length:
-      - "340"
+      - "332"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Feb 2023 14:47:54 GMT
+      - Fri, 21 Apr 2023 09:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -66,7 +66,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71db8764-daa2-4be0-a4bb-57f115acaa87
+      - 79b1afce-964a-4689-a32b-4f854c3ca4b9
     status: 200 OK
     code: 200
     duration: ""
@@ -75,27 +75,57 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"access_key":"SCWQN1ZYHWPFGJD28Q70","secret_key":null,"description":"iam","created_at":"2022-08-22T09:13:42.922733Z","updated_at":"2022-10-20T08:29:52.752429Z","expires_at":null,"default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","editable":true,"creation_ip":"51.159.73.9","user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    headers:
+      Content-Length:
+      - "332"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 21 Apr 2023 09:10:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fa092b4-0a92-449e-85e0-30b778d0812f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) scaleway-cli/0.0.0+test
     url: https://api.scaleway.com/iam/v1alpha1/ssh-keys?order_by=created_at_asc&page=1
     method: GET
   response:
-    body: '{"ssh_keys":[{"id":"70581bce-87f3-4625-b481-f75b24e52a3b","name":"key-keen-elgamal","public_key":"ecdsa-sha2-nistp256
-      AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBieay3nO9wViPkuvFVgGGaA1IRlkFrr946yqvg9LxZIRhsnZ61yLCPmIOhvUAZ/gTxZGmhgtMDxkenSUTsG3F0=
-      foobar@foobar","fingerprint":"256 MD5:19:ec:90:3b:95:c6:d8:93:ac:e1:14:4c:0e:cb:ea:44
-      foobar@foobar (ecdsa-sha2-nistp256)","created_at":"2023-02-15T16:02:46.819741Z","updated_at":"2023-02-15T16:02:46.819741Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"b5031816-c15a-4b0a-945d-e22b60228077","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
+    body: '{"ssh_keys":[{"id":"8c522499-5fb5-40db-9e3e-da462c636d21","name":"key-angry-cori","public_key":"ssh-rsa
+      AAAAB3NzaC1yc2EAAAADAQABAAABgQC5879tw+nxTLhH7u8FNuRoXFQpxpafuMiNUatkYtmJfpzDaj+KF71/2bcxEtSKGmppyQW/WiP5aam2fSrAUY93FAgCdjQ47XvNoYZi3H9NlSjYUdQvp7+1lfagVWttojbU/kqCVLo/qKsPcKsEiYwxQyg1K0xvpNT7FOOgGQ423MKiTU81nj3sxmgFnCkLMT6DoLRhia7EWvXc3zkMvdWMUAL8q+JEC2KtNvXg0lxCHuQXBbGvj/CEx+lkGXNGpk8OneGTzxgyBghENLmyfcYj7fgV7frtu/DzjtS7v/8YwEXM8vPyhBiSVN9lL5RYGKv4GmlJ596p7GubIYeTLDehjpy5PO0ivo8Cf+XGRDLd4VNNs464AWum4+nFYVu4aGA76otwpWv4t0CcygZoqjjFBTQguvCRK80Uxvbw8g+C6qafLcIA62d29KZWap0V/IPP1O8T0A7CSBJfjx3fOjGhQitwAyLdKDO5p+9WlFWutT/TTQ0Aaqsm3kZYVydi7ac=
+      julescasteran@fedora","fingerprint":"3072 MD5:9b:49:f8:06:04:c8:40:ab:75:6b:96:9c:f8:a8:bf:a8
+      julescasteran@fedora (ssh-rsa)","created_at":"2023-04-04T07:29:12.897933Z","updated_at":"2023-04-04T07:29:12.897933Z","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","disabled":false},{"id":"21ea18df-6e8d-4808-a80a-602a292eda69","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
       AAAAC3NzaC1lZDI1NTE5AAAAICd8ZxAm9mXQsRHhQ5iADEJuO+Ai8EbXMI7TIlsh9jbE foobar@foobar","fingerprint":"256
-      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.370383Z","updated_at":"2023-02-20T14:47:54.370383Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"cb3d0e42-1441-4b90-89a7-74ff85ea5f4e","name":"key-nostalgic-kalam","public_key":"ssh-ed25519
-      AAAAC3NzaC1lZDI1NTE5AAAAIIQE67HxSRicWd4ol7ntM2jdeD/qEehPJxK/3thmMiZg foobar@foobar","fingerprint":"256
-      MD5:ea:c1:a1:82:4b:41:2b:65:26:9c:18:27:da:0d:bd:91 foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.460075Z","updated_at":"2023-02-20T14:47:54.460075Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"34caa2f1-cd4c-4cbe-b315-2522ac7925e6","name":"key-friendly-kare","public_key":"ssh-ed25519
-      AAAAC3NzaC1lZDI1NTE5AAAAIIQE67HxSRicWd4ol7ntM2jdeD/qEehPJxK/3thmMiZg foobar@foobar","fingerprint":"256
-      MD5:ea:c1:a1:82:4b:41:2b:65:26:9c:18:27:da:0d:bd:91 foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.461997Z","updated_at":"2023-02-20T14:47:54.461997Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false}],"total_count":4}'
+      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-04-21T09:10:01.614443Z","updated_at":"2023-04-21T09:10:01.614443Z","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","disabled":false}],"total_count":2}'
     headers:
+      Content-Length:
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Feb 2023 14:47:54 GMT
+      - Fri, 21 Apr 2023 09:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -105,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1d441ad-f59f-4eb5-aa64-dc45779aea25
+      - d3776df6-2d7a-4622-9774-80b13831f98d
     status: 200 OK
     code: 200
     duration: ""
@@ -114,27 +144,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/iam/v1alpha1/ssh-keys?order_by=created_at_asc&page=1
     method: GET
   response:
-    body: '{"ssh_keys":[{"id":"70581bce-87f3-4625-b481-f75b24e52a3b","name":"key-keen-elgamal","public_key":"ecdsa-sha2-nistp256
-      AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBBieay3nO9wViPkuvFVgGGaA1IRlkFrr946yqvg9LxZIRhsnZ61yLCPmIOhvUAZ/gTxZGmhgtMDxkenSUTsG3F0=
-      foobar@foobar","fingerprint":"256 MD5:19:ec:90:3b:95:c6:d8:93:ac:e1:14:4c:0e:cb:ea:44
-      foobar@foobar (ecdsa-sha2-nistp256)","created_at":"2023-02-15T16:02:46.819741Z","updated_at":"2023-02-15T16:02:46.819741Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"b5031816-c15a-4b0a-945d-e22b60228077","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
+    body: '{"ssh_keys":[{"id":"8c522499-5fb5-40db-9e3e-da462c636d21","name":"key-angry-cori","public_key":"ssh-rsa
+      AAAAB3NzaC1yc2EAAAADAQABAAABgQC5879tw+nxTLhH7u8FNuRoXFQpxpafuMiNUatkYtmJfpzDaj+KF71/2bcxEtSKGmppyQW/WiP5aam2fSrAUY93FAgCdjQ47XvNoYZi3H9NlSjYUdQvp7+1lfagVWttojbU/kqCVLo/qKsPcKsEiYwxQyg1K0xvpNT7FOOgGQ423MKiTU81nj3sxmgFnCkLMT6DoLRhia7EWvXc3zkMvdWMUAL8q+JEC2KtNvXg0lxCHuQXBbGvj/CEx+lkGXNGpk8OneGTzxgyBghENLmyfcYj7fgV7frtu/DzjtS7v/8YwEXM8vPyhBiSVN9lL5RYGKv4GmlJ596p7GubIYeTLDehjpy5PO0ivo8Cf+XGRDLd4VNNs464AWum4+nFYVu4aGA76otwpWv4t0CcygZoqjjFBTQguvCRK80Uxvbw8g+C6qafLcIA62d29KZWap0V/IPP1O8T0A7CSBJfjx3fOjGhQitwAyLdKDO5p+9WlFWutT/TTQ0Aaqsm3kZYVydi7ac=
+      julescasteran@fedora","fingerprint":"3072 MD5:9b:49:f8:06:04:c8:40:ab:75:6b:96:9c:f8:a8:bf:a8
+      julescasteran@fedora (ssh-rsa)","created_at":"2023-04-04T07:29:12.897933Z","updated_at":"2023-04-04T07:29:12.897933Z","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","disabled":false},{"id":"21ea18df-6e8d-4808-a80a-602a292eda69","name":"test-cli-KeyRegistered","public_key":"ssh-ed25519
       AAAAC3NzaC1lZDI1NTE5AAAAICd8ZxAm9mXQsRHhQ5iADEJuO+Ai8EbXMI7TIlsh9jbE foobar@foobar","fingerprint":"256
-      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.370383Z","updated_at":"2023-02-20T14:47:54.370383Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"cb3d0e42-1441-4b90-89a7-74ff85ea5f4e","name":"key-nostalgic-kalam","public_key":"ssh-ed25519
-      AAAAC3NzaC1lZDI1NTE5AAAAIIQE67HxSRicWd4ol7ntM2jdeD/qEehPJxK/3thmMiZg foobar@foobar","fingerprint":"256
-      MD5:ea:c1:a1:82:4b:41:2b:65:26:9c:18:27:da:0d:bd:91 foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.460075Z","updated_at":"2023-02-20T14:47:54.460075Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false},{"id":"34caa2f1-cd4c-4cbe-b315-2522ac7925e6","name":"key-friendly-kare","public_key":"ssh-ed25519
-      AAAAC3NzaC1lZDI1NTE5AAAAIIQE67HxSRicWd4ol7ntM2jdeD/qEehPJxK/3thmMiZg foobar@foobar","fingerprint":"256
-      MD5:ea:c1:a1:82:4b:41:2b:65:26:9c:18:27:da:0d:bd:91 foobar@foobar (ssh-ed25519)","created_at":"2023-02-20T14:47:54.461997Z","updated_at":"2023-02-20T14:47:54.461997Z","organization_id":"63a66ec9-a385-4194-bc15-04aa6921274a","project_id":"63a66ec9-a385-4194-bc15-04aa6921274a","disabled":false}],"total_count":4}'
+      MD5:2e:c9:d3:87:1c:04:5f:c8:86:0c:08:4d:34:3f:ff:4c foobar@foobar (ssh-ed25519)","created_at":"2023-04-21T09:10:01.614443Z","updated_at":"2023-04-21T09:10:01.614443Z","organization_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","disabled":false}],"total_count":2}'
     headers:
+      Content-Length:
+      - "1505"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Feb 2023 14:47:54 GMT
+      - Fri, 21 Apr 2023 09:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -144,7 +172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 049136e6-a318-4de7-ac8c-717b8bc067d4
+      - 743f40d2-ca7e-4d7c-be18-96ef1ede546a
     status: 200 OK
     code: 200
     duration: ""
@@ -153,8 +181,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.19; darwin; amd64) cli-e2e-test
-    url: https://api.scaleway.com/iam/v1alpha1/ssh-keys/b5031816-c15a-4b0a-945d-e22b60228077
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/ssh-keys/21ea18df-6e8d-4808-a80a-602a292eda69
     method: DELETE
   response:
     body: ""
@@ -164,7 +192,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 20 Feb 2023 14:47:54 GMT
+      - Fri, 21 Apr 2023 09:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -174,7 +202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b5837ba-8a71-4d99-91f5-1b80cb2a6296
+      - 2895ae0f-36bd-4538-98a1-aa7be19f1676
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
Closes #2648 

Checks example:
```
A new version of scw is available (2.14.0), beware that you are currently running 2.13.0
Current api key expires in 32m43s
```