### PR TITLE
fix(container): limit to platforms supported by github.com/buildpacks/lifecycle

### DIFF
--- a/internal/namespaces/container/v1beta1/custom_deploy.go
+++ b/internal/namespaces/container/v1beta1/custom_deploy.go
@@ -1,4 +1,4 @@
-//go:build !wasm && !freebsd
+//go:build darwin || linux || windows
 
 package container
 

--- a/internal/namespaces/container/v1beta1/custom_deploy_disabled.go
+++ b/internal/namespaces/container/v1beta1/custom_deploy_disabled.go
@@ -1,4 +1,4 @@
-//go:build wasm || freebsd
+//go:build !(darwin || linux || windows)
 
 package container
 

--- a/internal/namespaces/container/v1beta1/custom_deploy_helpers.go
+++ b/internal/namespaces/container/v1beta1/custom_deploy_helpers.go
@@ -1,4 +1,4 @@
-//go:build !wasm && !freebsd
+//go:build darwin || linux || windows
 
 package container
 


### PR DESCRIPTION
"deploy" commands needs `github.com/buildpacks/lifecycle` and `github.com/buildpacks/lifecycle/path` is currently supported only by `darwin`, `linux` and `windows`.

Adjust the logic to only consider those 3 platforms instead of excluding only `wasm` and `freebsd`.

---

Noticed while building `scw` on NetBSD (but should affects all platforms that are not WASM, FreeBSD, macOS and Linux (e.g. other BSDs, Solaris)).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix support to more Unix-like (non-macOS/Linux/FreeBSD) platforms by disabling `container namespace deploy` command where it is not supported.
```
