### PR TITLE
fix(shell): crash on help flag

### DIFF
--- a/internal/core/shell.go
+++ b/internal/core/shell.go
@@ -271,6 +271,12 @@ func shellExecutor(rootCmd *cobra.Command, printer *Printer, meta *meta) func(s 
 			return
 		}
 
+		// command is nil if it does not have a Run function
+		// ex: instance -h
+		if meta.command == nil {
+			return
+		}
+
 		autoCompleteCache.Update(meta.command.Namespace)
 
 		printErr := printer.Print(meta.result, meta.command.getHumanMarshalerOpt())


### PR DESCRIPTION
Fixed crash when doing

```
$ scw shell
>>> instance -h
```

It also produced an invalid behavior when using a help flag after running a valid command