### PR TITLE
feat(secret-manager): add option 'field' and 'raw' to secret version accesss

### DIFF
--- a/internal/namespaces/secret/v1beta1/custom.go
+++ b/internal/namespaces/secret/v1beta1/custom.go
@@ -2,20 +2,28 @@ package secret
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
 
 	"github.com/scaleway/scaleway-cli/v2/internal/core"
 	secret "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 )
 
+type customAccessSecretVersionRequest struct {
+	secret.AccessSecretVersionRequest
+	Field *string
+	Raw   bool
+}
+
 func GetCommands() *core.Commands {
 	cmds := GetGeneratedCommands()
-
-	cmds.MustFind("secret", "version", "create").Override(dataCreateVersion)
+	cmds.MustFind("secret", "version", "create").Override(secretVersionCreateData)
 	cmds.MustFind("secret", "version", "access").Override(secretVersionAccessCommand)
 	return cmds
 }
 
-func dataCreateVersion(c *core.Command) *core.Command {
+func secretVersionCreateData(c *core.Command) *core.Command {
 	*c.ArgSpecs.GetByName("data") = core.ArgSpec{
 		Name:        "data",
 		Short:       "Content of the secret version. Base64 is handled by the SDK",
@@ -26,19 +34,65 @@ func dataCreateVersion(c *core.Command) *core.Command {
 }
 
 func secretVersionAccessCommand(c *core.Command) *core.Command {
-	c.Run = func(ctx context.Context, args interface{}) (i interface{}, e error) {
-		request := args.(*secret.AccessSecretVersionRequest)
+	c.ArgsType = reflect.TypeOf(customAccessSecretVersionRequest{})
 
+	c.ArgSpecs.AddBefore("region", &core.ArgSpec{
+		Name:  "field",
+		Short: "Return only the JSON field of the given name",
+	})
+
+	c.ArgSpecs.AddBefore("region", &core.ArgSpec{
+		Name:  "raw",
+		Short: "Return only the raw payload",
+	})
+
+	c.Run = func(ctx context.Context, args interface{}) (i interface{}, e error) {
 		client := core.ExtractClient(ctx)
 		api := secret.NewAPI(client)
-		res, err := api.AccessSecretVersion(request)
 
+		request := args.(*customAccessSecretVersionRequest)
+
+		response, err := api.AccessSecretVersion(&secret.AccessSecretVersionRequest{
+			Region:   request.Region,
+			SecretID: request.SecretID,
+			Revision: request.Revision,
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		return core.RawResult(res.Data), nil
+		if request.Field != nil {
+			response.Data, err = getSecretVersionField(response.Data, *request.Field)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if request.Raw {
+			return core.RawResult(response.Data), nil
+		}
+
+		return response, nil
 	}
 
 	return c
+}
+
+func getSecretVersionField(data []byte, field string) ([]byte, error) {
+	var rawFields interface{}
+	if err := json.Unmarshal(data, &rawFields); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal JSON data")
+	}
+
+	rawField, ok := rawFields.(map[string]interface{})[field]
+	if !ok {
+		return nil, fmt.Errorf("JSON field is not present")
+	}
+
+	switch field := rawField.(type) {
+	case string:
+		return []byte(field), nil
+	default:
+		return nil, fmt.Errorf("JSON field type is not valid")
+	}
 }


### PR DESCRIPTION
Add a new option 'field' to the secret version access subcommand. This option allows to retrieve only the JSON field with the given name from a Secret Version. The Secret Version data must be in JSON format.

Add a new option 'raw' to the secret version access subcommand. This option allows to retrieve only the raw payload of a Secret Version. This option was added because the change in https://github.com/scaleway/scaleway-cli/pull/3721 is a breaking change.

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
```release-note
* **sem**: add option 'raw' to secret version access to retrieve the raw payload only
* **sem**: add option 'field' to secret version access to retrieve a JSON field
```
