### PR TITLE
test(init): override SHELL variable to not depend on local shell

### DIFF
--- a/internal/namespaces/autocomplete/autocomplete.go
+++ b/internal/namespaces/autocomplete/autocomplete.go
@@ -172,8 +172,9 @@ func InstallCommandRun(ctx context.Context, argsI interface{}) (i interface{}, e
 	logger.Debugf("shellArg: %v", shellArg)
 	if shellArg == "" {
 		defaultShellName := "bash"
-		if os.Getenv("SHELL") != "" {
-			defaultShellName = filepath.Base(os.Getenv("SHELL"))
+
+		if core.ExtractEnv(ctx, "SHELL") != "" {
+			defaultShellName = filepath.Base(core.ExtractEnv(ctx, "SHELL"))
 		}
 
 		promptedShell, err := interactive.PromptStringWithConfig(&interactive.PromptStringConfig{

--- a/internal/namespaces/init/init_test.go
+++ b/internal/namespaces/init/init_test.go
@@ -226,10 +226,12 @@ func TestInit(t *testing.T) {
 
 func TestInit_Prompt(t *testing.T) {
 	promptResponse := []string{
-		"secret-key",
-		"access-key",
-		"organization-id",
-		" ",
+		"secret-key",      // Secret key prompt, should be replaced in BeforeFunc.
+		"access-key",      // Access key prompt, should be replaced in BeforeFunc.
+		"organization-id", // Organization prompt, should be replaced in BeforeFunc.
+		" ",               // default-project-id list prompt, space is validation, it will pick default organization project.
+		"",                // Telemetry prompt, use default value.
+		"y",               // Autocomplete prompt, enable it but the tests should override a SHELL variable to avoid breaking because of local configuration.
 	}
 
 	t.Run("Simple", core.Test(&core.TestConfig{
@@ -266,6 +268,9 @@ func TestInit_Prompt(t *testing.T) {
 				assert.Equal(t, *config.DefaultProjectID, *config.DefaultProjectID)
 			}),
 		),
+		OverrideEnv: map[string]string{
+			"SHELL": "/bin/bash",
+		},
 		PromptResponseMocks: promptResponse,
 	}))
 }


### PR DESCRIPTION
Fix #4133 