### PR TITLE
test: move type assertion helpers to testhelpers package

### DIFF
--- a/core/testing.go
+++ b/core/testing.go
@@ -89,27 +89,6 @@ func (meta testMetadata) render(strTpl string) string {
 	return buf.String()
 }
 
-func GetFromMeta[T any](t *testing.T, ctx *CheckFuncCtx, key string) T {
-	t.Helper()
-
-	item, ok := ctx.Meta[key]
-	assert.True(t, ok)
-	typedItem, typeIsCorrect := item.(T)
-	assert.True(t, typeIsCorrect)
-
-	return typedItem
-}
-
-func GetTestResult[T any](t *testing.T, ctx *CheckFuncCtx) T {
-	t.Helper()
-
-	typedItem, typeIsCorrect := ctx.Result.(T)
-	assert.True(t, typeIsCorrect)
-	assert.NotNil(t, typedItem)
-
-	return typedItem
-}
-
 func BeforeFuncStoreInMeta(key string, value interface{}) BeforeFunc {
 	return func(ctx *BeforeFuncCtx) error {
 		ctx.Meta[key] = value

--- a/internal/namespaces/instance/v1/custom_image_test.go
+++ b/internal/namespaces/instance/v1/custom_image_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alecthomas/assert"
 	"github.com/scaleway/scaleway-cli/v2/core"
 	"github.com/scaleway/scaleway-cli/v2/internal/namespaces/instance/v1"
+	"github.com/scaleway/scaleway-cli/v2/internal/testhelpers"
 	instanceSDK "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 )
@@ -62,8 +63,10 @@ func Test_ImageDelete(t *testing.T) {
 				t.Helper()
 				// Assert snapshot are deleted with the image
 				api := instanceSDK.NewAPI(ctx.Client)
+				snapshot := testhelpers.MapValue[*instanceSDK.CreateSnapshotResponse](t, ctx.Meta, "Snapshot")
+
 				_, err := api.GetSnapshot(&instanceSDK.GetSnapshotRequest{
-					SnapshotID: ctx.Meta["Snapshot"].(*instanceSDK.CreateSnapshotResponse).Snapshot.ID,
+					SnapshotID: snapshot.Snapshot.ID,
 				})
 				assert.IsType(t, &scw.ResourceNotFoundError{}, err)
 			},

--- a/internal/namespaces/instance/v1/custom_server_create_test.go
+++ b/internal/namespaces/instance/v1/custom_server_create_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/scaleway/scaleway-cli/v2/core"
 	block "github.com/scaleway/scaleway-cli/v2/internal/namespaces/block/v1alpha1"
 	"github.com/scaleway/scaleway-cli/v2/internal/namespaces/instance/v1"
+	"github.com/scaleway/scaleway-cli/v2/internal/testhelpers"
 	blockSDK "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
 	instanceSDK "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
@@ -123,7 +124,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size := ctx.Result.(*instanceSDK.Server).Volumes["0"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "0")
+					size := volume.Size
 					assert.Equal(t, 20*scw.GB, instance.SizeValue(size), "Size of volume should be 20 GB")
 				},
 				core.TestCheckExitCode(0),
@@ -143,7 +146,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size := ctx.Result.(*instanceSDK.Server).Volumes["0"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "0")
+					size := volume.Size
 					assert.Equal(t, 20*scw.GB, instance.SizeValue(size), "Size of volume should be 20 GB")
 				},
 			),
@@ -166,7 +171,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size := ctx.Result.(*instanceSDK.Server).Volumes["0"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "0")
+					size := volume.Size
 					assert.Equal(t, 20*scw.GB, instance.SizeValue(size), "Size of volume should be 20 GB")
 				},
 			),
@@ -184,8 +191,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size0 := ctx.Result.(*instanceSDK.Server).Volumes["0"].Size
-					size1 := ctx.Result.(*instanceSDK.Server).Volumes["1"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					size0 := testhelpers.MapTValue(t, server.Volumes, "0").Size
+					size1 := testhelpers.MapTValue(t, server.Volumes, "1").Size
 					assert.Equal(t, 10*scw.GB, instance.SizeValue(size0), "Size of volume should be 10 GB")
 					assert.Equal(t, 10*scw.GB, instance.SizeValue(size1), "Size of volume should be 10 GB")
 				},
@@ -206,8 +214,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size0 := ctx.Result.(*instanceSDK.Server).Volumes["0"].Size
-					size1 := ctx.Result.(*instanceSDK.Server).Volumes["1"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					size0 := testhelpers.MapTValue(t, server.Volumes, "0").Size
+					size1 := testhelpers.MapTValue(t, server.Volumes, "1").Size
 					assert.Equal(t, 20*scw.GB, instance.SizeValue(size0), "Size of volume should be 20 GB")
 					assert.Equal(t, 20*scw.GB, instance.SizeValue(size1), "Size of volume should be 20 GB")
 				},
@@ -227,9 +236,10 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					size1 := ctx.Result.(*instanceSDK.Server).Volumes["1"].Size
-					size2 := ctx.Result.(*instanceSDK.Server).Volumes["2"].Size
-					size3 := ctx.Result.(*instanceSDK.Server).Volumes["3"].Size
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					size1 := testhelpers.MapTValue(t, server.Volumes, "1").Size
+					size2 := testhelpers.MapTValue(t, server.Volumes, "2").Size
+					size3 := testhelpers.MapTValue(t, server.Volumes, "3").Size
 					assert.Equal(t, 1*scw.GB, instance.SizeValue(size1), "Size of volume should be 1 GB")
 					assert.Equal(t, 5*scw.GB, instance.SizeValue(size2), "Size of volume should be 5 GB")
 					assert.Equal(t, 10*scw.GB, instance.SizeValue(size3), "Size of volume should be 10 GB")
@@ -251,7 +261,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, ctx.Result.(*instanceSDK.Server).Volumes["1"].VolumeType)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "1")
+					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, volume.VolumeType)
 				},
 				core.TestCheckExitCode(0),
 			),
@@ -271,7 +283,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, ctx.Result.(*instanceSDK.Server).Volumes["1"].VolumeType)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "1")
+					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, volume.VolumeType)
 				},
 			),
 			AfterFunc: core.AfterFuncCombine(
@@ -293,7 +307,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, ctx.Result.(*instanceSDK.Server).Volumes["0"].VolumeType)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "0")
+					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, volume.VolumeType)
 				},
 			),
 			AfterFunc: core.AfterFuncCombine(
@@ -312,7 +328,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, ctx.Result.(*instanceSDK.Server).Volumes["0"].VolumeType)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					volume := testhelpers.MapTValue(t, server.Volumes, "0")
+					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, volume.VolumeType)
 				},
 			),
 			AfterFunc: core.AfterFuncCombine(
@@ -331,7 +349,9 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					rootVolume, rootVolumeExists := ctx.Result.(*instanceSDK.Server).Volumes["0"]
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+
+					rootVolume, rootVolumeExists := server.Volumes["0"]
 					assert.True(t, rootVolumeExists)
 					assert.Equal(t, instanceSDK.VolumeServerVolumeTypeSbsVolume, rootVolume.VolumeType)
 
@@ -362,8 +382,10 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.NotEmpty(t, ctx.Result.(*instanceSDK.Server).PublicIP.Address)
-					assert.Equal(t, false, ctx.Result.(*instanceSDK.Server).PublicIP.Dynamic)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					assert.NotNil(t, server.PublicIP)
+					assert.NotEmpty(t, server.PublicIP.Address)
+					assert.Equal(t, false, server.PublicIP.Dynamic)
 				},
 				core.TestCheckExitCode(0),
 			),
@@ -378,8 +400,10 @@ func Test_CreateServer(t *testing.T) {
 					t.Helper()
 					assert.NoError(t, ctx.Err)
 					assert.NotNil(t, ctx.Result)
-					assert.NotEmpty(t, ctx.Result.(*instanceSDK.Server).PublicIP.Address)
-					assert.Equal(t, true, ctx.Result.(*instanceSDK.Server).DynamicIPRequired)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					assert.NotNil(t, server.PublicIP)
+					assert.NotEmpty(t, server.PublicIP.Address)
+					assert.Equal(t, true, server.DynamicIPRequired)
 				},
 				core.TestCheckExitCode(0),
 			),
@@ -394,8 +418,10 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.NotEmpty(t, ctx.Result.(*instanceSDK.Server).PublicIP.Address)
-					assert.Equal(t, false, ctx.Result.(*instanceSDK.Server).PublicIP.Dynamic)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					assert.NotNil(t, server.PublicIP)
+					assert.NotEmpty(t, server.PublicIP.Address)
+					assert.Equal(t, false, server.PublicIP.Dynamic)
 				},
 				core.TestCheckExitCode(0),
 			),
@@ -410,8 +436,10 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result)
-					assert.NotEmpty(t, ctx.Result.(*instanceSDK.Server).PublicIP.Address)
-					assert.Equal(t, false, ctx.Result.(*instanceSDK.Server).PublicIP.Dynamic)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
+					assert.NotNil(t, server.PublicIP)
+					assert.NotEmpty(t, server.PublicIP.Address)
+					assert.Equal(t, false, server.PublicIP.Dynamic)
 				},
 				core.TestCheckExitCode(0),
 			),
@@ -425,7 +453,7 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					require.NotNil(t, ctx.Result, "Server is nil")
-					server := ctx.Result.(*instanceSDK.Server)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
 					assert.Len(t, server.PublicIPs, 1)
 					assert.Equal(t, instanceSDK.ServerIPIPFamilyInet6, server.PublicIPs[0].Family)
 				},
@@ -442,7 +470,7 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result, "server is nil")
-					server := ctx.Result.(*instanceSDK.Server)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
 					assert.Len(t, server.PublicIPs, 2)
 					assert.Equal(t, instanceSDK.ServerIPIPFamilyInet, server.PublicIPs[0].Family)
 					assert.True(t, server.PublicIPs[0].Dynamic)
@@ -460,7 +488,7 @@ func Test_CreateServer(t *testing.T) {
 				func(t *testing.T, ctx *core.CheckFuncCtx) {
 					t.Helper()
 					assert.NotNil(t, ctx.Result, "server is nil")
-					server := ctx.Result.(*instanceSDK.Server)
+					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
 					assert.Len(t, server.PublicIPs, 2)
 					assert.Equal(t, instanceSDK.ServerIPIPFamilyInet, server.PublicIPs[0].Family)
 					assert.Equal(t, instanceSDK.ServerIPIPFamilyInet6, server.PublicIPs[1].Family)

--- a/internal/namespaces/instance/v1/custom_server_rdp_test.go
+++ b/internal/namespaces/instance/v1/custom_server_rdp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/scaleway/scaleway-cli/v2/core"
 	iamCLI "github.com/scaleway/scaleway-cli/v2/internal/namespaces/iam/v1alpha1"
 	"github.com/scaleway/scaleway-cli/v2/internal/namespaces/instance/v1"
+	"github.com/scaleway/scaleway-cli/v2/internal/testhelpers"
 	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
 	"golang.org/x/crypto/ssh"
 )
@@ -128,10 +129,7 @@ func Test_ServerGetRdpPassword(t *testing.T) {
 			func(t *testing.T, ctx *core.CheckFuncCtx) {
 				t.Helper()
 				assert.NotNil(t, ctx.Result)
-				resp, ok := ctx.Result.(*instance.ServerGetRdpPasswordResponse)
-				if !ok {
-					t.Fatal("Unexpected result type: " + reflect.TypeOf(ctx.Result).String())
-				}
+				resp := testhelpers.Value[*instance.ServerGetRdpPasswordResponse](t, ctx.Result)
 
 				assert.NotEmpty(t, resp.Password)
 			},

--- a/internal/namespaces/instance/v1/testdata/test-server-terminate-without-ip.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-terminate-without-ip.cassette.yaml
@@ -2,82 +2,6 @@
 version: 1
 interactions:
 - request:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1183"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:36:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a2d9c80-332e-42eb-92a0-c20b42a711f6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
-      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cb01f4c-9cd0-4032-8ce6-325c458df811
-    method: GET
-  response:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
-      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "620"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:36:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8e72fabe-fb59-4b60-a16c-7211e1a04148
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
@@ -87,52 +11,55 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      167772160}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 36.1496, "hourly_price": 0.04952,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      209715200}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
       4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -141,16 +68,17 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
       300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      104857600}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
       12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -159,25 +87,26 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
       20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
       68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -186,26 +115,27 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
@@ -213,43 +143,46 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 576.262, "hourly_price": 0.7894,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000,
+      "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
       5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 296.672, "hourly_price": 0.4064,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 149.066, "hourly_price": 0.2042,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      524288000}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -258,26 +191,28 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 1220.122, "hourly_price": 1.6714,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000,
+      "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
       10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      314572800}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
@@ -285,17 +220,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram":
+      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
@@ -303,16 +239,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
       100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth":
+      3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}, "block_bandwidth":
+      3355443200}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -321,17 +258,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
       "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
@@ -339,16 +277,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -357,16 +296,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -375,34 +315,36 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -411,16 +353,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -429,16 +372,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -447,16 +391,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -465,16 +410,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -483,16 +429,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -501,38 +448,40 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
+      530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth":
+      3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}, "block_bandwidth":
+      419430400}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
@@ -545,52 +494,55 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      167772160}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 36.1496, "hourly_price": 0.04952,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      209715200}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
       4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -599,16 +551,17 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
       300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      104857600}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
       12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -617,25 +570,26 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
       20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
       68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -644,26 +598,27 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
@@ -671,43 +626,46 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 576.262, "hourly_price": 0.7894,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 5000000000,
+      "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
       5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 296.672, "hourly_price": 0.4064,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 149.066, "hourly_price": 0.2042,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      524288000}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -716,26 +674,28 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
       500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 1220.122, "hourly_price": 1.6714,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 10000000000,
+      "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
       10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      314572800}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
@@ -743,17 +703,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 19.71, "hourly_price": 0.027, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      83886080}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1, "ram":
+      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
@@ -761,16 +722,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
       100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth":
+      3200000000, "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3200000000}]}, "block_bandwidth":
+      3355443200}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -779,17 +741,18 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
       "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
@@ -797,16 +760,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
       400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth":
+      6400000000, "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 6400000000}]}, "block_bandwidth":
+      6710886400}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -815,16 +779,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
       4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -833,34 +798,36 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
       800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth":
+      12800000000, "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 12800000000}]}, "block_bandwidth":
+      13421772800}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
+      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
       1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -869,16 +836,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -887,16 +855,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -905,16 +874,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
       16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -923,16 +893,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
       3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 75.19, "hourly_price": 0.103, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
+      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      419430400}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
       32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -941,16 +912,17 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
       6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth":
+      800000000, "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 800000000}]}, "block_bandwidth":
+      838860800}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
       64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
@@ -959,108 +931,139 @@ interactions:
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
       12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 300.76, "hourly_price": 0.412, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth":
+      1600000000, "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1600000000}]}, "block_bandwidth":
+      1677721600}, "POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      530.29, "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "baremetal": false, "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": false, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth":
+      3000000000, "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 3000000000}]}, "block_bandwidth":
+      419430400}}}'
+    headers:
+      Content-Length:
+      - "39559"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Dec 2024 08:50:19 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - baa10bd8-6a68-4ac0-8e7f-064997173933
+      X-Total-Count:
+      - "69"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}, "PRO2-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
       6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
       3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "38026"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:36:30 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 162ec333-02c0-4902-b9ff-b89da197aa66
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
       700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      700000000}]}, "block_bandwidth": 262144000}, "PRO2-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
       350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      350000000}]}, "block_bandwidth": 131072000}, "RENDER-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 907.098, "hourly_price": 1.2426,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
+      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 3.3507, "hourly_price": 0.00459,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      52428800}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
@@ -1069,17 +1072,18 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
       400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      41943040}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth":
+      300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 300000000}]}, "block_bandwidth":
+      41943040}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
       2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -1088,17 +1092,18 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      41943040}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6,
+      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
@@ -1106,18 +1111,19 @@ interactions:
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
       200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 11.3515, "hourly_price": 0.01555,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2,
+      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
       false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
@@ -1125,37 +1131,38 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
       "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
       250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}, "block_bandwidth":
+      41943040}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      300000000000, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 86.9138, "hourly_price": 0.11906,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      41943040}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
@@ -1163,60 +1170,90 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
       1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}, "block_bandwidth":
+      41943040}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+    body: '{"servers": {"POP2-HN-5": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
       0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      330.29, "hourly_price": 0.4524, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}, "PRO2-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
       1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
       700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
+      700000000}]}, "block_bandwidth": 262144000}, "PRO2-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
       40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
       false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
       350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      350000000}]}, "block_bandwidth": 131072000}, "RENDER-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 907.098, "hourly_price": 1.2426,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
+      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      1000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 3.3507, "hourly_price": 0.00459,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      52428800}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
       8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
@@ -1225,17 +1262,18 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
       400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}, "block_bandwidth":
+      41943040}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
+      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth":
+      300000000, "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 300000000}]}, "block_bandwidth":
+      41943040}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
       2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
@@ -1244,17 +1282,18 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities":
+      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
+      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
+      {"ipv6_support": true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth":
+      100000000, "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 100000000}]}, "block_bandwidth":
+      41943040}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus": 6,
+      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
@@ -1262,18 +1301,19 @@ interactions:
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
       200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 11.3515, "hourly_price": 0.01555,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus": 2,
+      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
       1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
       false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
@@ -1281,37 +1321,38 @@ interactions:
       true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
       200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
       "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
       1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
       "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
       "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
       8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
       250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}, "block_bandwidth":
+      41943040}, "X64-30GB": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
+      32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      300000000000, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "baremetal": false, "monthly_price": 86.9138, "hourly_price": 0.11906,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth":
+      500000000, "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 500000000}]}, "block_bandwidth":
+      41943040}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
       400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
       null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
@@ -1319,21 +1360,22 @@ interactions:
       true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
       {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
       1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}, "block_bandwidth":
+      41943040}}}'
     headers:
       Content-Length:
-      - "12534"
+      - "15351"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:30 GMT
+      - Fri, 13 Dec 2024 08:50:20 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1341,30 +1383,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42344fa-f82e-41d5-8cdf-ed11c211e50f
+      - 61cef91c-a39f-410f-adf0-a2f397c65337
       X-Total-Count:
-      - "66"
+      - "69"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}}'
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1220"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Dec 2024 08:50:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ac73312-b782-4eaa-a775-30c78113c67e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
+    method: GET
+  response:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Dec 2024 08:50:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd35076a-8e1c-497d-ba64-4c72bbbf1b71
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
+      "prefix": null, "reverse": null, "server": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}}'
+    body: '{"ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
+      "prefix": null, "reverse": null, "server": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}}'
     headers:
       Content-Length:
       - "365"
@@ -1373,11 +1491,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:30 GMT
+      - Fri, 13 Dec 2024 08:50:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fca8b329-6c0e-4f9c-aa88-d5c197b5919a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1385,105 +1503,93 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9be99723-92ec-46b7-80e9-6980e43b92ce
+      - ce6b1378-df27-4be2-b850-234620744060
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
+      "", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
       "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"},
-      "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"},
+      "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
       "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}],
-      "mac_address": "de:00:00:5f:a0:e3", "routed_ip_enabled": true, "ipv6": null,
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}],
+      "mac_address": "de:00:00:86:28:e3", "routed_ip_enabled": true, "ipv6": null,
       "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:36:31.409856+00:00", "modification_date":
-      "2024-07-05T12:36:31.409856+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      null, "creation_date": "2024-12-13T08:50:21.367250+00:00", "modification_date":
+      "2024-12-13T08:50:21.367250+00:00", "bootscript": null, "security_group": {"id":
+      "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
+      "", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
       "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"},
-      "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"},
+      "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
       "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}],
-      "mac_address": "de:00:00:5f:a0:e3", "routed_ip_enabled": true, "ipv6": null,
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}],
+      "mac_address": "de:00:00:86:28:e3", "routed_ip_enabled": true, "ipv6": null,
       "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:36:31.409856+00:00", "modification_date":
-      "2024-07-05T12:36:31.409856+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      null, "creation_date": "2024-12-13T08:50:21.367250+00:00", "modification_date":
+      "2024-12-13T08:50:21.367250+00:00", "bootscript": null, "security_group": {"id":
+      "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3168"
+      - "2661"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:31 GMT
+      - Fri, 13 Dec 2024 08:50:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1491,29 +1597,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3145b61b-2012-40b3-ae8d-dd6d37a3cbd2
+      - 113c62ba-ad00-4ebe-8827-580979cc341b
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"task": {"id": "c48ce8b7-c9e7-457d-a9fb-638c4f7ed75c", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action",
-      "href_result": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba", "started_at":
-      "2024-07-05T12:36:32.225453+00:00", "terminated_at": null, "progress": 0, "zone":
+    body: '{"task": {"id": "4d0004ea-1be6-48f1-8aaa-056af533e409", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action",
+      "href_result": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73", "started_at":
+      "2024-12-13T08:50:22.379461+00:00", "terminated_at": null, "progress": 0, "zone":
       "par1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action
     method: POST
   response:
-    body: '{"task": {"id": "c48ce8b7-c9e7-457d-a9fb-638c4f7ed75c", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action",
-      "href_result": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba", "started_at":
-      "2024-07-05T12:36:32.225453+00:00", "terminated_at": null, "progress": 0, "zone":
+    body: '{"task": {"id": "4d0004ea-1be6-48f1-8aaa-056af533e409", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action",
+      "href_result": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73", "started_at":
+      "2024-12-13T08:50:22.379461+00:00", "terminated_at": null, "progress": 0, "zone":
       "par1"}}'
     headers:
       Content-Length:
@@ -1523,11 +1629,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:32 GMT
+      - Fri, 13 Dec 2024 08:50:22 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c48ce8b7-c9e7-457d-a9fb-638c4f7ed75c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/4d0004ea-1be6-48f1-8aaa-056af533e409
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1535,101 +1641,183 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f499ec5-736c-4516-9905-c52a95b581f7
+      - 71b7c7ad-aa24-4474-97a9-73d05a17073f
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "allocating node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
+    method: GET
+  response:
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2683"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Dec 2024 08:50:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cb2f3fa-9210-4f21-a0c3-ddf4df5c88a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
       ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
     method: GET
   response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "provisioning node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
       ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3190"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:32 GMT
+      - Fri, 13 Dec 2024 08:50:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1637,103 +1825,93 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1560350-40ab-4e70-ab9d-fbf72aeb88ca
+      - 52a07c4b-f7fa-4a54-bbef-0cf3de475908
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "provisioning node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
     method: GET
   response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "provisioning node", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:22.153327+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3289"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:37 GMT
+      - Fri, 13 Dec 2024 08:50:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1741,103 +1919,93 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4adef5f9-e7fd-47c9-a1ce-11d412ed6b5b
+      - 95c3d994-cb36-4333-9cd9-1f3fdd0eeff5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:34.305028+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
     method: GET
   response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.850854+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:34.305028+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3289"
+      - "2814"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:42 GMT
+      - Fri, 13 Dec 2024 08:50:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1845,103 +2013,93 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf8ce356-cf5e-4613-a761-68f7732f9e0f
+      - 0211608b-2854-43ff-9cfd-e6813217ebd3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "booting kernel", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:45.510525+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:34.305028+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73
     method: GET
   response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
+    body: '{"server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "hostname": "cli-srv-sweet-lichterman", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
+      "volumes": {"0": {"boot": false, "id": "546171f7-ebf1-4bf3-8c43-f02d2fa972c2",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
+      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73", "name": "cli-srv-sweet-lichterman"},
+      "size": 20000000000, "state": "available", "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:21.367250+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "booting kernel", "public_ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}, "public_ips": [{"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70",
+      "address": "51.15.234.137", "dynamic": false, "gateway": "62.210.0.1", "netmask":
       "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
+      "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}], "mac_address": "de:00:00:86:28:e3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:45.510525+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-13T08:50:21.367250+00:00",
+      "modification_date": "2024-12-13T08:50:34.305028+00:00", "bootscript": null,
+      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "37", "hypervisor_id": "1801", "node_id": "22"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3320"
+      - "2814"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:47 GMT
+      - Fri, 13 Dec 2024 08:50:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1949,133 +2107,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 050fdaf7-1b3c-43dc-af7d-28044e0be7d4
+      - 2807bd70-172b-488e-ad45-68dd8fce0cab
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:45.510525+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba
-    method: GET
-  response:
-    body: '{"server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-blissful-taussig", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "739132ca-4211-474f-86b5-6cca7c15355f",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba", "name": "cli-srv-blissful-taussig"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:31.409856+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}, "public_ips": [{"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a",
-      "address": "51.15.231.134", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}], "mac_address": "de:00:00:5f:a0:e3",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:36:31.409856+00:00",
-      "modification_date": "2024-07-05T12:36:45.510525+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "93", "hypervisor_id": "503", "node_id": "12"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3320"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:36:48 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab613005-9ba6-45c9-bfd8-840f29cab083
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"task": {"id": "76047624-41ba-43b3-9c6c-3dae7363bfab", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action",
-      "href_result": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba", "started_at":
-      "2024-07-05T12:36:48.279301+00:00", "terminated_at": null, "progress": 0, "zone":
+    body: '{"task": {"id": "a161358b-24b1-41dc-afe1-33f111ea6c81", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action",
+      "href_result": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73", "started_at":
+      "2024-12-13T08:50:38.463164+00:00", "terminated_at": null, "progress": 0, "zone":
       "par1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action
     method: POST
   response:
-    body: '{"task": {"id": "76047624-41ba-43b3-9c6c-3dae7363bfab", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba/action",
-      "href_result": "/servers/c34fdc49-8a7b-4245-9372-8d411682f1ba", "started_at":
-      "2024-07-05T12:36:48.279301+00:00", "terminated_at": null, "progress": 0, "zone":
+    body: '{"task": {"id": "a161358b-24b1-41dc-afe1-33f111ea6c81", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73/action",
+      "href_result": "/servers/029c611a-2130-4b79-bc52-e2750c40fb73", "started_at":
+      "2024-12-13T08:50:38.463164+00:00", "terminated_at": null, "progress": 0, "zone":
       "par1"}}'
     headers:
       Content-Length:
@@ -2085,11 +2139,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:47 GMT
+      - Fri, 13 Dec 2024 08:50:38 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/76047624-41ba-43b3-9c6c-3dae7363bfab
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a161358b-24b1-41dc-afe1-33f111ea6c81
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2097,28 +2151,28 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43e86aca-c328-4f54-82ce-9e55fbb55e0d
+      - cc72d4b7-958c-4792-a360-627013e389e3
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
-      "prefix": null, "reverse": null, "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba",
-      "name": "cli-srv-blissful-taussig"}, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "attached", "tags": [], "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}}'
+    body: '{"ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
+      "prefix": null, "reverse": null, "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73",
+      "name": "cli-srv-sweet-lichterman"}, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "attached", "tags": [], "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fca8b329-6c0e-4f9c-aa88-d5c197b5919a
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70
     method: GET
   response:
-    body: '{"ip": {"id": "fca8b329-6c0e-4f9c-aa88-d5c197b5919a", "address": "51.15.231.134",
-      "prefix": null, "reverse": null, "server": {"id": "c34fdc49-8a7b-4245-9372-8d411682f1ba",
-      "name": "cli-srv-blissful-taussig"}, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "attached", "tags": [], "ipam_id": "08d94f8e-6aea-4932-ac05-8ea42e6c8d0d"}}'
+    body: '{"ip": {"id": "bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70", "address": "51.15.234.137",
+      "prefix": null, "reverse": null, "server": {"id": "029c611a-2130-4b79-bc52-e2750c40fb73",
+      "name": "cli-srv-sweet-lichterman"}, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "attached", "tags": [], "ipam_id": "4def5064-f8a4-4675-acf2-2b078270314c"}}'
     headers:
       Content-Length:
       - "443"
@@ -2127,9 +2181,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:48 GMT
+      - Fri, 13 Dec 2024 08:50:38 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2137,7 +2191,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7465c2b6-4b74-4f04-83d9-ec2a1ed9d189
+      - c9f405ac-8d20-4406-b2e9-730770adae3d
     status: 200 OK
     code: 200
     duration: ""
@@ -2146,8 +2200,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/fca8b329-6c0e-4f9c-aa88-d5c197b5919a
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/bef7fe09-8e5b-4372-a4ca-b8d42aa0fb70
     method: DELETE
   response:
     body: ""
@@ -2157,9 +2211,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:36:49 GMT
+      - Fri, 13 Dec 2024 08:50:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2167,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47de1699-8dce-4c6f-933c-2a18b7412922
+      - bd1f5983-6cbb-47ca-b6ee-6c6edb947498
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/testhelpers/helpers.go
+++ b/internal/testhelpers/helpers.go
@@ -1,0 +1,42 @@
+package testhelpers
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+)
+
+// MapValue gets a value from a map[string]any using a given key.
+// If key does not exist or type is invalid, test will fail.
+func MapValue[T any](t *testing.T, m map[string]any, key string) T {
+	t.Helper()
+
+	item, ok := m[key]
+	assert.True(t, ok)
+	typedItem, typeIsCorrect := item.(T)
+	assert.True(t, typeIsCorrect)
+
+	return typedItem
+}
+
+// MapTValue functions like MapValue but for typed maps
+func MapTValue[T any](t *testing.T, m map[string]T, key string) T {
+	t.Helper()
+
+	item, ok := m[key]
+	assert.True(t, ok, "Requested key %q does not exist in given map", key)
+	assert.NotNil(t, item, "Item is nil")
+
+	return item
+}
+
+// Value tries to assert a type value and will make test fail if type is invalid.
+func Value[T any](t *testing.T, v any) T {
+	t.Helper()
+
+	typedItem, typeIsCorrect := v.(T)
+	assert.True(t, typeIsCorrect)
+	assert.NotNil(t, typedItem)
+
+	return typedItem
+}


### PR DESCRIPTION
I added helpers to core/testing in a previous PR to help use write tests. I moved these helpers to testhelpers to avoid adding more to core.
I also used these new helpers in some instance tests.

The goal of those helpers is to limit test crashing. If a test crash, it will stop the whole test suite. If we make tests fail on failed type assertions, the rest of the test suite will still run.