### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You can build the `scw` CLI with Docker. If you have Docker installed, you can r
 docker build -t scaleway/cli .
 ```
 
-Once build, you can then use the CLI as you would run any image:
+Once built, you can then use the CLI as you would run any image:
 
 ```sh
 docker run -i --rm scaleway/cli

--- a/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-instance-server-create-usage.golden
@@ -35,8 +35,8 @@ ARGS:
   [tags.{index}]                 Server tags
   [ipv6]                         Enable IPv6
   [stopped]                      Do not start server after its creation
-  [security-group-id]            The security group ID it use for this server
-  [placement-group-id]           The placement group ID in witch the server has to be created
+  [security-group-id]            The security group ID used for this server
+  [placement-group-id]           The placement group ID in which the server has to be created
   [bootscript-id]                The bootscript ID to use, if empty the local boot will be used
   [cloud-init]                   The cloud-init script to use (Support file loading with @/path/to/file)
   [boot-type=local]              The boot type to use, if empty the local boot will be used. Will be overwritten to bootscript if bootscript-id is set. (local | bootscript | rescue)

--- a/docs/commands/instance.md
+++ b/docs/commands/instance.md
@@ -1712,8 +1712,8 @@ scw instance server create [arg=value ...]
 | tags.{index} |  | Server tags |
 | ipv6 |  | Enable IPv6 |
 | stopped |  | Do not start server after its creation |
-| security-group-id |  | The security group ID it use for this server |
-| placement-group-id |  | The placement group ID in witch the server has to be created |
+| security-group-id |  | The security group ID used for this server |
+| placement-group-id |  | The placement group ID in which the server has to be created |
 | bootscript-id |  | The bootscript ID to use, if empty the local boot will be used |
 | cloud-init |  | The cloud-init script to use |
 | boot-type | Default: `local`<br />One of: `local`, `bootscript`, `rescue` | The boot type to use, if empty the local boot will be used. Will be overwritten to bootscript if bootscript-id is set. |

--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -104,11 +104,11 @@ func serverCreateCommand() *core.Command {
 			},
 			{
 				Name:  "security-group-id",
-				Short: "The security group ID it use for this server",
+				Short: "The security group ID used for this server",
 			},
 			{
 				Name:  "placement-group-id",
-				Short: "The placement group ID in witch the server has to be created",
+				Short: "The placement group ID in which the server has to be created",
 			},
 			{
 				Name:  "bootscript-id",


### PR DESCRIPTION
Fixes a few simple typos in the help output for the `scw instance server create` command. Also one typo in the README.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
