### PR TITLE
test(k8s): ignore scw env variable in exec-credentials tests

### DIFF
--- a/internal/namespaces/k8s/v1/custom_execcredentials_test.go
+++ b/internal/namespaces/k8s/v1/custom_execcredentials_test.go
@@ -26,6 +26,10 @@ func Test_ExecCredential(t *testing.T) {
 		TmpHomeDir: true,
 		BeforeFunc: beforeFuncCreateFullConfig(),
 		Cmd:        "scw k8s exec-credential",
+		OverrideEnv: map[string]string{
+			scw.ScwAccessKeyEnv: "", // Ignore keys in test env
+			scw.ScwSecretKeyEnv: "", // Ignore keys in test env
+		},
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),
 			core.TestCheckGolden(),
@@ -57,6 +61,8 @@ func Test_ExecCredential(t *testing.T) {
 		Cmd:        "scw k8s exec-credential",
 		OverrideEnv: map[string]string{
 			scw.ScwActiveProfileEnv: "p2",
+			scw.ScwAccessKeyEnv:     "", // Ignore keys in test env
+			scw.ScwSecretKeyEnv:     "", // Ignore keys in test env
 		},
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),
@@ -71,6 +77,10 @@ func Test_ExecCredential(t *testing.T) {
 		TmpHomeDir: true,
 		BeforeFunc: beforeFuncCreateFullConfig(),
 		Cmd:        "scw --profile p3 k8s exec-credential",
+		OverrideEnv: map[string]string{
+			scw.ScwAccessKeyEnv: "", // Ignore keys in test env
+			scw.ScwSecretKeyEnv: "", // Ignore keys in test env
+		},
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),
 			core.TestCheckGolden(),
@@ -86,6 +96,8 @@ func Test_ExecCredential(t *testing.T) {
 		Cmd:        "scw --profile p3 k8s exec-credential",
 		OverrideEnv: map[string]string{
 			scw.ScwActiveProfileEnv: "p2",
+			scw.ScwAccessKeyEnv:     "", // Ignore keys in test env
+			scw.ScwSecretKeyEnv:     "", // Ignore keys in test env
 		},
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),


### PR DESCRIPTION
These tests create their own profiles to test how env is loaded. We must ignore env variables that are used to run the tests as they collide with test's profiles
