### PR TITLE
feat: support aarch64 in get script

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -18,6 +18,7 @@ esac
 case "$(uname -m)" in
 x86_64) arch="amd64" ;;
 armv8*) arch="arm64" ;;
+aarch64) arch="arm64" ;;
 armv*) arch="arm" ;;
 i386) arch="386" ;;
 *)


### PR DESCRIPTION
If you try to run a docker build with `--platform=linux/amd64,linux/arm64`, you'll get an error:`aarch64 is not supported by this installation script`

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
feat: add aarch64 installation support with get script
```
