### PR TITLE
fix(rdb): user list region

### DIFF
--- a/internal/namespaces/rdb/v1/custom_user.go
+++ b/internal/namespaces/rdb/v1/custom_user.go
@@ -50,7 +50,10 @@ func userListBuilder(c *core.Command) *core.Command {
 
 		api := rdb.NewAPI(core.ExtractClient(ctx))
 		listPrivileges, err := api.ListPrivileges(
-			&rdb.ListPrivilegesRequest{InstanceID: listUserRequest.InstanceID},
+			&rdb.ListPrivilegesRequest{
+				InstanceID: listUserRequest.InstanceID,
+				Region:     listUserRequest.Region,
+			},
 			scw.WithAllPages(),
 		)
 		if err != nil {


### PR DESCRIPTION
The `rdb user list` do a second requests to get privileges but it did not use the region passed as argument `region=nl-ams`