### PR TITLE
[doc] add missing param on upgrade pool command example

### DIFF
--- a/docs/commands/k8s.md
+++ b/docs/commands/k8s.md
@@ -1012,7 +1012,7 @@ scw k8s pool upgrade <pool-id ...> [arg=value ...]
 
 Upgrade a specific pool to the Kubernetes version 1.24.7
 ```
-scw k8s pool upgrade 11111111-1111-1111-111111111111 version=1.24.7
+scw k8s pool upgrade 11111111-1111-1111-111111111111 region=fr-par version=1.24.7 
 ```
 
 


### PR DESCRIPTION
The parameter region is mandatory on upgrade pool command

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
