### PR TITLE
feat(init): no overwrite prompt when adding a new profile

### DIFF
--- a/internal/namespaces/init/init.go
+++ b/internal/namespaces/init/init.go
@@ -136,7 +136,12 @@ Default path for configuration file is based on the following priority order:
 			// Show logo banner, or simple welcome message
 			printScalewayBanner()
 
-			err := promptProfileOverride(ctx, configPath, profileName)
+			config, err := loadConfigOrEmpty(configPath)
+			if err != nil {
+				return nil, err
+			}
+
+			err = promptProfileOverride(ctx, config, configPath, profileName)
 			if err != nil {
 				return nil, err
 			}
@@ -213,11 +218,6 @@ Default path for configuration file is based on the following priority order:
 				DefaultRegion:         scw.StringPtr(args.Region.String()),
 				DefaultOrganizationID: &args.OrganizationID,
 				DefaultProjectID:      &args.ProjectID, // An API key is always bound to a project.
-			}
-
-			config, err := loadConfigOrEmpty(configPath)
-			if err != nil {
-				return nil, err
 			}
 
 			// Save the profile as default or as a named profile

--- a/internal/namespaces/init/prompt.go
+++ b/internal/namespaces/init/prompt.go
@@ -163,15 +163,22 @@ func promptDefaultZone(ctx context.Context) (scw.Zone, error) {
 	return scw.ParseZone(zone)
 }
 
-// promptProfileOverride prompt user if profileName is getting override in configPath
-func promptProfileOverride(ctx context.Context, configPath string, profileName string) error {
-	config, err := scw.LoadConfigFromPath(configPath)
+// promptProfileOverride prompt user if profileName is getting override in config
+func promptProfileOverride(ctx context.Context, config *scw.Config, configPath string, profileName string) error {
+	var profile *scw.Profile
+	var profileExists bool
 
-	// If it is not a new config, ask if we want to override the existing config
-	if err == nil && !config.IsEmpty() {
+	if profileName == scw.DefaultProfileName {
+		profile = &config.Profile
+		profileExists = true
+	} else {
+		profile, profileExists = config.Profiles[profileName]
+	}
+
+	if !config.IsEmpty() && profileExists {
 		_, _ = interactive.PrintlnWithoutIndent(`
 					Current config is located at ` + configPath + `
-					` + terminal.Style(fmt.Sprint(config), color.Faint) + `
+					` + terminal.Style(fmt.Sprint(profile), color.Faint) + `
 				`)
 		overrideConfig, err := interactive.PromptBoolWithConfig(&interactive.PromptBoolConfig{
 			Prompt:       fmt.Sprintf("Do you want to override the current profile (%s) ?", profileName),

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-no-prompt-overwrite-for-new-profile.cassette.yaml
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-no-prompt-overwrite-for-new-profile.cassette.yaml
@@ -1,0 +1,35 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"message":"authentication is denied","method":"api_key","reason":"not_found","type":"denied_authentication"}'
+    headers:
+      Content-Length:
+      - "109"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 27 Apr 2023 09:09:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4765a621-1ac1-4a7f-bdb4-4602f94764eb
+    status: 401 Unauthorized
+    code: 401
+    duration: ""

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-no-prompt-overwrite-for-new-profile.golden
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-no-prompt-overwrite-for-new-profile.golden
@@ -1,0 +1,8 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+✅ Initialization completed with success.
+🟩🟩🟩 JSON STDOUT 🟩🟩🟩
+{
+  "message": "Initialization completed with success",
+  "details": ""
+}

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-prompt-overwrite-for-existing-profile.cassette.yaml
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-prompt-overwrite-for-existing-profile.cassette.yaml
@@ -1,0 +1,35 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"message":"authentication is denied","method":"api_key","reason":"not_found","type":"denied_authentication"}'
+    headers:
+      Content-Length:
+      - "109"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 27 Apr 2023 09:09:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 314626bd-48a4-4e66-91bc-7a31b3f17210
+    status: 401 Unauthorized
+    code: 401
+    duration: ""

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-prompt-overwrite-for-existing-profile.golden
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-prompt-overwrite-for-existing-profile.golden
@@ -1,0 +1,7 @@
+🎲🎲🎲 EXIT CODE: 1 🎲🎲🎲
+🟥🟥🟥 STDERR️️ 🟥🟥🟥️
+Initialization canceled
+🟥🟥🟥 JSON STDERR 🟥🟥🟥
+{
+  "error": "initialization canceled"
+}


### PR DESCRIPTION
Improvement for init rework #2792 
Lookup https://github.com/scaleway/scaleway-cli/issues/2792#issuecomment-1520057224

Now we get an override prompt only when doing init for an existing profile. There is not prompt for `scw init -p mynewprofile`
Also the override prompt has changed, it only print the profile that will be override instead of the whole config