### PR TITLE
feat(args): handle scw.Duration unmarshal as flat field

### DIFF
--- a/internal/args/unmarshal.go
+++ b/internal/args/unmarshal.go
@@ -115,6 +115,14 @@ var unmarshalFuncs = map[reflect.Type]UnmarshalFunc{
 		*(dest.(*[]byte)) = []byte(value)
 		return nil
 	},
+	reflect.TypeOf((*scw.Duration)(nil)).Elem(): func(value string, dest interface{}) error {
+		duration, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("failed to parse duration: %w", err)
+		}
+		*(dest.(*scw.Duration)) = *scw.NewDurationFromTimeDuration(duration)
+		return nil
+	},
 }
 
 // UnmarshalStruct parses args like ["arg1=1", "arg2=2"] to a Go structure using reflection.


### PR DESCRIPTION
scw.Duration was handled as two scalar fields

This would require a change of generator to have the durations as a flat field. Draft is available for it with # 321.