### PR TITLE
fix(core): recreate io.Reader after read during file loading

### DIFF
--- a/core/arg_file_content.go
+++ b/core/arg_file_content.go
@@ -39,6 +39,10 @@ func loadArgsFileContent(cmd *Command, cmdArgs interface{}) error {
 					}
 					test := bytes.NewBuffer(content)
 					v.Set(reflect.ValueOf(test))
+				} else {
+					// Reader must be re-created as it can only be read once.
+					r := bytes.NewReader(b)
+					v.Set(reflect.ValueOf(r))
 				}
 			case *string:
 				if strings.HasPrefix(*i, "@") {


### PR DESCRIPTION
When the command allow for a file to be loaded, the argument as io.Reader would be read, thus preventing the argument from being used in the command afterward.

Issue can be reproduced with `scw instance user-data set server-id={server_id} key=foo content="bar"`.
The `bar` string would be read to search for a `@`, then it would not be available once the command really runs.
