### PR TITLE
feat(k8s): add cluster migrate-to-private-network command

### DIFF
--- a/cmd/scw/testdata/test-all-usage-k8s-cluster-migrate-to-private-network-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-k8s-cluster-migrate-to-private-network-usage.golden
@@ -1,6 +1,6 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-Migrate a cluster that was created before the release of Private Network clusters to a new one with a Private Network.
+Migrate a cluster that was created before the release of Private Network clusters to a new one with a Private Network. If none is provided, a private network will be created
 
 USAGE:
   scw k8s cluster migrate-to-private-network <cluster-id ...> [arg=value ...]
@@ -10,9 +10,9 @@ EXAMPLES:
     scw k8s cluster migrate-to-private-network 11111111-1111-1111-111111111111 private-network-id=11111111-1111-1111-111111111111
 
 ARGS:
-  cluster-id           ID of the cluster to migrate
-  private-network-id   ID of the Private Network to link to the cluster
-  [region=fr-par]      Region to target. If none is passed will use default region from the config (fr-par | nl-ams | pl-waw)
+  cluster-id             ID of the cluster to migrate
+  [private-network-id]   ID of the Private Network to link to the cluster. If none is provided, a private network will be created
+  [region=fr-par]        Region to target. If none is passed will use default region from the config (fr-par | nl-ams | pl-waw)
 
 FLAGS:
   -h, --help   help for migrate-to-private-network

--- a/docs/commands/k8s.md
+++ b/docs/commands/k8s.md
@@ -272,7 +272,7 @@ scw k8s cluster list-available-versions 11111111-1111-1111-111111111111
 
 ### Migrate an existing cluster to a Private Network cluster
 
-Migrate a cluster that was created before the release of Private Network clusters to a new one with a Private Network.
+Migrate a cluster that was created before the release of Private Network clusters to a new one with a Private Network. If none is provided, a private network will be created
 
 **Usage:**
 
@@ -286,7 +286,7 @@ scw k8s cluster migrate-to-private-network <cluster-id ...> [arg=value ...]
 | Name |   | Description |
 |------|---|-------------|
 | cluster-id | Required | ID of the cluster to migrate |
-| private-network-id | Required | ID of the Private Network to link to the cluster |
+| private-network-id |  | ID of the Private Network to link to the cluster. If none is provided, a private network will be created |
 | region | Default: `fr-par`<br />One of: `fr-par`, `nl-ams`, `pl-waw` | Region to target. If none is passed will use default region from the config |
 
 

--- a/internal/namespaces/k8s/v1/custom.go
+++ b/internal/namespaces/k8s/v1/custom.go
@@ -36,6 +36,7 @@ func GetCommands() *core.Commands {
 	cmds.MustFind("k8s", "cluster", "update").Override(clusterUpdateBuilder)
 	cmds.MustFind("k8s", "cluster", "upgrade").Override(clusterUpgradeBuilder)
 	cmds.MustFind("k8s", "cluster", "delete").Override(clusterDeleteBuilder)
+	cmds.MustFind("k8s", "cluster", "migrate-to-private-network").Override(clusterMigrateToPrivateNetworkBuilder)
 
 	cmds.MustFind("k8s", "pool", "create").Override(poolCreateBuilder)
 	cmds.MustFind("k8s", "pool", "update").Override(poolUpdateBuilder)

--- a/internal/namespaces/k8s/v1/custom_migrate.go
+++ b/internal/namespaces/k8s/v1/custom_migrate.go
@@ -1,0 +1,95 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+
+	"github.com/scaleway/scaleway-cli/v2/internal/core"
+	"github.com/scaleway/scaleway-sdk-go/api/k8s/v1"
+	"github.com/scaleway/scaleway-sdk-go/api/vpc/v2"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func clusterMigrateToPrivateNetworkBuilder(c *core.Command) *core.Command {
+	c.ArgSpecs.GetByName("private-network-id").Required = false
+
+	infoPNID := " If none is provided, a private network will be created"
+	c.Long += infoPNID
+	c.ArgSpecs.GetByName("private-network-id").Short += "." + infoPNID
+
+	c.Run = func(ctx context.Context, args interface{}) (i interface{}, e error) {
+		request := args.(*k8s.MigrateToPrivateNetworkClusterRequest)
+		client := core.ExtractClient(ctx)
+		k8sAPI := k8s.NewAPI(client)
+		vpcAPI := vpc.NewAPI(client)
+
+		pnCreated := false
+		var pn *vpc.PrivateNetwork
+		var err error
+
+		if request.PrivateNetworkID == "" {
+			pn, err = vpcAPI.CreatePrivateNetwork(&vpc.CreatePrivateNetworkRequest{
+				Region: request.Region,
+				Tags:   []string{"created-along-with-k8s-cluster", "created-by-cli"},
+			}, scw.WithContext(ctx))
+			if err != nil {
+				return nil, err
+			}
+			request.PrivateNetworkID = pn.ID
+			pnCreated = true
+		} else {
+			pn, err = vpcAPI.GetPrivateNetwork(&vpc.GetPrivateNetworkRequest{
+				Region:           request.Region,
+				PrivateNetworkID: request.PrivateNetworkID,
+			}, scw.WithContext(ctx))
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		cluster, err := k8sAPI.MigrateToPrivateNetworkCluster(request, scw.WithContext(ctx))
+		if err != nil {
+			if pnCreated {
+				errPN := vpcAPI.DeletePrivateNetwork(&vpc.DeletePrivateNetworkRequest{
+					Region:           request.Region,
+					PrivateNetworkID: request.PrivateNetworkID,
+				}, scw.WithContext(ctx))
+
+				if err != nil {
+					return nil, errors.Join(err, errPN)
+				}
+			}
+			return nil, err
+		}
+
+		return struct {
+			*k8s.Cluster
+			*vpc.PrivateNetwork `json:"PrivateNetwork"`
+		}{
+			cluster,
+			pn,
+		}, nil
+	}
+
+	c.View = &core.View{
+		Sections: []*core.ViewSection{
+			{
+				FieldName: "AutoscalerConfig",
+				Title:     "Autoscaler configuration",
+			},
+			{
+				FieldName: "AutoUpgrade",
+				Title:     "Auto-upgrade settings",
+			},
+			{
+				FieldName: "OpenIDConnectConfig",
+				Title:     "Open ID Connect configuration",
+			},
+			{
+				FieldName: "PrivateNetwork",
+				Title:     "Private Network",
+			},
+		},
+	}
+	return c
+}


### PR DESCRIPTION
This PR adds the temporary command `scw k8s cluster migrate-to-private-network` to the CLI.
It will be used to migrate legacy clusters (those created without a private network) to clusters with a private network.
