### PR TITLE
fix(dedibox): remove command from custom setProjectDefaultValue

### DIFF
--- a/internal/namespaces/dedibox/v1/custom.go
+++ b/internal/namespaces/dedibox/v1/custom.go
@@ -15,7 +15,6 @@ func GetCommands() *core.Commands {
 		{"dedibox", "offer", "list"},
 		{"dedibox", "offer", "get"},
 		{"dedibox", "os", "list"},
-		{"dedibox", "os", "get"},
 		{"dedibox", "fip", "list"},
 		{"dedibox", "fip", "get-quota"},
 		{"dedibox", "billing", "list-invoice"},


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
