### PR TITLE
fix(instance): use routed-ip-enabled for IP type when explicit

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -778,10 +778,12 @@ func instanceServerCreateIPCreate(args *instanceCreateServerRequest, api *instan
 		Organization: args.OrganizationID,
 	}
 
-	if args.RoutedIPEnabled != nil && *args.RoutedIPEnabled {
-		req.Type = instance.IPTypeRoutedIPv4
-	} else {
-		req.Type = instance.IPTypeNat
+	if args.RoutedIPEnabled != nil {
+		if *args.RoutedIPEnabled {
+			req.Type = instance.IPTypeRoutedIPv4
+		} else {
+			req.Type = instance.IPTypeNat
+		}
 	}
 
 	res, err := api.CreateIP(req)


### PR DESCRIPTION
Routed IPs are getting enabled per default.
This fix: `scw instance server create` with an API that enable `routed_ip_enabled` per default.

Before this fix, the server is created with `routed_ip_enabled=true` but the IP will be created as NAT because the CLI do that when `routed-ip-enabled` is omitted.