### PR TITLE
feat: improve sentry reports

### DIFF
--- a/cmd/scw/main.go
+++ b/cmd/scw/main.go
@@ -33,6 +33,8 @@ var (
 	BetaMode  = os.Getenv(scw.ScwEnableBeta) == "true"
 )
 
+// cleanup does the recover
+// If name change, must be reported in internal/sentry
 func cleanup(buildInfo *core.BuildInfo) {
 	if err := recover(); err != nil {
 		fmt.Println(sentry.ErrorBanner)
@@ -41,7 +43,7 @@ func cleanup(buildInfo *core.BuildInfo) {
 
 		// This will send an anonymous report on Scaleway's sentry.
 		if buildInfo.IsRelease() {
-			sentry.RecoverPanicAndSendReport(buildInfo, err)
+			sentry.RecoverPanicAndSendReport(buildInfo.Tags(), buildInfo.Version.String(), err)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.15.0
-	github.com/getsentry/raven-go v0.2.0
+	github.com/getsentry/sentry-go v0.20.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-version v1.6.0
@@ -72,7 +72,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/buildpacks/imgutil v0.0.0-20230428141433-24db5a78c900 // indirect
 	github.com/buildpacks/lifecycle v0.17.0-pre.2 // indirect
-	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/containerd/containerd v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,6 @@ github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/c-bata/go-prompt v0.2.6 h1:POP+nrHE+DfLYx370bedwNhsqmpCUynWPxuHi0C5vZI=
 github.com/c-bata/go-prompt v0.2.6/go.mod h1:/LMAke8wD2FsNu9EXNdHxNLbd9MedkPnCdfpU9wwHfY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV47EEXL8mWmRdEfGscSJ+7EgePNgt0s=
-github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=
@@ -242,12 +240,13 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
 github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
-github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
-github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
+github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
+github.com/getsentry/sentry-go v0.20.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
+github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
@@ -472,6 +471,7 @@ github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M5
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 h1:DiLBVp4DAcZlBVBEtJpNWZpZVq0AEeCY7Hqk8URVs4o=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/core/build_info.go
+++ b/internal/core/build_info.go
@@ -53,6 +53,15 @@ func (b *BuildInfo) GetUserAgent() string {
 	return userAgentPrefix
 }
 
+func (b *BuildInfo) Tags() map[string]string {
+	return map[string]string{
+		"version":    b.Version.String(),
+		"go_arch":    b.GoArch,
+		"go_os":      b.GoOS,
+		"go_version": b.GoVersion,
+	}
+}
+
 func (b *BuildInfo) checkVersion(ctx context.Context) {
 	if !b.IsRelease() || ExtractEnv(ctx, scwDisableCheckVersionEnv) == "true" {
 		ExtractLogger(ctx).Debug("skipping check version")

--- a/internal/core/cobra_utils.go
+++ b/internal/core/cobra_utils.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/scaleway/scaleway-cli/v2/internal/args"
+	"github.com/scaleway/scaleway-cli/v2/internal/sentry"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,8 @@ func cobraRun(ctx context.Context, cmd *Command) func(*cobra.Command, []string) 
 
 		meta := extractMeta(ctx)
 		meta.command = cmd
+
+		sentry.AddCommandContext(cmd.GetCommandLine("scw"))
 
 		// If command requires authentication and the client was not directly provided in the bootstrap config, we create a new client and overwrite the existing one
 		if !cmd.AllowAnonymousClient && !meta.isClientFromBootstrapConfig {
@@ -99,6 +102,8 @@ func run(ctx context.Context, cobraCmd *cobra.Command, cmd *Command, rawArgs []s
 	// create a new Args interface{}
 	// unmarshalled arguments will be store in this interface
 	cmdArgs := reflect.New(cmd.ArgsType).Interface()
+
+	sentry.AddArgumentsContext(args.SplitRaw(rawArgs))
 
 	// Unmarshal args.
 	// After that we are done working with rawArgs

--- a/internal/core/shell.go
+++ b/internal/core/shell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c-bata/go-prompt"
 	"github.com/scaleway/scaleway-cli/v2/internal/cache"
 	"github.com/scaleway/scaleway-cli/v2/internal/interactive"
+	"github.com/scaleway/scaleway-cli/v2/internal/sentry"
 	"github.com/spf13/cobra"
 )
 
@@ -255,6 +256,9 @@ func NewShellCompleter(ctx context.Context) *Completer {
 func shellExecutor(rootCmd *cobra.Command, printer *Printer, meta *meta) func(s string) {
 	return func(s string) {
 		args := strings.Fields(s)
+
+		sentry.AddCommandContext(strings.Join(removeOptions(args), " "))
+
 		rootCmd.SetArgs(meta.CliConfig.Alias.ResolveAliases(args))
 
 		err := rootCmd.Execute()

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -2,9 +2,10 @@ package sentry
 
 import (
 	"fmt"
+	"strings"
+	"time"
 
-	"github.com/getsentry/raven-go"
-	"github.com/scaleway/scaleway-cli/v2/internal/core"
+	"github.com/getsentry/sentry-go"
 	"github.com/scaleway/scaleway-sdk-go/logger"
 )
 
@@ -17,44 +18,119 @@ An error occurred, we are sorry, please consider opening a ticket on github usin
 Give us as many details as possible so we can reproduce the error and fix it.
 ---------------------------------------------------------------------------------------`
 
-// RecoverPanicAndSendReport will recover error if any, log them, and send them to sentry.
-// It must be called with the defer built-in.
-func RecoverPanicAndSendReport(buildInfo *core.BuildInfo, e interface{}) {
-	sentryClient, err := newSentryClient(buildInfo)
+// RecoverPanicAndSendReport is to be called after recover.
+// It expects tags returned by core.BuildInfo and the recovered error
+func RecoverPanicAndSendReport(tags map[string]string, version string, e interface{}) {
+	sentryHub, err := sentryHub(tags, version)
 	if err != nil {
-		logger.Debugf("cannot create sentry client: %s", err)
+		logger.Debugf("cannot get sentry hub: %s", err)
 	}
 
 	err, isError := e.(error)
 	if isError {
-		logAndSentry(sentryClient, err)
+		logAndSentry(sentryHub, err)
 	} else {
-		logAndSentry(sentryClient, fmt.Errorf("unknownw error: %v", e))
+		logAndSentry(sentryHub, fmt.Errorf("unknown error: %v", e))
 	}
 }
 
-func logAndSentry(sentryClient *raven.Client, err error) {
+func logAndSentry(sentryHub *sentry.Hub, err error) {
 	logger.Errorf("%s", err)
-	if sentryClient != nil {
-		logger.Debugf("sending sentry report: %s", sentryClient.CaptureErrorAndWait(err, nil))
+	if sentryHub != nil {
+		event := sentryHub.Recover(err)
+		if event == nil {
+			logger.Debugf("failed to capture exception with sentry")
+			return
+		}
+		logger.Debugf("sending sentry report: %s", *event)
+		if !sentry.Flush(time.Second * 2) {
+			logger.Debugf("failed to send report")
+		}
 	}
 }
 
 // newSentryClient create a sentry client with build info tags.
-func newSentryClient(buildInfo *core.BuildInfo) (*raven.Client, error) {
-	client, err := raven.New(dsn)
+func newSentryClient(version string) (*sentry.Client, error) {
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:              dsn,
+		AttachStacktrace: true,
+		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+			filterStackFrames(event)
+			return event
+		},
+		Release: version,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	tagsContext := map[string]string{
-		"version":    buildInfo.Version.String(),
-		"go_arch":    buildInfo.GoArch,
-		"go_os":      buildInfo.GoOS,
-		"go_version": buildInfo.GoVersion,
+	return client, nil
+}
+
+func configureSentryScope(tags map[string]string) {
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetTags(tags)
+	})
+}
+
+// AddCommandContext is used to pass executed command
+func AddCommandContext(line string) {
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("command", map[string]interface{}{
+			"line": line,
+		})
+	})
+}
+
+func AddArgumentsContext(args [][2]string) {
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		argMap := map[string]interface{}{}
+
+		for _, arg := range args {
+			argMap[arg[0]] = len(arg[1])
+		}
+
+		scope.SetContext("arguments", argMap)
+	})
+}
+
+func sentryHub(tags map[string]string, version string) (*sentry.Hub, error) {
+	hub := sentry.CurrentHub()
+
+	if hub.Client() == nil {
+		client, err := newSentryClient(version)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create sentry client: %w", err)
+		}
+		hub.BindClient(client)
+		configureSentryScope(tags)
 	}
 
-	client.SetTagsContext(tagsContext)
+	return hub, nil
+}
 
-	return client, nil
+// Filter the stack frames so that the top frame is the one causing panic.
+// On top of the culprit one there should be
+// - the deferred recover function
+// - The two functions called in this package
+func filterStackFrames(event *sentry.Event) {
+	for _, e := range event.Exception {
+		if e.Stacktrace == nil {
+			continue
+		}
+		frames := e.Stacktrace.Frames[:0]
+		for _, frame := range e.Stacktrace.Frames {
+			if frame.Module == "main" && strings.HasPrefix(frame.Function, "cleanup") {
+				continue
+			}
+			if frame.Module == "github.com/scaleway/scaleway-cli/v2/internal/sentry" && strings.HasPrefix(frame.Function, "RecoverPanicAndSendReport") {
+				continue
+			}
+			if frame.Module == "github.com/scaleway/scaleway-cli/v2/internal/sentry" && strings.HasPrefix(frame.Function, "logAndSentry") {
+				continue
+			}
+			frames = append(frames, frame)
+		}
+		e.Stacktrace.Frames = frames
+	}
 }


### PR DESCRIPTION
Switch to the new sentry sdk. The stack trace is cleaned up.
Added some informations to the report:
- The command used
- The list of arguments used without their content
- The CLI version as release
