### PR TITLE
feat(block): add volume wait command

### DIFF
--- a/cmd/scw/testdata/test-all-usage-block-volume-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-block-volume-usage.golden
@@ -12,6 +12,9 @@ AVAILABLE COMMANDS:
   list        List volumes
   update      Update a volume
 
+WORKFLOW COMMANDS:
+  wait        Wait for volume to reach a stable state
+
 FLAGS:
   -h, --help   help for volume
 

--- a/cmd/scw/testdata/test-all-usage-block-volume-wait-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-block-volume-wait-usage.golden
@@ -1,0 +1,25 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟥🟥🟥 STDERR️️ 🟥🟥🟥️
+Wait for volume to reach a stable state. This is similar to using --wait flag on other action commands, but without requiring a new action on the volume.
+
+USAGE:
+  scw block volume wait <volume-id ...> [arg=value ...]
+
+EXAMPLES:
+  Wait for a volume to be available
+    scw block volume wait 11111111-1111-1111-1111-111111111111 terminal-status=available
+
+ARGS:
+  [timeout=5m0s]      Timeout of the wait
+  volume-id           ID of the volume affected by the action.
+  [terminal-status]   Expected terminal status, will wait until this status is reached. (unknown_status | creating | available | in_use | deleting | deleted | resizing | error | snapshotting | locked | updating)
+  [zone=fr-par-1]     Zone to target. If none is passed will use default zone from the config (fr-par-1 | fr-par-2 | fr-par-3 | nl-ams-1 | nl-ams-2 | nl-ams-3 | pl-waw-1 | pl-waw-2 | pl-waw-3)
+
+FLAGS:
+  -h, --help   help for wait
+
+GLOBAL FLAGS:
+  -c, --config string    The path to the config file
+  -D, --debug            Enable debug mode
+  -o, --output string    Output format: json or human, see 'scw help output' for more info (default "human")
+  -p, --profile string   The config profile to use

--- a/docs/commands/block.md
+++ b/docs/commands/block.md
@@ -16,6 +16,7 @@ This API allows you to manage your Block Storage volumes.
   - [Get a volume](#get-a-volume)
   - [List volumes](#list-volumes)
   - [Update a volume](#update-a-volume)
+  - [Wait for volume to reach a stable state](#wait-for-volume-to-reach-a-stable-state)
 - [Block Storage volume types are determined by their storage class and their IOPS. There are two storage classes available: `bssd` and `sbs`. The IOPS can be chosen for volumes of the `sbs` storage class](#block-storage-volume-types-are-determined-by-their-storage-class-and-their-iops.-there-are-two-storage-classes-available:-`bssd`-and-`sbs`.-the-iops-can-be-chosen-for-volumes-of-the-`sbs`-storage-class)
   - [List volume types](#list-volume-types)
 
@@ -303,6 +304,38 @@ scw block volume update <volume-id ...> [arg=value ...]
 | tags.{index} |  | List of tags assigned to the volume |
 | perf-iops |  | The maximum IO/s expected, according to the different options available in stock (`5000 | 15000`) |
 | zone | Default: `fr-par-1`<br />One of: `fr-par-1`, `fr-par-2`, `fr-par-3`, `nl-ams-1`, `nl-ams-2`, `nl-ams-3`, `pl-waw-1`, `pl-waw-2`, `pl-waw-3` | Zone to target. If none is passed will use default zone from the config |
+
+
+
+### Wait for volume to reach a stable state
+
+Wait for volume to reach a stable state. This is similar to using --wait flag on other action commands, but without requiring a new action on the volume.
+
+**Usage:**
+
+```
+scw block volume wait <volume-id ...> [arg=value ...]
+```
+
+
+**Args:**
+
+| Name |   | Description |
+|------|---|-------------|
+| timeout | Default: `5m0s` | Timeout of the wait |
+| volume-id | Required | ID of the volume affected by the action. |
+| terminal-status | One of: `unknown_status`, `creating`, `available`, `in_use`, `deleting`, `deleted`, `resizing`, `error`, `snapshotting`, `locked`, `updating` | Expected terminal status, will wait until this status is reached. |
+| zone | Default: `fr-par-1`<br />One of: `fr-par-1`, `fr-par-2`, `fr-par-3`, `nl-ams-1`, `nl-ams-2`, `nl-ams-3`, `pl-waw-1`, `pl-waw-2`, `pl-waw-3` | Zone to target. If none is passed will use default zone from the config |
+
+
+**Examples:**
+
+
+Wait for a volume to be available
+```
+scw block volume wait 11111111-1111-1111-1111-111111111111 terminal-status=available
+```
+
 
 
 

--- a/internal/namespaces/block/v1alpha1/custom.go
+++ b/internal/namespaces/block/v1alpha1/custom.go
@@ -45,6 +45,8 @@ var (
 func GetCommands() *core.Commands {
 	cmds := GetGeneratedCommands()
 
+	cmds.Add(volumeWaitCommand())
+
 	human.RegisterMarshalerFunc(block.VolumeStatus(""), human.EnumMarshalFunc(volumeStatusMarshalSpecs))
 	human.RegisterMarshalerFunc(block.SnapshotStatus(""), human.EnumMarshalFunc(snapshotStatusMarshalSpecs))
 	human.RegisterMarshalerFunc(block.ReferenceStatus(""), human.EnumMarshalFunc(referenceStatusMarshalSpecs))

--- a/internal/namespaces/block/v1alpha1/custom_volume.go
+++ b/internal/namespaces/block/v1alpha1/custom_volume.go
@@ -1,0 +1,75 @@
+package block
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/scaleway/scaleway-cli/v2/core"
+	block "github.com/scaleway/scaleway-sdk-go/api/block/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/api/instance/v1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+const (
+	volumeActionTimeout = 5 * time.Minute
+)
+
+type volumeWaitRequest struct {
+	Zone     scw.Zone
+	VolumeID string
+	Timeout  time.Duration
+
+	TerminalStatus *block.VolumeStatus
+}
+
+func volumeWaitCommand() *core.Command {
+	terminalStatus := block.VolumeStatus("").Values()
+	terminalStatusStrings := make([]string, len(terminalStatus))
+	for k, v := range terminalStatus {
+		terminalStatusStrings[k] = v.String()
+	}
+
+	return &core.Command{
+		Short:     `Wait for volume to reach a stable state`,
+		Long:      `Wait for volume to reach a stable state. This is similar to using --wait flag on other action commands, but without requiring a new action on the volume.`,
+		Namespace: "block",
+		Resource:  "volume",
+		Verb:      "wait",
+		Groups:    []string{"workflow"},
+		ArgsType:  reflect.TypeOf(volumeWaitRequest{}),
+		Run: func(ctx context.Context, argsI interface{}) (i interface{}, err error) {
+			args := argsI.(*volumeWaitRequest)
+
+			return block.NewAPI(core.ExtractClient(ctx)).WaitForVolume(&block.WaitForVolumeRequest{
+				Zone:          args.Zone,
+				VolumeID:      args.VolumeID,
+				Timeout:       scw.TimeDurationPtr(args.Timeout),
+				RetryInterval: core.DefaultRetryInterval,
+
+				TerminalStatus: args.TerminalStatus,
+			})
+		},
+		ArgSpecs: core.ArgSpecs{
+			core.WaitTimeoutArgSpec(volumeActionTimeout),
+			{
+				Name:       "volume-id",
+				Short:      `ID of the volume affected by the action.`,
+				Required:   true,
+				Positional: true,
+			},
+			{
+				Name:       "terminal-status",
+				Short:      `Expected terminal status, will wait until this status is reached.`,
+				EnumValues: terminalStatusStrings,
+			},
+			core.ZoneArgSpec((*instance.API)(nil).Zones()...),
+		},
+		Examples: []*core.Example{
+			{
+				Short:    "Wait for a volume to be available",
+				ArgsJSON: `{"volume_id": "11111111-1111-1111-1111-111111111111", "terminal_status": "available"}`,
+			},
+		},
+	}
+}


### PR DESCRIPTION
It would be great to be able to wait for a volume to be detached. Some of our instance's tests currently use `instance volume wait` but will need this new command when we switch to sbs volumes.