### PR TITLE
feat(k8s): add support to show up the zone in the pool infos of a clu…

### DIFF
--- a/internal/namespaces/k8s/v1/custom_cluster.go
+++ b/internal/namespaces/k8s/v1/custom_cluster.go
@@ -260,6 +260,7 @@ func clusterGetBuilder(c *core.Command) *core.Command {
 			MaxSize     uint32         `json:"max_size"`
 			Autoscaling bool           `json:"autoscaling"`
 			Autohealing bool           `json:"autohealing"`
+			Zone        scw.Zone       `json:"zone"`
 		}
 
 		customPools := []customPool{}
@@ -276,6 +277,7 @@ func clusterGetBuilder(c *core.Command) *core.Command {
 				MaxSize:     pool.MaxSize,
 				Autoscaling: pool.Autoscaling,
 				Autohealing: pool.Autohealing,
+				Zone:        pool.Zone,
 			})
 		}
 

--- a/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.golden
+++ b/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.golden
@@ -43,8 +43,8 @@ UsernamePrefix  -
 GroupsPrefix    -
 
 Pools:
-ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN SIZE  SIZE  MAX SIZE  AUTOSCALING  AUTOHEALING
-1da2aa9e-463c-422a-b523-11274412dd5d  default  scaling  1.27.1   dev1_m     0         1     1         false        false
+ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN SIZE  SIZE  MAX SIZE  AUTOSCALING  AUTOHEALING  ZONE
+1da2aa9e-463c-422a-b523-11274412dd5d  default  scaling  1.27.1   dev1_m     0         1     1         false        false        fr-par-1
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "id": "e96a93a2-c36f-42bb-b7e1-bebf52db7956",
@@ -107,7 +107,8 @@ ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN 
       "size": 1,
       "max_size": 1,
       "autoscaling": false,
-      "autohealing": false
+      "autohealing": false,
+      "zone": "fr-par-1"
     }
   ]
 }


### PR DESCRIPTION
Because pools can be in different AZ within the same region, it would be helpful to show where they are

```
Pools:
ID                                    NAME                     STATUS  VERSION  NODE TYPE  MIN SIZE  SIZE  MAX SIZE  AUTOSCALING  AUTOHEALING  ZONE
0819d779-ade0-4b32-9b24-bab8c5284944  cli-pool-silly-kapitsa   ready   1.29.1   dev1_m     1         1     10        true         false        fr-par-1
8e17ea00-fad7-4e58-ab9e-248c23d37a5a  pool-unruffled-beaver    ready   1.29.1   pro2_s     0         3     3         false        true         fr-par-1
1bba0861-a326-4d93-a610-d1b7a1691ec4  pool-crazy-rhodes        ready   1.29.1   pro2_s     0         3     3         false        true         fr-par-2
bc96c5c4-a985-4ba0-bd19-ef1f64f80a56  cli-pool-hopeful-edison  ready   1.29.1   pro2_s     0         1     1         false        false        fr-par-3
```