### PR TITLE
chore: change wasm package path

### DIFF
--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@scaleway/scaleway-cli-wasm",
+  "name": "@scaleway-internal/scaleway-cli-wasm",
   "version": "0.0.11",
   "description": "",
   "type": "module",


### PR DESCRIPTION
The package is intended to be public but it currently remains on our private repository for testing purpose.