### PR TITLE
fix(k8s): fix empty PNID when not created alongside cluster

### DIFF
--- a/internal/namespaces/k8s/v1/custom_cluster.go
+++ b/internal/namespaces/k8s/v1/custom_cluster.go
@@ -132,7 +132,7 @@ func clusterCreateBuilder(c *core.Command) *core.Command {
 			} else {
 				pn, err = vpcAPI.GetPrivateNetwork(&vpc.GetPrivateNetworkRequest{
 					Region:           request.Region,
-					PrivateNetworkID: pn.ID,
+					PrivateNetworkID: *request.PrivateNetworkID,
 				}, scw.WithContext(ctx))
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Closes #3338 