### PR TITLE
docs: update invalid seealso commands

### DIFF
--- a/cmd/scw/testdata/test-all-usage-config-dump-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-config-dump-usage.golden
@@ -16,4 +16,4 @@ GLOBAL FLAGS:
 
 SEE ALSO:
   # Config management help
-  scw config --help
+  scw config

--- a/cmd/scw/testdata/test-all-usage-config-get-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-config-get-usage.golden
@@ -26,4 +26,4 @@ GLOBAL FLAGS:
 
 SEE ALSO:
   # Config management help
-  scw config --help
+  scw config

--- a/cmd/scw/testdata/test-all-usage-config-info-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-config-info-usage.golden
@@ -23,4 +23,4 @@ GLOBAL FLAGS:
 
 SEE ALSO:
   # Config management help
-  scw config --help
+  scw config

--- a/cmd/scw/testdata/test-all-usage-config-set-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-config-set-usage.golden
@@ -35,4 +35,4 @@ GLOBAL FLAGS:
 
 SEE ALSO:
   # Config management help
-  scw config --help
+  scw config

--- a/internal/namespaces/config/commands.go
+++ b/internal/namespaces/config/commands.go
@@ -80,15 +80,15 @@ func configRoot() *core.Command {
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Init your Scaleway config",
-				Command: "scw config init",
+				Command: "scw init",
 			},
 			{
 				Short:   "Set a config attribute",
-				Command: "scw config set --help",
+				Command: "scw config set",
 			},
 			{
 				Short:   "Set a config attribute",
-				Command: "scw config get --help",
+				Command: "scw config get",
 			},
 			{
 				Short:   "Dump the config",
@@ -137,7 +137,7 @@ func configGetCommand() *core.Command {
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Config management help",
-				Command: "scw config --help",
+				Command: "scw config",
 			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {
@@ -260,7 +260,7 @@ The only allowed attributes are access_key, secret_key, default_organization_id,
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Config management help",
-				Command: "scw config --help",
+				Command: "scw config",
 			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, err error) {
@@ -377,7 +377,7 @@ func configDumpCommand() *core.Command {
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Config management help",
-				Command: "scw config --help",
+				Command: "scw config",
 			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {
@@ -574,7 +574,7 @@ func configInfoCommand() *core.Command {
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Config management help",
-				Command: "scw config --help",
+				Command: "scw config",
 			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {

--- a/internal/namespaces/init/init.go
+++ b/internal/namespaces/init/init.go
@@ -124,7 +124,7 @@ Default path for configuration file is based on the following priority order:
 		SeeAlsos: []*core.SeeAlso{
 			{
 				Short:   "Config management help",
-				Command: "scw config --help",
+				Command: "scw config",
 			},
 		},
 		Run: func(ctx context.Context, argsI interface{}) (i interface{}, e error) {

--- a/internal/qa/qa.go
+++ b/internal/qa/qa.go
@@ -22,6 +22,7 @@ func LintCommands(commands *core.Commands) []error {
 	errors = append(errors, testArgSpecInvalidError(commands)...)
 	errors = append(errors, testArgSpecMissingError(commands)...)
 	errors = append(errors, testCommandInvalidJSONExampleError(commands)...)
+	errors = append(errors, testCommandInvalidSeeAlsoError(commands)...)
 
 	errors = filterIgnore(errors)
 

--- a/internal/qa/seealso.go
+++ b/internal/qa/seealso.go
@@ -1,0 +1,46 @@
+package qa
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/scaleway/scaleway-cli/v2/internal/core"
+)
+
+type CommandInvalidSeeAlsoError struct {
+	Command        *core.Command
+	SeeAlsoCommand string
+}
+
+func (err CommandInvalidSeeAlsoError) Error() string {
+	return fmt.Sprintf("command has invalid see_also commands, '%s' has '%s'",
+		err.Command.GetCommandLine("scw"),
+		err.SeeAlsoCommand,
+	)
+}
+
+// testArgSpecInvalidError tests that all commands' see_also commands exist.
+func testCommandInvalidSeeAlsoError(commands *core.Commands) []error {
+	errors := []error(nil)
+
+	for _, command := range commands.GetAll() {
+		for _, seeAlso := range command.SeeAlsos {
+			seeAlsoCommand := strings.Fields(seeAlso.Command)
+
+			// Only check scw commands
+			if len(seeAlsoCommand) <= 1 || seeAlsoCommand[0] != "scw" {
+				continue
+			}
+			seeAlsoCommand = seeAlsoCommand[1:]
+
+			if commands.Find(seeAlsoCommand...) == nil {
+				errors = append(errors, &CommandInvalidSeeAlsoError{
+					Command:        command,
+					SeeAlsoCommand: seeAlso.Command,
+				})
+			}
+		}
+	}
+
+	return errors
+}


### PR DESCRIPTION
Fix #3194 

Fix seealso commands, remove extra `--help`.
Also add a qa rule to validate commands, there is still some to fix. Has to be done on generation side, I made an MR.