### PR TITLE
ci(release): remove homebrew bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  homebrew:
-    needs:
-      - goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Bump scw Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{secrets.SCALEWAY_BOT_TOKEN}}
-          formula: scw
-
   wasm:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Scaleway's cli is listed in homebrew-core [autobump list](https://github.com/Homebrew/homebrew-core/blob/master/.github/autobump.txt).
This now blocks the CI from making a manual bump PR using homebrew formulae bump tool.

CI output:
```
Error: Whoops, the scw formula has its version update
pull requests automatically opened by BrewTestBot!
We'd still love your contributions, though, so try another one
that's not in the autobump list:
  https://github.com/Homebrew/homebrew-core/blob/master/.github/autobump.txt
```