### PR TITLE
feat(wasm): export an autocomplete function

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,3 +28,7 @@ jobs:
         run: ./scripts/build-wasm.sh
       - name: Run npm package tests
         run: ./scripts/run-tests-wasm.sh
+      - name: Run custom tester
+        run: ./scripts/run-tests-wasm.sh
+        env:
+          TESTER: true

--- a/cmd/scw-wasm-tester/args.go
+++ b/cmd/scw-wasm-tester/args.go
@@ -1,0 +1,24 @@
+//go:build wasm && js
+
+package main
+
+import (
+	"os"
+)
+
+type Args struct {
+	callback     string
+	targetObject string
+}
+
+func getArgs() Args {
+	args := Args{}
+	if len(os.Args) > 0 {
+		args.callback = os.Args[0]
+	}
+	if len(os.Args) > 1 {
+		args.targetObject = os.Args[1]
+	}
+
+	return args
+}

--- a/cmd/scw-wasm-tester/slices.go
+++ b/cmd/scw-wasm-tester/slices.go
@@ -1,0 +1,13 @@
+//go:build wasm && js
+
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/scaleway/scaleway-cli/v2/internal/jshelpers"
+)
+
+func wasmTestFromSlice(_ js.Value, _ []js.Value) any {
+	return jshelpers.FromSlice([]string{"1", "2", "3"})
+}

--- a/internal/core/wasm.go
+++ b/internal/core/wasm.go
@@ -1,5 +1,0 @@
-package core
-
-type WasmConfig struct {
-	JWT *string
-}

--- a/internal/jshelpers/arrays.go
+++ b/internal/jshelpers/arrays.go
@@ -13,6 +13,10 @@ var (
 )
 
 func asSlice(typ reflect.Type, value js.Value) (any, error) {
+	if !value.InstanceOf(jsArray) {
+		return nil, fmt.Errorf("value type should be Array")
+	}
+
 	l := value.Length()
 
 	slice := reflect.MakeSlice(reflect.SliceOf(typ), l, l)
@@ -31,10 +35,6 @@ func asSlice(typ reflect.Type, value js.Value) (any, error) {
 // value must be an array of a type handled by goValue
 func AsSlice[T any](value js.Value) ([]T, error) {
 	var t T
-
-	if !value.InstanceOf(jsArray) {
-		return nil, fmt.Errorf("value type should be Array")
-	}
 
 	slice, err := asSlice(reflect.TypeOf(t), value)
 	if err != nil {

--- a/internal/jshelpers/arrays.go
+++ b/internal/jshelpers/arrays.go
@@ -43,3 +43,15 @@ func AsSlice[T any](value js.Value) ([]T, error) {
 
 	return slice.([]T), nil
 }
+
+// FromSlice converts a Go slice to a JS Array
+func FromSlice(from any) js.Value {
+	fromValue := reflect.ValueOf(from)
+
+	arrayItems := make([]any, fromValue.Len())
+	for i := 0; i < len(arrayItems); i++ {
+		arrayItems[i] = jsValue(fromValue.Index(i).Interface())
+	}
+
+	return jsArray.New(arrayItems...)
+}

--- a/internal/jshelpers/async.go
+++ b/internal/jshelpers/async.go
@@ -1,31 +1,22 @@
-//go:build wasm && js
+//go:build js
 
-package main
+package jshelpers
 
 import (
 	"fmt"
 	"runtime/debug"
 	"syscall/js"
-
-	"github.com/scaleway/scaleway-cli/v2/internal/jshelpers"
 )
 
-type fn func(this js.Value, args []js.Value) (any, error)
-
-var (
-	jsErr     = js.Global().Get("Error")
-	jsPromise = js.Global().Get("Promise")
-)
-
-func asyncFunc(innerFunc fn) js.Func {
-	return js.FuncOf(func(this js.Value, args []js.Value) any {
+func AsyncJsFunc(innerFunc JsFuncWithError) JsFunc {
+	return func(this js.Value, args []js.Value) any {
 		handler := js.FuncOf(func(_ js.Value, promFn []js.Value) any {
 			resolve, reject := promFn[0], promFn[1]
 
 			go func() {
 				defer func() {
 					if r := recover(); r != nil {
-						reject.Invoke(jshelpers.NewError(
+						reject.Invoke(NewError(
 							fmt.Sprintf("panic: %v\n%s", r, string(debug.Stack())),
 						))
 					}
@@ -33,7 +24,7 @@ func asyncFunc(innerFunc fn) js.Func {
 
 				res, err := innerFunc(this, args)
 				if err != nil {
-					reject.Invoke(jshelpers.NewError(err.Error()))
+					reject.Invoke(NewError(err.Error()))
 				} else {
 					resolve.Invoke(res)
 				}
@@ -43,5 +34,5 @@ func asyncFunc(innerFunc fn) js.Func {
 		})
 
 		return jsPromise.New(handler)
-	})
+	}
 }

--- a/internal/jshelpers/errors.go
+++ b/internal/jshelpers/errors.go
@@ -4,11 +4,6 @@ package jshelpers
 
 import "syscall/js"
 
-var (
-	jsObject = js.Global().Get("Object")
-	jsErr    = js.Global().Get("Error")
-)
-
 func NewError(msg any) js.Value {
 	return jsErr.New(msg)
 }

--- a/internal/jshelpers/function.go
+++ b/internal/jshelpers/function.go
@@ -63,7 +63,7 @@ func AsPromise(goFunc any) JsFunc {
 		for i, argType := range goFuncArgs {
 			arg, err := goValue(argType, args[i])
 			if err != nil {
-				return nil, fmt.Errorf("invalid argument at index %d with type %s: %w", i, argType.String(), err)
+				return nil, fmt.Errorf("invalid argument at index %d, expected type %s: %w", i, argType.String(), err)
 			}
 			argValues[i] = reflect.ValueOf(arg)
 		}

--- a/internal/jshelpers/function.go
+++ b/internal/jshelpers/function.go
@@ -21,7 +21,10 @@ func jsValue(val any) js.Value {
 	switch valType.Kind() {
 	case reflect.Struct:
 		return FromObject(val)
+	case reflect.Slice:
+		return FromSlice(val)
 	}
+
 	return js.ValueOf(val)
 }
 
@@ -32,10 +35,10 @@ func errValue(val any) error {
 	return val.(error)
 }
 
-// AsFunction convert a classic Go function to a function taking js arguments.
+// AsPromise convert a classic Go function to a function taking js arguments.
 // arguments and return types must be types handled by this package
 // function must return 2 variables, second one must be an error
-func AsFunction(goFunc any) func(this js.Value, args []js.Value) (any, error) {
+func AsPromise(goFunc any) JsFunc {
 	goFuncValue := reflect.ValueOf(goFunc)
 	goFuncType := goFuncValue.Type()
 
@@ -51,7 +54,7 @@ func AsFunction(goFunc any) func(this js.Value, args []js.Value) (any, error) {
 		panic("function must return an error")
 	}
 
-	return func(this js.Value, args []js.Value) (any, error) {
+	return AsyncJsFunc(func(this js.Value, args []js.Value) (any, error) {
 		if len(args) != len(goFuncArgs) {
 			return nil, fmt.Errorf("invalid number of arguments, expected %d, got %d", len(goFuncArgs), len(args))
 		}
@@ -68,5 +71,5 @@ func AsFunction(goFunc any) func(this js.Value, args []js.Value) (any, error) {
 		returnValues := goFuncValue.Call(argValues)
 
 		return jsValue(returnValues[0].Interface()), errValue(returnValues[1].Interface())
-	}
+	})
 }

--- a/internal/jshelpers/objects.go
+++ b/internal/jshelpers/objects.go
@@ -30,6 +30,10 @@ func goValue(typ reflect.Type, value js.Value) (any, error) {
 }
 
 func asObject(typ reflect.Type, value js.Value) (any, error) {
+	if value.Type() != js.TypeObject {
+		return nil, fmt.Errorf("value type should be Object")
+	}
+
 	objPtr := reflect.New(typ)
 	obj := objPtr.Elem()
 
@@ -54,10 +58,6 @@ func asObject(typ reflect.Type, value js.Value) (any, error) {
 // Given Go struct must have "js" tags to specify fields mapping
 func AsObject[T any](value js.Value) (*T, error) {
 	var t T
-
-	if value.Type() != js.TypeObject {
-		return nil, fmt.Errorf("value type should be Object")
-	}
 
 	obj, err := asObject(reflect.TypeOf(t), value)
 	if err != nil {

--- a/internal/jshelpers/types.go
+++ b/internal/jshelpers/types.go
@@ -1,0 +1,18 @@
+//go:build js
+
+package jshelpers
+
+import "syscall/js"
+
+type (
+	// JsFunc represent a function that can be converted to a js.Func using js.FuncOf
+	JsFunc func(this js.Value, args []js.Value) any
+	// JsFuncWithError is a JsFunc with an additional error returned, convert it to a promise with AsPromise
+	JsFuncWithError func(this js.Value, args []js.Value) (any, error)
+)
+
+var (
+	jsPromise = js.Global().Get("Promise")
+	jsObject  = js.Global().Get("Object")
+	jsErr     = js.Global().Get("Error")
+)

--- a/internal/wasm/autocomplete.go
+++ b/internal/wasm/autocomplete.go
@@ -1,0 +1,40 @@
+package wasm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type AutoCompleteConfig struct {
+	JWT          string   `js:"jwt"`
+	LeftWords    []string `js:"leftWords"`
+	SelectedWord string   `js:"selectedWord"`
+	RightWords   []string `js:"rightWords"`
+}
+
+func Autocomplete(cfg *AutoCompleteConfig) ([]string, error) {
+	indexToComplete := int64(len(cfg.LeftWords) + 2)
+
+	words := append(cfg.LeftWords, cfg.SelectedWord)
+	words = append(words, cfg.RightWords...)
+
+	completeCommand := []string{"autocomplete", "complete", "zsh", strconv.FormatInt(indexToComplete, 10), "scw"}
+
+	completeCommand = append(completeCommand, words...)
+
+	resp, err := Run(&RunConfig{
+		JWT: cfg.JWT,
+	}, completeCommand)
+	if err != nil {
+		return nil, fmt.Errorf("error running complete command: %w", err)
+	}
+
+	if resp.ExitCode != 0 {
+		return nil, fmt.Errorf("invalid exit code %d: %s", resp.ExitCode, resp.Stderr)
+	}
+
+	suggestions := strings.Fields(resp.Stdout)
+
+	return suggestions, nil
+}

--- a/scripts/run-tests-wasm.sh
+++ b/scripts/run-tests-wasm.sh
@@ -1,6 +1,18 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../wasm" && pwd)"
 
+TEST_FLAGS=(
+  --run
+)
+
+if [[ "${TESTER}" == "true" ]]; then
+  echo "building"
+  GOOS=js GOARCH=wasm go build -o "$ROOT_DIR/cliTester.wasm" ./cmd/scw-wasm-tester
+  TEST_FLAGS+=(-t "With test environment")
+else
+  TEST_FLAGS+=(-t "With wasm CLI")
+fi
+
 cd $ROOT_DIR
 pnpm install
-pnpm test -- --run
+pnpm test -- "${TEST_FLAGS[@]}"

--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 cli.wasm
+cliTester.wasm
 lib
 .idea

--- a/wasm/cli.d.ts
+++ b/wasm/cli.d.ts
@@ -8,6 +8,15 @@ export type RunResponse = {
     exitCode: string
 }
 
+export type AutocompleteConfig = {
+    jwt: string
+    leftWords: string[]
+    selectedWord: string
+    rightWords: string[]
+}
+
 export type CLI = {
     run(cfg: RunConfig, args: string[]): Promise<RunResponse>
+    complete(cfg: AutocompleteConfig): Promise<string[]>
+    stop(): Promise<void>
 }

--- a/wasm/index.d.ts
+++ b/wasm/index.d.ts
@@ -1,9 +1,4 @@
-import {CLI, RunConfig, RunResponse} from "./cli";
+export type {CLI, RunConfig, RunResponse } from './cli'
+export type { Go } from './wasm_exec'
 
-export type _ = {
-    wasmURL: URL,
-    RunConfig,
-    RunResponse,
-    CLI,
-    Go,
-}
+export declare const wasmURL: URL;

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scaleway/scaleway-cli-wasm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "type": "module",
   "main": "index.js",
@@ -17,6 +17,7 @@
   "files": [
     "cli.wasm",
     "cli.d.ts",
+    "index.d.ts",
     "index.js",
     "wasm_exec.cjs",
     "wasm_exec.d.ts",

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scaleway/scaleway-cli-wasm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "type": "module",
   "main": "index.js",

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@scaleway/scaleway-cli-wasm",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest src"
   },
   "types": "index.d.ts",
   "keywords": [],

--- a/wasm/src/cli.test.ts
+++ b/wasm/src/cli.test.ts
@@ -2,39 +2,25 @@
 // It will load go misc files in
 // /usr/local/go/misc/wasm
 
-import {describe, it, expect, afterAll} from 'vitest'
+import {describe, it, expect, afterAll, beforeAll} from 'vitest'
 
 import '../wasm_exec_node.cjs'
 import '../wasm_exec.cjs'
 import {CLI, RunConfig} from '../cli'
 import * as fs from 'fs'
 import {Go} from "../wasm_exec";
+import {loadWasmBinary} from "./utils";
 
 const CLI_PACKAGE = 'scw'
 const CLI_CALLBACK = 'cliLoaded'
 
 describe('With wasm CLI', async () => {
-    // @ts-ignore
-    const go = new globalThis.Go() as Go
+    let cli: CLI
 
-    const waitForCLI = new Promise((resolve) => {
+    beforeAll(async () => {
         // @ts-ignore
-        globalThis[CLI_CALLBACK] = () => {
-            resolve({})
-        }
+        cli = await loadWasmBinary('./cli.wasm') as CLI
     })
-    go.argv = [CLI_CALLBACK, CLI_PACKAGE]
-
-    WebAssembly.instantiate(fs.readFileSync('./cli.wasm'), go.importObject).then((result) => {
-        return go.run(result.instance)
-    }).catch((err) => {
-        console.error(err)
-        console.error("webassembly error")
-        process.exit(1)
-    })
-    await waitForCLI
-    // @ts-ignore
-    const cli = globalThis[CLI_PACKAGE] as CLI
 
     const run = async (expected: string | RegExp, command: string[], runCfg: RunConfig | null = null) => {
         if (runCfg === null) {

--- a/wasm/src/jshelpers.test.ts
+++ b/wasm/src/jshelpers.test.ts
@@ -1,0 +1,57 @@
+
+import {describe, it, expect, afterAll} from 'vitest'
+
+import '../wasm_exec_node.cjs'
+import '../wasm_exec.cjs'
+import {RunConfig} from '../cli'
+import * as fs from 'fs'
+
+const CLI_PACKAGE = 'scw'
+const CLI_CALLBACK = 'cliLoaded'
+
+type CLITester = {
+    stop: () => Promise<void>
+    FromSlice: () => string[]
+}
+
+describe('With test environment', async () => {
+    // @ts-ignore
+    const go = new globalThis.Go()
+
+    const waitForCLI = new Promise((resolve) => {
+        // @ts-ignore
+        globalThis[CLI_CALLBACK] = () => {
+            resolve({})
+        }
+    })
+    go.argv = [CLI_CALLBACK, CLI_PACKAGE]
+
+    WebAssembly.instantiate(fs.readFileSync('./cliTester.wasm'), go.importObject).then((result) => {
+        return go.run(result.instance)
+    }).catch((err) => {
+        console.error(err)
+        console.error("webassembly error")
+        process.exit(1)
+    })
+    await waitForCLI
+    // @ts-ignore
+    const cli = globalThis[CLI_PACKAGE] as CLITester
+
+    it('can return array', async () => {
+        const array = cli.FromSlice()
+
+        expect(array).toHaveLength(3)
+        expect(array).toContain("1")
+        expect(array).toContain("2")
+        expect(array).toContain("3")
+    })
+
+    afterAll(async () => {
+        try {
+            await cli.stop()
+            go._resume()
+        } catch (e) {
+            console.log(e)
+        }
+    })
+})

--- a/wasm/src/utils.ts
+++ b/wasm/src/utils.ts
@@ -1,0 +1,32 @@
+import '../wasm_exec_node.cjs'
+import '../wasm_exec.cjs'
+import {CLI, RunConfig} from '../cli'
+import * as fs from 'fs'
+import {Go} from "../wasm_exec";
+
+const CLI_PACKAGE = 'scw'
+const CLI_CALLBACK = 'cliLoaded'
+
+export const loadWasmBinary = async (binaryName: string): Promise<unknown> => {
+    // @ts-ignore
+    const go = new globalThis.Go() as Go
+
+    const waitForCLI = new Promise((resolve) => {
+        // @ts-ignore
+        globalThis[CLI_CALLBACK] = () => {
+            resolve({})
+        }
+    })
+    go.argv = [CLI_CALLBACK, CLI_PACKAGE]
+
+    WebAssembly.instantiate(fs.readFileSync(binaryName), go.importObject).then((result) => {
+        return go.run(result.instance)
+    }).catch((err) => {
+        console.error(err)
+        console.error("webassembly error")
+        process.exit(1)
+    })
+    await waitForCLI
+
+    return globalThis[CLI_PACKAGE]
+}

--- a/wasm/wasm_exec.d.ts
+++ b/wasm/wasm_exec.d.ts
@@ -5,4 +5,5 @@ export class Go {
         go: {[key: string]: (sp: number) => void},
     }
     async run(instance: WebAssembly.Instance)
+    _resume()
 }


### PR DESCRIPTION
Closes #3111 
Closes #3114 
Currently not using directly autocomplete as it requires a filled Context, will be done in the future.

The completion tree is built upon each call. 