### PR TITLE
feat(instance): allow to create IPv6 only instances

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create.go
+++ b/internal/namespaces/instance/v1/custom_server_create.go
@@ -28,6 +28,7 @@ type instanceCreateServerRequest struct {
 	IP                string
 	Tags              []string
 	IPv6              bool
+	IPv4              bool
 	Stopped           bool
 	SecurityGroupID   string
 	PlacementGroupID  string
@@ -99,6 +100,11 @@ func serverCreateCommand() *core.Command {
 			{
 				Name:  "ipv6",
 				Short: "Enable IPv6, to be used with routed-ip-enabled=false",
+			},
+			{
+				Name:    "ipv4",
+				Short:   "Enable/disable IPv4. Useful for routed IPs",
+				Default: core.DefaultValueSetter("true"),
 			},
 			{
 				Name:  "stopped",
@@ -209,6 +215,7 @@ func instanceServerCreateRun(ctx context.Context, argsI interface{}) (i interfac
 		AddOrganizationID(args.OrganizationID).
 		AddProjectID(args.ProjectID).
 		AddEnableIPv6(scw.BoolPtr(args.IPv6)).
+		AddEnableIPv4(scw.BoolPtr(args.IPv4)).
 		AddTags(args.Tags).
 		AddRoutedIPEnabled(args.RoutedIPEnabled).
 		AddAdminPasswordEncryptionSSHKeyID(args.AdminPasswordEncryptionSSHKeyID).


### PR DESCRIPTION
With the routed IP, when creating a new instances with `ip=<IPv6_UUID>` you still end up with an IPv4 attached to your instance due to the `dynamic_ip_required` defaulting to `true`.
This change allows one to create IPv6 only instances when passing the new option `ipv4=false` (which defaults to `true` to remain backward compatible).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
feat(instance): allow to create IPv6 only instances
```
