### PR TITLE
Added instruction to run the Docker image with Podman

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -61,3 +61,10 @@ complete -F _scw scw
 ```
 
 The trick is to remove the `-t` when using docker inside the completion function.
+
+# Using the CLI with Podman
+If running with Podman and SELinux in enforcing mode, one must use the :Z option when mounting the configuration file.  
+For instance:  
+```bash
+podman run -it --rm -v $HOME/.config/scw:/root/.config/scw:Z scaleway/cli:v2.3.0
+```


### PR DESCRIPTION
When executing the `scw` command using Podman with SELinux in enforcing mode, a permission denial may be encountered when attempting to access the `config.yaml` file on the host. This commit provides a small update to the documentation to remedy this issue and run a rootless container seamlessly while maintaining SELinux in enforcing mode.