### PR TITLE
feat(init): activate first create profile

### DIFF
--- a/internal/namespaces/init/init.go
+++ b/internal/namespaces/init/init.go
@@ -136,7 +136,7 @@ Default path for configuration file is based on the following priority order:
 			// Show logo banner, or simple welcome message
 			printScalewayBanner()
 
-			config, err := loadConfigOrEmpty(configPath)
+			config, err := loadConfigOrEmpty(configPath, profileName)
 			if err != nil {
 				return nil, err
 			}
@@ -280,12 +280,16 @@ func printScalewayBanner() {
 
 // loadConfigOrEmpty checks if a config exists
 // Creates a new one if it does not
-func loadConfigOrEmpty(configPath string) (*scw.Config, error) {
+// defaultProfile will be the activated one if different that default
+func loadConfigOrEmpty(configPath string, activeProfile string) (*scw.Config, error) {
 	config, err := scw.LoadConfigFromPath(configPath)
 	if err != nil {
 		_, ok := err.(*scw.ConfigFileNotFoundError)
 		if ok {
 			config = &scw.Config{}
+			if activeProfile != scw.DefaultProfileName {
+				config.ActiveProfile = &activeProfile
+			}
 			interactive.Printf("Creating new config\n")
 		} else {
 			return nil, err

--- a/internal/namespaces/init/init_test.go
+++ b/internal/namespaces/init/init_test.go
@@ -197,6 +197,21 @@ func TestInit(t *testing.T) {
 				"no",
 			},
 		}))
+
+		t.Run("Default profile activated", core.Test(&core.TestConfig{
+			Commands:   GetCommands(),
+			BeforeFunc: baseBeforeFunc(),
+			TmpHomeDir: true,
+			Cmd:        appendArgs("scw -p newprofile init", defaultArgs),
+			Check: core.TestCheckCombine(
+				core.TestCheckGolden(),
+				checkConfig(func(t *testing.T, ctx *core.CheckFuncCtx, config *scw.Config) {
+					assert.NotNil(t, config.ActiveProfile)
+					assert.Equal(t, "newprofile", *config.ActiveProfile)
+				}),
+			),
+		}))
+
 	})
 }
 

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-default-profile-activated.cassette.yaml
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-default-profile-activated.cassette.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"access_key":"SCWQN1ZYHWPFGJD28Q70", "secret_key":null, "description":"iam",
+      "created_at":"2022-08-22T09:13:42.922733Z", "updated_at":"2022-10-20T08:29:52.752429Z",
+      "expires_at":null, "default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "editable":true, "creation_ip":"51.159.73.9", "user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) scaleway-cli/0.0.0+test
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXXXXXXXXXXXXXXXXX
+    method: GET
+  response:
+    body: '{"access_key":"SCWQN1ZYHWPFGJD28Q70", "secret_key":null, "description":"iam",
+      "created_at":"2022-08-22T09:13:42.922733Z", "updated_at":"2022-10-20T08:29:52.752429Z",
+      "expires_at":null, "default_project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "editable":true, "creation_ip":"51.159.73.9", "user_id":"38d8ec28-dbee-4dbe-a4e8-56adcc285e8b"}'
+    headers:
+      Content-Length:
+      - "341"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 18 Oct 2023 12:53:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3107e65a-7df2-4aa8-8e1e-883cc691e9af
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/namespaces/init/testdata/test-init-cl-iv2-config-default-profile-activated.golden
+++ b/internal/namespaces/init/testdata/test-init-cl-iv2-config-default-profile-activated.golden
@@ -1,0 +1,8 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+✅ Initialization completed with success.
+🟩🟩🟩 JSON STDOUT 🟩🟩🟩
+{
+  "message": "Initialization completed with success",
+  "details": ""
+}


### PR DESCRIPTION
On the console you get a snippet when you create a new api key
```
scw init -p newprofile \
  access-key=SCWXXXXXXXXXX\
  secret-key=xxxx-xxxx-xxxx-xxxx\
  organization-id=xxxx-xxxx-xxxx-xxxx\
  project-id=xxxx-xxxx-xxxx-xxxx
```

This snippet will create a new profile but it will not be activated if it is your first profile, this can lead to confusion as next commands will not work.
Now the first created profile will be activated