### PR TITLE
fix(instance): explicitly set IP type based on routed-ip-enabled value

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -780,6 +780,8 @@ func instanceServerCreateIPCreate(args *instanceCreateServerRequest, api *instan
 
 	if args.RoutedIPEnabled != nil && *args.RoutedIPEnabled {
 		req.Type = instance.IPTypeRoutedIPv4
+	} else {
+		req.Type = instance.IPTypeNat
 	}
 
 	res, err := api.CreateIP(req)


### PR DESCRIPTION
The default values for 'server.routed-ip-enabled' and 'ip.type' will change in a near future.
This fix ensures we always set the ip.type accordingly with the context.

Without this change, users will end up with the following error:
```
❯ scw instance server create routed-ip-enabled=false
Cannot create the server: scaleway-sdk-go: http error 400 Bad Request: cannot attach ip of type 'routed'
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- fix: explicitly set IP type based on routed-ip-enabled value
```
