### PR TITLE
fix(vpc): check that redis endpoint is not nil 

### DIFF
--- a/internal/namespaces/vpc/v2/custom_private_network.go
+++ b/internal/namespaces/vpc/v2/custom_private_network.go
@@ -357,7 +357,7 @@ func listCustomRedisClusters(client *scw.Client, pn *vpc.PrivateNetwork) ([]cust
 		}
 		for _, cluster := range listRedisClusters.Clusters {
 			for _, endpoint := range cluster.Endpoints {
-				if endpoint.PrivateNetwork.ID == pn.ID {
+				if endpoint.PrivateNetwork != nil && endpoint.PrivateNetwork.ID == pn.ID {
 					customClusters = append(customClusters, customRedis{
 						ID:         cluster.ID,
 						Name:       cluster.Name,


### PR DESCRIPTION
CMD ISSUE :
- vpc private-network get

ISSUE :
when vpc with no redis cluster attach to issue because of nil pointer