### PR TITLE
feat(instance): use sbs api for block volumes 

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create_builder.go
+++ b/internal/namespaces/instance/v1/custom_server_create_builder.go
@@ -164,7 +164,7 @@ func (sb *ServerBuilder) AddImage(image string) (*ServerBuilder, error) {
 		ImageID: *(sb.createReq.Image),
 	})
 	if err != nil {
-		logger.Warningf("cannot get image %s: %s", sb.createReq.Image, err)
+		logger.Warningf("cannot get image %s: %s", *sb.createReq.Image, err)
 	} else {
 		sb.serverImage = getImageResponse.Image
 	}
@@ -546,12 +546,11 @@ func NewVolumeBuilder(zone scw.Zone, flagV string) (*VolumeBuilder, error) {
 		switch parts[0] {
 		case "l", "local":
 			vb.VolumeType = instance.VolumeVolumeTypeLSSD
-		case "b", "block":
-			vb.VolumeType = instance.VolumeVolumeTypeBSSD
+		case "sbs", "b", "block":
+			vb.VolumeType = instance.VolumeVolumeTypeSbsVolume
 		case "s", "scratch":
 			vb.VolumeType = instance.VolumeVolumeTypeScratch
-		case "sbs":
-			vb.VolumeType = instance.VolumeVolumeTypeSbsVolume
+
 		default:
 			return nil, fmt.Errorf("invalid volume type %s in %s volume", parts[0], flagV)
 		}

--- a/internal/namespaces/instance/v1/custom_server_create_builder.go
+++ b/internal/namespaces/instance/v1/custom_server_create_builder.go
@@ -583,7 +583,7 @@ func NewVolumeBuilder(zone scw.Zone, flagV string) (*VolumeBuilder, error) {
 }
 
 // buildSnapshotVolume builds the requested volume template to create a new volume from a snapshot
-func (vb *VolumeBuilder) buildSnapshotVolume(api *instance.API) (*instance.VolumeServerTemplate, error) {
+func (vb *VolumeBuilder) buildSnapshotVolume(api *instance.API, blockAPI *block.API) (*instance.VolumeServerTemplate, error) {
 	if vb.SnapshotID == nil {
 		return nil, errors.New("tried to build a volume from snapshot with an empty ID")
 	}
@@ -591,23 +591,41 @@ func (vb *VolumeBuilder) buildSnapshotVolume(api *instance.API) (*instance.Volum
 		Zone:       vb.Zone,
 		SnapshotID: *vb.SnapshotID,
 	})
+	if err != nil && !core.IsNotFoundError(err) {
+		return nil, fmt.Errorf("invalid snapshot %s: %w", *vb.SnapshotID, err)
+	}
+
+	if res != nil {
+		snapshotType := res.Snapshot.VolumeType
+
+		if snapshotType != instance.VolumeVolumeTypeUnified && snapshotType != vb.VolumeType {
+			return nil, fmt.Errorf("snapshot of type %s not compatible with requested volume type %s", snapshotType, vb.VolumeType)
+		}
+
+		return &instance.VolumeServerTemplate{
+			Name:         &res.Snapshot.Name,
+			VolumeType:   vb.VolumeType,
+			BaseSnapshot: &res.Snapshot.ID,
+			Size:         &res.Snapshot.Size,
+		}, nil
+	}
+
+	blockRes, err := blockAPI.GetSnapshot(&block.GetSnapshotRequest{
+		Zone:       vb.Zone,
+		SnapshotID: *vb.SnapshotID,
+	})
 	if err != nil {
 		if core.IsNotFoundError(err) {
 			return nil, fmt.Errorf("snapshot %s does not exist", *vb.SnapshotID)
 		}
-	}
-
-	snapshotType := res.Snapshot.VolumeType
-
-	if snapshotType != instance.VolumeVolumeTypeUnified && snapshotType != vb.VolumeType {
-		return nil, fmt.Errorf("snapshot of type %s not compatible with requested volume type %s", snapshotType, vb.VolumeType)
+		return nil, err
 	}
 
 	return &instance.VolumeServerTemplate{
-		Name:         &res.Snapshot.Name,
+		Name:         &blockRes.Name,
 		VolumeType:   vb.VolumeType,
-		BaseSnapshot: &res.Snapshot.ID,
-		Size:         &res.Snapshot.Size,
+		BaseSnapshot: &blockRes.ID,
+		Size:         &blockRes.Size,
 	}, nil
 }
 
@@ -670,7 +688,7 @@ func (vb *VolumeBuilder) buildNewVolume() (*instance.VolumeServerTemplate, error
 // BuildVolumeServerTemplate builds the requested volume template to be used in a CreateServerRequest
 func (vb *VolumeBuilder) BuildVolumeServerTemplate(apiInstance *instance.API, apiBlock *block.API) (*instance.VolumeServerTemplate, error) {
 	if vb.SnapshotID != nil {
-		return vb.buildSnapshotVolume(apiInstance)
+		return vb.buildSnapshotVolume(apiInstance, apiBlock)
 	}
 
 	if vb.VolumeID != nil {

--- a/internal/namespaces/instance/v1/custom_server_create_test.go
+++ b/internal/namespaces/instance/v1/custom_server_create_test.go
@@ -233,17 +233,9 @@ func Test_CreateServer(t *testing.T) {
 			Cmd:      testServerCommand("image=ubuntu_bionic additional-volumes.0=b:1G additional-volumes.1=b:5G additional-volumes.2=b:10G stopped=true"),
 			Check: core.TestCheckCombine(
 				core.TestCheckExitCode(0),
-				func(t *testing.T, ctx *core.CheckFuncCtx) {
-					t.Helper()
-					assert.NotNil(t, ctx.Result)
-					server := testhelpers.Value[*instanceSDK.Server](t, ctx.Result)
-					size1 := testhelpers.MapTValue(t, server.Volumes, "1").Size
-					size2 := testhelpers.MapTValue(t, server.Volumes, "2").Size
-					size3 := testhelpers.MapTValue(t, server.Volumes, "3").Size
-					assert.Equal(t, 1*scw.GB, instance.SizeValue(size1), "Size of volume should be 1 GB")
-					assert.Equal(t, 5*scw.GB, instance.SizeValue(size2), "Size of volume should be 5 GB")
-					assert.Equal(t, 10*scw.GB, instance.SizeValue(size3), "Size of volume should be 10 GB")
-				},
+				testServerSBSVolumeSize("1", 1),
+				testServerSBSVolumeSize("2", 5),
+				testServerSBSVolumeSize("3", 10),
 			),
 			AfterFunc: deleteServerAfterFunc(),
 		}))

--- a/internal/namespaces/instance/v1/helpers_test.go
+++ b/internal/namespaces/instance/v1/helpers_test.go
@@ -170,6 +170,11 @@ func deleteSnapshot(metaKey string) core.AfterFunc {
 	return core.ExecAfterCmd("scw instance snapshot delete {{ ." + metaKey + ".Snapshot.ID }}")
 }
 
+// deleteSnapshot deletes a snapshot previously registered in the context Meta at metaKey.
+func deleteBlockSnapshot(metaKey string) core.AfterFunc {
+	return core.ExecAfterCmd("scw block snapshot delete {{ ." + metaKey + ".ID }}")
+}
+
 func createPN() core.BeforeFunc {
 	return core.ExecStoreBeforeCmd(
 		"PN",

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-additional-volume-snapshot-id.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-additional-volume-snapshot-id.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:37:08 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47061631-1642-43a5-94ed-6d5bb4a0bc4c
+      - f926d108-86fe-4f4e-98ae-5f1314737399
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:37:08 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86e6c69a-d9c1-42be-85a6-a60b62eb54e4
+      - fc88060b-7123-4707-a8d4-3b31da248506
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1349,9 +1349,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cbf060d-1427-4407-aa7b-38d15fdf5735
+      - a531b33b-86c0-435f-824b-890977c04b67
     status: 200 OK
     code: 200
     duration: ""
@@ -1393,9 +1393,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:37:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1403,12 +1403,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c557da24-8645-430b-9e6f-5c3c310fe5b6
+      - fa6e9817-e39f-4730-8b78-6209ef10d55b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_snapshot",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
       "resource_id": "29da9ad9-e759-4a56-82c8-f0607f93055c"}'
     form: {}
     headers:
@@ -1417,7 +1417,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/29da9ad9-e759-4a56-82c8-f0607f93055c
     method: GET
   response:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_snapshot",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
       "resource_id": "29da9ad9-e759-4a56-82c8-f0607f93055c"}'
     headers:
       Content-Length:
@@ -1427,9 +1427,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:37:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1437,7 +1437,39 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 898a1ac6-ed9d-4b39-ad0d-b9cdd19fea1b
+      - 4cbe2bb3-6bb1-4a57-97f1-5fb7f8aa9671
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"message":"resource is not found","resource":"snapshot","resource_id":"29da9ad9-e759-4a56-82c8-f0607f93055c","type":"not_found"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/29da9ad9-e759-4a56-82c8-f0607f93055c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"snapshot","resource_id":"29da9ad9-e759-4a56-82c8-f0607f93055c","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:37:09 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2fecb006-7ac4-47be-ab7d-d89f3a7e298a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-root-volume-snapshot-id.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-root-volume-snapshot-id.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:13 GMT
+      - Thu, 23 Jan 2025 13:36:36 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b951708-06bb-4358-bad8-02f2b660d004
+      - a777fde2-76db-4057-999a-36e541e952a7
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:13 GMT
+      - Thu, 23 Jan 2025 13:36:36 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed19b977-ee15-4e18-8e8b-9f1215f7d50f
+      - da8bdc52-a8a4-4d14-8dd6-18b2edcfc006
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1349,9 +1349,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:36:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a7e5bf4-8840-4e3f-aa6c-b20601758f7f
+      - 7a46f379-2f9a-4d28-bdcd-b3127afd4af4
     status: 200 OK
     code: 200
     duration: ""
@@ -1393,9 +1393,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:13 GMT
+      - Thu, 23 Jan 2025 13:36:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1403,12 +1403,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68f61940-d30d-41ed-aec8-a2f0a9b166e7
+      - e9632045-2b88-49a4-ad39-f673673a3830
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_snapshot",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
       "resource_id": "29da9ad9-e759-4a56-82c8-f0607f93055c"}'
     form: {}
     headers:
@@ -1417,7 +1417,7 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/29da9ad9-e759-4a56-82c8-f0607f93055c
     method: GET
   response:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_snapshot",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
       "resource_id": "29da9ad9-e759-4a56-82c8-f0607f93055c"}'
     headers:
       Content-Length:
@@ -1427,9 +1427,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:14 GMT
+      - Thu, 23 Jan 2025 13:36:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1437,7 +1437,39 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c47bc0c7-637e-4a88-9764-56ddbea7467b
+      - 1205b3d8-b8e9-465b-a2f2-eab6bd455010
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"message":"resource is not found","resource":"snapshot","resource_id":"29da9ad9-e759-4a56-82c8-f0607f93055c","type":"not_found"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/29da9ad9-e759-4a56-82c8-f0607f93055c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"snapshot","resource_id":"29da9ad9-e759-4a56-82c8-f0607f93055c","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:36:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d189e0ce-9a0e-4805-9523-1bf3006e3e23
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-total-local-volumes-size-too-low2.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-errors-error-invalid-total-local-volumes-size-too-low2.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:07 GMT
+      - Wed, 15 Jan 2025 16:54:50 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89cfa2f4-4a29-4f36-bb2b-bbfaaf4a21b5
+      - 0224e2ec-f1df-415b-80d9-d075e42f3128
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:07 GMT
+      - Wed, 15 Jan 2025 16:54:50 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14624b33-5fbf-4c6e-ac86-cb92654660b4
+      - 6cb438b4-d5e2-42ba-8108-903c0aeb2aa6
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1349,9 +1349,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:08 GMT
+      - Wed, 15 Jan 2025 16:54:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 891a5b61-8d34-44a7-91e8-5ab4da57c1ea
+      - be52593a-8059-4dd3-b5b6-902932550342
     status: 200 OK
     code: 200
     duration: ""
@@ -1393,9 +1393,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:28:07 GMT
+      - Wed, 15 Jan 2025 16:54:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1403,7 +1403,153 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 477a4a29-6b31-49c9-87be-7c0eb99fc873
+      - 1d6acd87-5812-4b7d-abdc-4bdeb4c912f5
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"id":"d7238006-dcd5-4340-8189-ea0427af6eed", "name":"cli-vol-crazy-cray",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:50.994310Z", "updated_at":"2025-01-15T16:54:50.994310Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"d7238006-dcd5-4340-8189-ea0427af6eed", "name":"cli-vol-crazy-cray",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:50.994310Z", "updated_at":"2025-01-15T16:54:50.994310Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "415"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b05b15c3-a2e2-46e3-af6f-c1da7d52b049
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d7238006-dcd5-4340-8189-ea0427af6eed"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d7238006-dcd5-4340-8189-ea0427af6eed
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d7238006-dcd5-4340-8189-ea0427af6eed"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f024fe91-e20c-4a5b-af3b-8cbe5c514aa0
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"d7238006-dcd5-4340-8189-ea0427af6eed", "name":"cli-vol-crazy-cray",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:50.994310Z", "updated_at":"2025-01-15T16:54:50.994310Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d7238006-dcd5-4340-8189-ea0427af6eed
+    method: GET
+  response:
+    body: '{"id":"d7238006-dcd5-4340-8189-ea0427af6eed", "name":"cli-vol-crazy-cray",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:50.994310Z", "updated_at":"2025-01-15T16:54:50.994310Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "416"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a64901f3-4e25-43d9-947b-fdac2508b608
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d7238006-dcd5-4340-8189-ea0427af6eed
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad18071b-2834-482d-90e9-8518b679a92a
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-additional-block-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-additional-block-volumes.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:14 GMT
+      - Tue, 21 Jan 2025 10:59:42 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 610739aa-96ac-42a8-9159-44c1c02d3ee4
+      - 6484bdb1-2564-4887-afda-a2f017aee84f
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:15 GMT
+      - Tue, 21 Jan 2025 10:59:41 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f03f84d2-5870-4b84-a740-dd03ceb15e05
+      - 8571d81d-8bd9-4b19-ab86-29530bb888c1
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:15 GMT
+      - Tue, 21 Jan 2025 10:59:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d2833b6-b517-49f8-9109-c6a5b2c9d6bc
+      - e3cd1b9d-382a-4537-9b5e-07ad78d465df
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:14 GMT
+      - Tue, 21 Jan 2025 10:59:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,14 +1391,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5d587f1-1739-454e-9c65-29fd8796053e
+      - 6d226c95-0549-4fd5-90e4-3255a42d008c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
       "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:42.459888Z",
       "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     form: {}
@@ -1410,10 +1410,168 @@ interactions:
     url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
       "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:42.459888Z",
       "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 266a7e1b-2c28-422f-a854-768f10b9560b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:42.589086Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:42.589086Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "416"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a89da01-ba12-4d5d-8862-ac17b1e9ae40
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:42.723270Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:42.723270Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "417"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fff4f045-879c-4276-b261-6e0a81658f2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "6e1e3efb-d913-43e3-bdcf-335804a5c102"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6e1e3efb-d913-43e3-bdcf-335804a5c102
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "6e1e3efb-d913-43e3-bdcf-335804a5c102"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e10114e-e886-4075-a47a-26e28dda0b57
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:42.459888Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6e1e3efb-d913-43e3-bdcf-335804a5c102
+    method: GET
+  response:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:42.459888Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     headers:
       Content-Length:
@@ -1423,9 +1581,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:15 GMT
+      - Tue, 21 Jan 2025 10:59:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1433,106 +1591,22 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b37cd434-354e-418d-b306-b96148f05d40
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
-      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
-      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
-    method: POST
-  response:
-    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
-      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
-      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "420"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 15 Jan 2025 09:42:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42a48cd2-c0c3-42e0-84d1-df62a0e66db6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
-      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
-      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
-    method: POST
-  response:
-    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
-      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
-      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "430"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19de44e0-bb12-4e4f-b840-27f6c26da179
+      - af961dba-1a77-424e-9591-fd058f45ecee
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1"}'
+      "resource_id": "f75cf795-0b94-4e59-ba32-3100bf6d66a3"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f75cf795-0b94-4e59-ba32-3100bf6d66a3
     method: GET
   response:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1"}'
+      "resource_id": "f75cf795-0b94-4e59-ba32-3100bf6d66a3"}'
     headers:
       Content-Length:
       - "143"
@@ -1541,9 +1615,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
+      - Tue, 21 Jan 2025 10:59:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1551,39 +1625,39 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b3c9df8-1151-44c6-acbc-0a8dbe2656b6
+      - 776599fa-cf50-44f4-82e3-8c5b7e135016
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
-      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:42.589086Z",
       "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f75cf795-0b94-4e59-ba32-3100bf6d66a3
     method: GET
   response:
-    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
-      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:42.589086Z",
       "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "420"
+      - "417"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
+      - Tue, 21 Jan 2025 10:59:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1591,22 +1665,22 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0314330b-ffec-440f-9097-b9f02b8ee389
+      - 61a2f285-e116-4f21-a1bf-fb62cb2edbf4
     status: 200 OK
     code: 200
     duration: ""
 - request:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "8b8983cd-7107-4384-8df1-896593e8cc47"}'
+      "resource_id": "a9dcdc6d-720e-4673-8857-453724c6f10c"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8b8983cd-7107-4384-8df1-896593e8cc47
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a9dcdc6d-720e-4673-8857-453724c6f10c
     method: GET
   response:
     body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "8b8983cd-7107-4384-8df1-896593e8cc47"}'
+      "resource_id": "a9dcdc6d-720e-4673-8857-453724c6f10c"}'
     headers:
       Content-Length:
       - "143"
@@ -1615,9 +1689,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
+      - Tue, 21 Jan 2025 10:59:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1625,39 +1699,39 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 336fee3b-2ebc-496f-82bc-09467db04486
+      - 5a8a951e-b7c6-4b3e-883b-db475921a53c
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
-      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:42.723270Z",
       "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/8b8983cd-7107-4384-8df1-896593e8cc47
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a9dcdc6d-720e-4673-8857-453724c6f10c
     method: GET
   response:
-    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
-      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:42.723270Z",
       "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
       "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "421"
+      - "418"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
+      - Tue, 21 Jan 2025 10:59:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1665,110 +1739,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbd78bfd-4602-4188-a162-419f52d471cb
+      - a500fab3-6446-4db0-8b92-816a942f176e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "e92a272a-a93d-44df-8d33-8a572fde1ea1"}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e92a272a-a93d-44df-8d33-8a572fde1ea1
-    method: GET
-  response:
-    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
-      "resource_id": "e92a272a-a93d-44df-8d33-8a572fde1ea1"}'
-    headers:
-      Content-Length:
-      - "143"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 15 Jan 2025 09:42:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 919e34d2-c0a1-41a8-9d59-5a6ab2d9d1a4
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
-      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
-      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e92a272a-a93d-44df-8d33-8a572fde1ea1
-    method: GET
-  response:
-    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
-      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
-      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
-      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "431"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 15 Jan 2025 09:42:16 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c5f51c2-9da0-49fe-9367-f1b1e4db30ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton",
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-epic-newton", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "852a4238-e504-44df-88de-d4bec5d71a94",
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton"},
-      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:42:16.928247+00:00",
-      "modification_date": "2025-01-15T09:42:16.928247+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
       "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
-      "8b8983cd-7107-4384-8df1-896593e8cc47", "zone": "fr-par-1"}, "3": {"boot": false,
-      "volume_type": "sbs_volume", "id": "e92a272a-a93d-44df-8d33-8a572fde1ea1", "zone":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:77",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:42:16.928247+00:00",
-      "modification_date": "2025-01-15T09:42:16.928247+00:00", "bootscript": null,
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
       "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
@@ -1781,47 +1781,47 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton",
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-epic-newton", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "852a4238-e504-44df-88de-d4bec5d71a94",
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton"},
-      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:42:16.928247+00:00",
-      "modification_date": "2025-01-15T09:42:16.928247+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
       "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
-      "8b8983cd-7107-4384-8df1-896593e8cc47", "zone": "fr-par-1"}, "3": {"boot": false,
-      "volume_type": "sbs_volume", "id": "e92a272a-a93d-44df-8d33-8a572fde1ea1", "zone":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:77",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:42:16.928247+00:00",
-      "modification_date": "2025-01-15T09:42:16.928247+00:00", "bootscript": null,
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
       "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2466"
+      - "2487"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 09:42:18 GMT
+      - Tue, 21 Jan 2025 10:59:44 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54669232-a570-4a10-8763-14ac8a2ed507
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1829,7 +1829,635 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3abc0634-e9eb-4d6e-8d8c-d5170a74ff7e
+      - 0ef2cdca-f19d-41f4-823c-9840d988ab00
     status: 201 Created
     code: 201
+    duration: ""
+- request:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:43.542394Z",
+      "references":[{"id":"fdfda5ff-33b6-4ae3-a6a0-4e5603df1cff", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.542394Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6e1e3efb-d913-43e3-bdcf-335804a5c102
+    method: GET
+  response:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:43.542394Z",
+      "references":[{"id":"fdfda5ff-33b6-4ae3-a6a0-4e5603df1cff", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.542394Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "651"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00c2c8a6-07bc-4e8e-9434-c2c938946f43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:43.638255Z",
+      "references":[{"id":"94f5a5cd-81d5-4ca5-89dd-b33a2870decc", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.638255Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f75cf795-0b94-4e59-ba32-3100bf6d66a3
+    method: GET
+  response:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:43.638255Z",
+      "references":[{"id":"94f5a5cd-81d5-4ca5-89dd-b33a2870decc", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.638255Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "649"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b9af26de-f6d3-4d86-beed-118088bfa8e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:43.704412Z",
+      "references":[{"id":"21d7dcbb-b5a7-48c4-8108-dfeb09af7692", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.704412Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a9dcdc6d-720e-4673-8857-453724c6f10c
+    method: GET
+  response:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:43.704412Z",
+      "references":[{"id":"21d7dcbb-b5a7-48c4-8108-dfeb09af7692", "product_resource_type":"instance_server",
+      "product_resource_id":"54669232-a570-4a10-8763-14ac8a2ed507", "created_at":"2025-01-21T10:59:43.704412Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "650"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 500552ae-a957-4397-8adf-56a73e6410ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54669232-a570-4a10-8763-14ac8a2ed507
+    method: GET
+  response:
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2487"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dbe15ad2-8cf0-4bc9-9801-d7123260b455
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54669232-a570-4a10-8763-14ac8a2ed507
+    method: GET
+  response:
+    body: '{"server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-fermi", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1f37f989-9652-4c9a-b9e7-e16b97965391",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "54669232-a570-4a10-8763-14ac8a2ed507", "name": "cli-srv-affectionate-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "6e1e3efb-d913-43e3-bdcf-335804a5c102",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "f75cf795-0b94-4e59-ba32-3100bf6d66a3", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "a9dcdc6d-720e-4673-8857-453724c6f10c", "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8e:a4:bb",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-21T10:59:43.423289+00:00",
+      "modification_date": "2025-01-21T10:59:43.423289+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2487"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce6245af-8f73-42cf-83c0-3dba6d598011
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54669232-a570-4a10-8763-14ac8a2ed507
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc54f763-eb41-45cb-a0a8-0755c54ef64d
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:45.344132Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.344132Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6e1e3efb-d913-43e3-bdcf-335804a5c102
+    method: GET
+  response:
+    body: '{"id":"6e1e3efb-d913-43e3-bdcf-335804a5c102", "name":"cli-vol-crazy-chatelet",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.459888Z", "updated_at":"2025-01-21T10:59:45.344132Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.344132Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "444"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1aad5770-7a75-42ea-bcca-d1f56b420364
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/6e1e3efb-d913-43e3-bdcf-335804a5c102
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c4ff780-0e9c-4204-a5fd-594b8a564c48
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:45.420359Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.420359Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f75cf795-0b94-4e59-ba32-3100bf6d66a3
+    method: GET
+  response:
+    body: '{"id":"f75cf795-0b94-4e59-ba32-3100bf6d66a3", "name":"cli-vol-happy-rhodes",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.589086Z", "updated_at":"2025-01-21T10:59:45.420359Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.420359Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "442"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b4ccdd2-6c73-4e1b-a781-f1ede0f9a06f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f75cf795-0b94-4e59-ba32-3100bf6d66a3
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 115a6059-d85a-4c3a-aa93-630c3334e31d
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:45.497075Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.497075Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a9dcdc6d-720e-4673-8857-453724c6f10c
+    method: GET
+  response:
+    body: '{"id":"a9dcdc6d-720e-4673-8857-453724c6f10c", "name":"cli-vol-funny-wilbur",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-21T10:59:42.723270Z", "updated_at":"2025-01-21T10:59:45.497075Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-21T10:59:45.497075Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "443"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3a7ea76-258c-425e-85b8-183eb2c6818e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/a9dcdc6d-720e-4673-8857-453724c6f10c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd0b974f-feec-4e0a-b8aa-b96e9fc460a3
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"volume": {"id": "1f37f989-9652-4c9a-b9e7-e16b97965391", "name": "Ubuntu
+      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-01-21T10:59:43.423289+00:00", "modification_date": "2025-01-21T10:59:45.039119+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1f37f989-9652-4c9a-b9e7-e16b97965391
+    method: GET
+  response:
+    body: '{"volume": {"id": "1f37f989-9652-4c9a-b9e7-e16b97965391", "name": "Ubuntu
+      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-01-21T10:59:43.423289+00:00", "modification_date": "2025-01-21T10:59:45.039119+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "448"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 515c086a-2573-4d99-92b4-a56982844843
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1f37f989-9652-4c9a-b9e7-e16b97965391
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jan 2025 10:59:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 881bb746-7f33-4b93-a794-e1c5268c4ef1
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-additional-block-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-additional-block-volumes.cassette.yaml
@@ -919,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:16 GMT
+      - Wed, 15 Jan 2025 09:42:14 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87414c6f-39c2-4385-92b0-a84b2cc558b8
+      - 610739aa-96ac-42a8-9159-44c1c02d3ee4
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:16 GMT
+      - Wed, 15 Jan 2025 09:42:15 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 088fb569-00b1-4d32-a3ec-af8f2cad2afe
+      - f03f84d2-5870-4b84-a740-dd03ceb15e05
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,7 +1337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:17 GMT
+      - Wed, 15 Jan 2025 09:42:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a795b11-c40d-4ae7-934d-f7ea8fec75a0
+      - 8d2833b6-b517-49f8-9109-c6a5b2c9d6bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:17 GMT
+      - Wed, 15 Jan 2025 09:42:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1391,51 +1391,385 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ace15ce-76b2-4d64-87f8-7a9c2727ef59
+      - d5d587f1-1739-454e-9c65-29fd8796053e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
+    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "419"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b37cd434-354e-418d-b306-b96148f05d40
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "420"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42a48cd2-c0c3-42e0-84d1-df62a0e66db6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "430"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19de44e0-bb12-4e4f-b840-27f6c26da179
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b3c9df8-1151-44c6-acbc-0a8dbe2656b6
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1
+    method: GET
+  response:
+    body: '{"id":"7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1", "name":"cli-vol-cranky-goldberg",
+      "type":"sbs_5k", "size":1000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.431220Z", "updated_at":"2025-01-15T09:42:15.431220Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "420"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0314330b-ffec-440f-9097-b9f02b8ee389
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "8b8983cd-7107-4384-8df1-896593e8cc47"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8b8983cd-7107-4384-8df1-896593e8cc47
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "8b8983cd-7107-4384-8df1-896593e8cc47"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 336fee3b-2ebc-496f-82bc-09467db04486
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/8b8983cd-7107-4384-8df1-896593e8cc47
+    method: GET
+  response:
+    body: '{"id":"8b8983cd-7107-4384-8df1-896593e8cc47", "name":"cli-vol-gracious-babbage",
+      "type":"sbs_5k", "size":5000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.567740Z", "updated_at":"2025-01-15T09:42:15.567740Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "421"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbd78bfd-4602-4188-a162-419f52d471cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "e92a272a-a93d-44df-8d33-8a572fde1ea1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e92a272a-a93d-44df-8d33-8a572fde1ea1
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "e92a272a-a93d-44df-8d33-8a572fde1ea1"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 919e34d2-c0a1-41a8-9d59-5a6ab2d9d1a4
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/e92a272a-a93d-44df-8d33-8a572fde1ea1
+    method: GET
+  response:
+    body: '{"id":"e92a272a-a93d-44df-8d33-8a572fde1ea1", "name":"cli-vol-interesting-proskuriakova",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:42:15.985267Z", "updated_at":"2025-01-15T09:42:15.985267Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "431"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c5f51c2-9da0-49fe-9367-f1b1e4db30ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-epic-newton", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
+      "volumes": {"0": {"boot": false, "id": "852a4238-e504-44df-88de-d4bec5d71a94",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:42:16.928247+00:00",
+      "modification_date": "2025-01-15T09:42:16.928247+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8b8983cd-7107-4384-8df1-896593e8cc47", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "e92a272a-a93d-44df-8d33-8a572fde1ea1", "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:77",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:42:16.928247+00:00",
+      "modification_date": "2025-01-15T09:42:16.928247+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1447,59 +1781,45 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
+    body: '{"server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-epic-newton", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
+      "volumes": {"0": {"boot": false, "id": "852a4238-e504-44df-88de-d4bec5d71a94",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb", "name": "cli-srv-epic-newton"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:42:16.928247+00:00",
+      "modification_date": "2025-01-15T09:42:16.928247+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7a0f1fb1-e28f-49f0-9a1e-9e1abe5cd6d1",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8b8983cd-7107-4384-8df1-896593e8cc47", "zone": "fr-par-1"}, "3": {"boot": false,
+      "volume_type": "sbs_volume", "id": "e92a272a-a93d-44df-8d33-8a572fde1ea1", "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:77",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:42:16.928247+00:00",
+      "modification_date": "2025-01-15T09:42:16.928247+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3736"
+      - "2466"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:17 GMT
+      - Wed, 15 Jan 2025 09:42:18 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c19c991c-66db-4343-b065-925888034853
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/122f6c47-0ba2-4bf5-a82c-40eae7d2e5fb
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1509,547 +1829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c4d1fb3-16d1-4821-84a3-1ed3fb11557c
+      - 3abc0634-e9eb-4d6e-8d8c-d5170a74ff7e
     status: 201 Created
     code: 201
-    duration: ""
-- request:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c19c991c-66db-4343-b065-925888034853
-    method: GET
-  response:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3736"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a65684c-6993-455f-9a9b-c6927b0e38a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c19c991c-66db-4343-b065-925888034853
-    method: GET
-  response:
-    body: '{"server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-modest-albattani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "7d73afca-340f-40ed-9fb8-55f57daeeac7",
-      "name": "cli-srv-modest-albattani-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 1000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "2": {"boot": false, "id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d",
-      "name": "cli-srv-modest-albattani-2", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 5000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}, "3": {"boot": false, "id": "5a73c54e-6923-4d20-ad6b-095372d1307a",
-      "name": "cli-srv-modest-albattani-3", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "c19c991c-66db-4343-b065-925888034853", "name": "cli-srv-modest-albattani"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:59",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:17.469274+00:00",
-      "modification_date": "2024-12-24T09:26:17.469274+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3736"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aa4b54aa-e529-4cdd-92bb-cb85360051fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c19c991c-66db-4343-b065-925888034853
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3e177efd-86bf-40d8-b6ee-de118af40c56
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348", "name": "Ubuntu
-      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T09:26:17.469274+00:00", "modification_date": "2024-12-24T09:26:18.355426+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6af724f-bde8-4710-bcd8-e6e0e6bd8348
-    method: GET
-  response:
-    body: '{"volume": {"id": "f6af724f-bde8-4710-bcd8-e6e0e6bd8348", "name": "Ubuntu
-      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T09:26:17.469274+00:00", "modification_date": "2024-12-24T09:26:18.355426+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30810a02-df08-435a-b76a-ee082df158cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f6af724f-bde8-4710-bcd8-e6e0e6bd8348
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70c59941-17a4-4f77-ad98-b85611cb024e
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "7d73afca-340f-40ed-9fb8-55f57daeeac7", "name": "cli-srv-modest-albattani-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7d73afca-340f-40ed-9fb8-55f57daeeac7
-    method: GET
-  response:
-    body: '{"volume": {"id": "7d73afca-340f-40ed-9fb8-55f57daeeac7", "name": "cli-srv-modest-albattani-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 1000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "447"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bc26868a-e70b-4295-a56c-f853c1f77a07
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7d73afca-340f-40ed-9fb8-55f57daeeac7
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2b23a12-5b53-4d26-b189-3f2568d0af21
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d", "name": "cli-srv-modest-albattani-2",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 5000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d
-    method: GET
-  response:
-    body: '{"volume": {"id": "15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d", "name": "cli-srv-modest-albattani-2",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 5000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "447"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70083980-8c25-463c-8320-52fac882a1cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/15ceb6e3-be1b-476e-91cc-3d1f37ca4f8d
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 65f6cf87-1772-4424-a295-736ec2d7d314
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "5a73c54e-6923-4d20-ad6b-095372d1307a", "name": "cli-srv-modest-albattani-3",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5a73c54e-6923-4d20-ad6b-095372d1307a
-    method: GET
-  response:
-    body: '{"volume": {"id": "5a73c54e-6923-4d20-ad6b-095372d1307a", "name": "cli-srv-modest-albattani-3",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:17.469274+00:00", "modification_date":
-      "2024-12-24T09:26:18.355426+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 453793c6-5330-4419-bcf6-c310740d80bd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/5a73c54e-6923-4d20-ad6b-095372d1307a
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 329212fb-3eff-49cd-ade5-98dc1c22b648
-    status: 204 No Content
-    code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-double-snapshot.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-double-snapshot.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
+      - Wed, 15 Jan 2025 17:06:11 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 353e05fd-f59b-41fc-8553-5724e7da1457
+      - 2cb9ce36-58fa-43a9-a51c-de08c4597234
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
+      - Wed, 15 Jan 2025 17:06:11 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 140f80de-c390-407c-8b3d-261f7818e5de
+      - 4ebc09e5-69b5-4657-bfdf-f687e49fe9b3
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
+      - Wed, 15 Jan 2025 17:06:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b092377-a1c0-498d-9279-7aa1c031ed86
+      - 77e1f931-b20d-4ddb-ae1a-9164d894cd25
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:18 GMT
+      - Wed, 15 Jan 2025 17:06:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,33 +1391,33 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d4f03b2-f756-48a6-a68f-5499643abdd3
+      - ae8b9b77-45df-4f66-8a1b-c503b489832f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky",
+    body: '{"server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-pedantic-meninsky", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-amazing-wiles", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963",
+      "volumes": {"0": {"boot": false, "id": "a247285c-3e9f-4633-87fd-6c99b90b1280",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-01-15T17:06:12.223557+00:00",
+      "modification_date": "2025-01-15T17:06:12.223557+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:71",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:93:41",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T17:06:12.223557+00:00",
+      "modification_date": "2025-01-15T17:06:12.223557+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1429,43 +1429,43 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky",
+    body: '{"server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-pedantic-meninsky", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-amazing-wiles", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963",
+      "volumes": {"0": {"boot": false, "id": "a247285c-3e9f-4633-87fd-6c99b90b1280",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-01-15T17:06:12.223557+00:00",
+      "modification_date": "2025-01-15T17:06:12.223557+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:71",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:93:41",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T17:06:12.223557+00:00",
+      "modification_date": "2025-01-15T17:06:12.223557+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2133"
+      - "2121"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
+      - Wed, 15 Jan 2025 17:06:12 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3e700e1a-3b2c-4f75-912a-af89ff98f329
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae29e0c1-0d50-45b5-a506-7d24c831bd0b
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1473,21 +1473,21 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38195d00-af7a-4e99-b970-3b57930565ee
+      - 44c21796-ff90-4046-a604-e9d2e6c7b640
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
+    body: '{"snapshot": {"id": "ee51e0b1-3bbb-49a6-ad9c-75018882383c", "name": "cli-snp-kind-albattani",
+      "volume_type": "unified", "creation_date": "2025-01-15T17:06:12.871308+00:00",
+      "modification_date": "2025-01-15T17:06:12.871308+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "a247285c-3e9f-4633-87fd-6c99b90b1280", "name":
       "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "986a66a7-fae2-47f3-827d-dbc18fb54a99", "description":
-      "volume_cold_snapshot", "status": "success", "href_from": "/snapshots", "href_result":
-      "snapshots/58b4666e-d678-48c2-8d54-dc18881c4ddf", "started_at": "2024-12-24T09:26:20.069997+00:00",
-      "terminated_at": null, "progress": 100, "zone": "par1"}}'
+      null}, "task": {"id": "fa075ce1-6847-4dff-9a97-57fc639409bf", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ee51e0b1-3bbb-49a6-ad9c-75018882383c", "started_at": "2025-01-15T17:06:13.128910+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
@@ -1497,27 +1497,27 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
+    body: '{"snapshot": {"id": "ee51e0b1-3bbb-49a6-ad9c-75018882383c", "name": "cli-snp-kind-albattani",
+      "volume_type": "unified", "creation_date": "2025-01-15T17:06:12.871308+00:00",
+      "modification_date": "2025-01-15T17:06:12.871308+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "a247285c-3e9f-4633-87fd-6c99b90b1280", "name":
       "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "986a66a7-fae2-47f3-827d-dbc18fb54a99", "description":
-      "volume_cold_snapshot", "status": "success", "href_from": "/snapshots", "href_result":
-      "snapshots/58b4666e-d678-48c2-8d54-dc18881c4ddf", "started_at": "2024-12-24T09:26:20.069997+00:00",
-      "terminated_at": null, "progress": 100, "zone": "par1"}}'
+      null}, "task": {"id": "fa075ce1-6847-4dff-9a97-57fc639409bf", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ee51e0b1-3bbb-49a6-ad9c-75018882383c", "started_at": "2025-01-15T17:06:13.128910+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "852"
+      - "847"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
+      - Wed, 15 Jan 2025 17:06:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1525,7 +1525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f98edaca-5071-4fbc-9876-c654362b86c9
+      - dfa92fc7-5d43-4f3e-94dc-302ff6c10147
     status: 201 Created
     code: 201
     duration: ""
@@ -2447,12 +2447,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
+      - Wed, 15 Jan 2025 17:06:13 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2460,7 +2460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ecf608e-f27d-484c-8c4f-98425a1107bd
+      - f107b6d1-d565-48a4-9802-c223a84d11fa
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -2810,12 +2810,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:19 GMT
+      - Wed, 15 Jan 2025 17:06:13 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2823,51 +2823,33 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 653d5c67-512c-4276-9b21-acd1f5d8e6e1
+      - 547e062e-ee0b-417f-ab2a-b406c74f968c
       X-Total-Count:
       - "68"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"local_images":[{"id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "arch":"x86_64",
-      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
-      "DEV1-XL", "ENT1-2XL", "ENT1-L", "ENT1-M", "ENT1-S", "ENT1-XL", "ENT1-XS", "ENT1-XXS",
-      "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "GPU-3070-S", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO", "POP2-16C-64G", "POP2-2C-8G", "POP2-32C-128G", "POP2-4C-16G",
-      "POP2-64C-256G", "POP2-8C-32G", "POP2-HC-16C-32G", "POP2-HC-2C-4G", "POP2-HC-32C-64G",
-      "POP2-HC-4C-8G", "POP2-HC-64C-128G", "POP2-HC-8C-16G", "POP2-HM-16C-128G", "POP2-HM-2C-16G",
-      "POP2-HM-32C-256G", "POP2-HM-4C-32G", "POP2-HM-64C-512G", "POP2-HM-8C-64G",
-      "PRO2-L", "PRO2-M", "PRO2-S", "PRO2-XS"], "label":"ubuntu_bionic", "type":"instance_local"}],
-      "total_count":1}'
+    body: '{"local_images":[], "total_count":0}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_bionic&order_by=type_asc&type=instance_local&zone=fr-par-1
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_bionic&order_by=type_asc&type=instance_sbs&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "arch":"x86_64",
-      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
-      "DEV1-XL", "ENT1-2XL", "ENT1-L", "ENT1-M", "ENT1-S", "ENT1-XL", "ENT1-XS", "ENT1-XXS",
-      "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "GPU-3070-S", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO", "POP2-16C-64G", "POP2-2C-8G", "POP2-32C-128G", "POP2-4C-16G",
-      "POP2-64C-256G", "POP2-8C-32G", "POP2-HC-16C-32G", "POP2-HC-2C-4G", "POP2-HC-32C-64G",
-      "POP2-HC-4C-8G", "POP2-HC-64C-128G", "POP2-HC-8C-16G", "POP2-HM-16C-128G", "POP2-HM-2C-16G",
-      "POP2-HM-32C-256G", "POP2-HM-4C-32G", "POP2-HM-64C-512G", "POP2-HM-8C-64G",
-      "PRO2-L", "PRO2-M", "PRO2-S", "PRO2-XS"], "label":"ubuntu_bionic", "type":"instance_local"}],
-      "total_count":1}'
+    body: '{"local_images":[], "total_count":0}'
     headers:
       Content-Length:
-      - "779"
+      - "36"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:26:20 GMT
+      - Wed, 15 Jan 2025 17:06:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2875,793 +2857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fc4b3cf-de93-406c-acdd-219696216bb4
+      - 99c7192d-a790-45de-82a2-2de69597d879
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: '{"image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "name": "Ubuntu
-      18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/655aeea7-8a30-418a-bc2e-3c04e3fdc8aa
-    method: GET
-  response:
-    body: '{"image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "name": "Ubuntu
-      18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "616"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:20 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 206a1290-ab85-40b3-b2f0-31392407a362
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/58b4666e-d678-48c2-8d54-dc18881c4ddf
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "538"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:20 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7af37434-2ae1-4590-9d34-988a5d1ed8b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/58b4666e-d678-48c2-8d54-dc18881c4ddf
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "58b4666e-d678-48c2-8d54-dc18881c4ddf", "name": "cli-snp-awesome-margulis",
-      "volume_type": "unified", "creation_date": "2024-12-24T09:26:19.828189+00:00",
-      "modification_date": "2024-12-24T09:26:19.828189+00:00", "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "538"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:20 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 292f3e59-0663-4c67-a227-b278aabd4d4d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-    method: POST
-  response:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:21 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43f71daf-3e02-4600-b74e-25ddc0b890ba
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1773d923-7f7c-43e9-a029-1c140ababdde
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-pedantic-meninsky", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:71",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3e700e1a-3b2c-4f75-912a-af89ff98f329
-    method: GET
-  response:
-    body: '{"server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-pedantic-meninsky", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "3e700e1a-3b2c-4f75-912a-af89ff98f329", "name": "cli-srv-pedantic-meninsky"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:71",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:19.270645+00:00",
-      "modification_date": "2024-12-24T09:26:19.270645+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2133"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d8cd6d3d-a558-41f0-ae75-1c26a8995d8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3e700e1a-3b2c-4f75-912a-af89ff98f329
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e915ee89-1c1f-4d1b-9d89-f0f18cd03d6f
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name": "Ubuntu
-      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": null, "size": 20000000000, "state": "available", "creation_date":
-      "2024-12-24T09:26:19.270645+00:00", "modification_date": "2024-12-24T09:26:21.616494+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf00c9e-4222-47ed-b6d8-d0a2049f6963
-    method: GET
-  response:
-    body: '{"volume": {"id": "fbf00c9e-4222-47ed-b6d8-d0a2049f6963", "name": "Ubuntu
-      18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": null, "size": 20000000000, "state": "available", "creation_date":
-      "2024-12-24T09:26:19.270645+00:00", "modification_date": "2024-12-24T09:26:21.616494+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "448"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c96d85cb-96b1-48ab-8bf5-72c1780db005
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fbf00c9e-4222-47ed-b6d8-d0a2049f6963
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8988991f-6577-4492-884c-12c380890f49
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43f71daf-3e02-4600-b74e-25ddc0b890ba
-    method: GET
-  response:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5d37f2b9-1b7c-4c78-87f2-9d626bbf0f11
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43f71daf-3e02-4600-b74e-25ddc0b890ba
-    method: GET
-  response:
-    body: '{"server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-mirzakhani", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86",
-      "name": "cli-srv-xenodochial-mirzakhani-0", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783",
-      "name": "cli-srv-xenodochial-mirzakhani-1", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "43f71daf-3e02-4600-b74e-25ddc0b890ba", "name": "cli-srv-xenodochial-mirzakhani"},
-      "size": 20000000000, "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:34:81",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:26:20.861457+00:00",
-      "modification_date": "2024-12-24T09:26:20.861457+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 307035dd-76ea-4e6d-bf74-6174165c4e40
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43f71daf-3e02-4600-b74e-25ddc0b890ba
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c059cadb-9912-4883-a272-36929ec268ff
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86", "name": "cli-srv-xenodochial-mirzakhani-0",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00", "modification_date":
-      "2024-12-24T09:26:22.345717+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0c15178b-83ff-4ee9-b26f-a8a974cbbc86
-    method: GET
-  response:
-    body: '{"volume": {"id": "0c15178b-83ff-4ee9-b26f-a8a974cbbc86", "name": "cli-srv-xenodochial-mirzakhani-0",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00", "modification_date":
-      "2024-12-24T09:26:22.345717+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "454"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6025fb99-9c2d-4240-9ca0-e83ab814c213
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0c15178b-83ff-4ee9-b26f-a8a974cbbc86
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 69a35b77-71d0-415d-bac9-3a291e204aa3
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783", "name": "cli-srv-xenodochial-mirzakhani-1",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00", "modification_date":
-      "2024-12-24T09:26:22.345717+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fa2a54e1-a095-4d87-902c-c07c2fdb6783
-    method: GET
-  response:
-    body: '{"volume": {"id": "fa2a54e1-a095-4d87-902c-c07c2fdb6783", "name": "cli-srv-xenodochial-mirzakhani-1",
-      "volume_type": "l_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-12-24T09:26:20.861457+00:00", "modification_date":
-      "2024-12-24T09:26:22.345717+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "454"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a0f0b9ec-bebd-4193-8e9f-c58abed47d9b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fa2a54e1-a095-4d87-902c-c07c2fdb6783
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f092b78-c4e3-48dd-99bb-27d529bd0f7c
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/58b4666e-d678-48c2-8d54-dc18881c4ddf
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:26:22 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92434119-2e1b-4ff3-b102-d1792ae32983
-    status: 204 No Content
-    code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-double-snapshot.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-server-volumes-valid-double-snapshot.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:11 GMT
+      - Thu, 23 Jan 2025 13:33:01 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cb9ce36-58fa-43a9-a51c-de08c4597234
+      - 9e89aa9c-c335-4b36-883e-82d43521a2ff
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:11 GMT
+      - Thu, 23 Jan 2025 13:33:01 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,51 +1295,63 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ebc09e5-69b5-4657-bfdf-f687e49fe9b3
+      - 6b888951-17bf-45d8-8310-9cd6df0e259b
       X-Total-Count:
       - "68"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"local_images":[{"id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "arch":"x86_64",
+    body: '{"local_images":[{"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "arch":"x86_64",
       "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
-      "DEV1-XL", "ENT1-2XL", "ENT1-L", "ENT1-M", "ENT1-S", "ENT1-XL", "ENT1-XS", "ENT1-XXS",
-      "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "GPU-3070-S", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO", "POP2-16C-64G", "POP2-2C-8G", "POP2-32C-128G", "POP2-4C-16G",
-      "POP2-64C-256G", "POP2-8C-32G", "POP2-HC-16C-32G", "POP2-HC-2C-4G", "POP2-HC-32C-64G",
-      "POP2-HC-4C-8G", "POP2-HC-64C-128G", "POP2-HC-8C-16G", "POP2-HM-16C-128G", "POP2-HM-2C-16G",
-      "POP2-HM-32C-256G", "POP2-HM-4C-32G", "POP2-HM-64C-512G", "POP2-HM-8C-64G",
-      "PRO2-L", "PRO2-M", "PRO2-S", "PRO2-XS"], "label":"ubuntu_bionic", "type":"instance_local"}],
-      "total_count":1}'
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M",
+      "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB",
+      "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G",
+      "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G",
+      "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G",
+      "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G",
+      "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy",
+      "type":"instance_sbs"}, {"id":"7044ae1e-a35d-4364-a962-93811c845f2f", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_sbs"}], "total_count":2}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_bionic&order_by=type_asc&type=instance_local&zone=fr-par-1
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"id":"655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "arch":"x86_64",
+    body: '{"local_images":[{"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "arch":"x86_64",
       "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
-      "DEV1-XL", "ENT1-2XL", "ENT1-L", "ENT1-M", "ENT1-S", "ENT1-XL", "ENT1-XS", "ENT1-XXS",
-      "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "GPU-3070-S", "PLAY2-MICRO",
-      "PLAY2-NANO", "PLAY2-PICO", "POP2-16C-64G", "POP2-2C-8G", "POP2-32C-128G", "POP2-4C-16G",
-      "POP2-64C-256G", "POP2-8C-32G", "POP2-HC-16C-32G", "POP2-HC-2C-4G", "POP2-HC-32C-64G",
-      "POP2-HC-4C-8G", "POP2-HC-64C-128G", "POP2-HC-8C-16G", "POP2-HM-16C-128G", "POP2-HM-2C-16G",
-      "POP2-HM-32C-256G", "POP2-HM-4C-32G", "POP2-HM-64C-512G", "POP2-HM-8C-64G",
-      "PRO2-L", "PRO2-M", "PRO2-S", "PRO2-XS"], "label":"ubuntu_bionic", "type":"instance_local"}],
-      "total_count":1}'
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M",
+      "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB",
+      "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G",
+      "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G",
+      "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G",
+      "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G",
+      "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy",
+      "type":"instance_sbs"}, {"id":"7044ae1e-a35d-4364-a962-93811c845f2f", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_sbs"}], "total_count":2}'
     headers:
       Content-Length:
-      - "779"
+      - "1296"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:11 GMT
+      - Thu, 23 Jan 2025 13:33:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,43 +1359,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e1f931-b20d-4ddb-ae1a-9164d894cd25
+      - bc87de29-1ffb-4b25-9a47-36fcfc40dd01
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "name": "Ubuntu
-      18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/655aeea7-8a30-418a-bc2e-3c04e3fdc8aa
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/1fb9bfa4-68c3-4d6f-a362-8913a1af27b0
     method: GET
   response:
-    body: '{"image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa", "name": "Ubuntu
-      18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "616"
+      - "587"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:11 GMT
+      - Thu, 23 Jan 2025 13:33:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,32 +1405,28 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae8b9b77-45df-4f66-8a1b-c503b489832f
+      - 29555453-3510-464c-aa5c-d6c016eb3cfd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles",
+    body: '{"server": {"id": "54f1cb5f-d632-43bd-b324-f6a951e4a612", "name": "cli-srv-affectionate-euler",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-amazing-wiles", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "a247285c-3e9f-4633-87fd-6c99b90b1280",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-15T17:06:12.223557+00:00",
-      "modification_date": "2025-01-15T17:06:12.223557+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:93:41",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T17:06:12.223557+00:00",
-      "modification_date": "2025-01-15T17:06:12.223557+00:00", "bootscript": null,
+      "hostname": "cli-srv-affectionate-euler", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "f3abbb35-050c-4fd8-8568-92caf105731c", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:8f:3e:11", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-01-23T13:33:02.199501+00:00",
+      "modification_date": "2025-01-23T13:33:02.199501+00:00", "bootscript": null,
       "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
@@ -1429,43 +1439,39 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles",
+    body: '{"server": {"id": "54f1cb5f-d632-43bd-b324-f6a951e4a612", "name": "cli-srv-affectionate-euler",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-amazing-wiles", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "a247285c-3e9f-4633-87fd-6c99b90b1280",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "ae29e0c1-0d50-45b5-a506-7d24c831bd0b", "name": "cli-srv-amazing-wiles"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-15T17:06:12.223557+00:00",
-      "modification_date": "2025-01-15T17:06:12.223557+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:93:41",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T17:06:12.223557+00:00",
-      "modification_date": "2025-01-15T17:06:12.223557+00:00", "bootscript": null,
+      "hostname": "cli-srv-affectionate-euler", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "f3abbb35-050c-4fd8-8568-92caf105731c", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:8f:3e:11", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-01-23T13:33:02.199501+00:00",
+      "modification_date": "2025-01-23T13:33:02.199501+00:00", "bootscript": null,
       "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2121"
+      - "1686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:12 GMT
+      - Thu, 23 Jan 2025 13:33:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae29e0c1-0d50-45b5-a506-7d24c831bd0b
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54f1cb5f-d632-43bd-b324-f6a951e4a612
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1473,51 +1479,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44c21796-ff90-4046-a604-e9d2e6c7b640
+      - 707c1d61-48c4-44ff-a963-7725cce84940
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "ee51e0b1-3bbb-49a6-ad9c-75018882383c", "name": "cli-snp-kind-albattani",
-      "volume_type": "unified", "creation_date": "2025-01-15T17:06:12.871308+00:00",
-      "modification_date": "2025-01-15T17:06:12.871308+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "a247285c-3e9f-4633-87fd-6c99b90b1280", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "fa075ce1-6847-4dff-9a97-57fc639409bf", "description":
-      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/ee51e0b1-3bbb-49a6-ad9c-75018882383c", "started_at": "2025-01-15T17:06:13.128910+00:00",
-      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"creating",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot": {"id": "ee51e0b1-3bbb-49a6-ad9c-75018882383c", "name": "cli-snp-kind-albattani",
-      "volume_type": "unified", "creation_date": "2025-01-15T17:06:12.871308+00:00",
-      "modification_date": "2025-01-15T17:06:12.871308+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "a247285c-3e9f-4633-87fd-6c99b90b1280", "name":
-      "Ubuntu 18.04 Bionic Beaver"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "fa075ce1-6847-4dff-9a97-57fc639409bf", "description":
-      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/ee51e0b1-3bbb-49a6-ad9c-75018882383c", "started_at": "2025-01-15T17:06:13.128910+00:00",
-      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"creating",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "847"
+      - "472"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:13 GMT
+      - Thu, 23 Jan 2025 13:33:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1525,9 +1523,97 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfa92fc7-5d43-4f3e-94dc-302ff6c10147
-    status: 201 Created
-    code: 201
+      - f37124d7-692c-444f-8aae-88ca72891920
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[{"id":"9b188dbc-1bb8-4a1e-96cf-01ded38821bc",
+      "product_resource_type":"internal", "product_resource_id":"00000000-0000-0000-0000-000000000000",
+      "created_at":"2025-01-23T13:33:02.815368Z", "type":"unknown_type", "status":"attached"}],
+      "status":"creating", "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[{"id":"9b188dbc-1bb8-4a1e-96cf-01ded38821bc",
+      "product_resource_type":"internal", "product_resource_id":"00000000-0000-0000-0000-000000000000",
+      "created_at":"2025-01-23T13:33:02.815368Z", "type":"unknown_type", "status":"attached"}],
+      "status":"creating", "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db999145-a210-4ba9-b8de-9122acfc910b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "473"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 15216574-9949-4b93-a4fb-37e25afee40a
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
@@ -2447,12 +2533,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:13 GMT
+      - Thu, 23 Jan 2025 13:33:07 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2460,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f107b6d1-d565-48a4-9802-c223a84d11fa
+      - 54dda703-cc69-4135-b5e4-c3fd0f4427d8
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -2810,12 +2896,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:13 GMT
+      - Thu, 23 Jan 2025 13:33:08 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2823,33 +2909,63 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 547e062e-ee0b-417f-ab2a-b406c74f968c
+      - cbf949c5-f8b3-4c22-b01b-4f2a7bb3b76d
       X-Total-Count:
       - "68"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"local_images":[], "total_count":0}'
+    body: '{"local_images":[{"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M",
+      "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB",
+      "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G",
+      "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G",
+      "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G",
+      "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G",
+      "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy",
+      "type":"instance_sbs"}, {"id":"7044ae1e-a35d-4364-a962-93811c845f2f", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_sbs"}], "total_count":2}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_bionic&order_by=type_asc&type=instance_sbs&zone=fr-par-1
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[], "total_count":0}'
+    body: '{"local_images":[{"id":"1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "START1-L", "START1-M",
+      "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB", "X64-30GB",
+      "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M", "ENT1-L", "ENT1-XL",
+      "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M", "PRO2-L", "STARDUST1-S",
+      "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G", "POP2-4C-16G", "POP2-8C-32G",
+      "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G", "POP2-HM-2C-16G", "POP2-HM-4C-32G",
+      "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G", "POP2-HM-64C-512G",
+      "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G", "POP2-HC-32C-64G",
+      "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"], "label":"ubuntu_jammy",
+      "type":"instance_sbs"}, {"id":"7044ae1e-a35d-4364-a962-93811c845f2f", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_sbs"}], "total_count":2}'
     headers:
       Content-Length:
-      - "36"
+      - "1296"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 15 Jan 2025 17:06:13 GMT
+      - Thu, 23 Jan 2025 13:33:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2857,7 +2973,939 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99c7192d-a790-45de-82a2-2de69597d879
+      - 475e653b-ac65-4b47-876f-8bee5e196a04
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/1fb9bfa4-68c3-4d6f-a362-8913a1af27b0
+    method: GET
+  response:
+    body: '{"image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "587"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 051aded2-d593-4fa4-8bfe-60e9e15495a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "f10e1539-d060-4a77-a048-8898d17a9e49"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "f10e1539-d060-4a77-a048-8898d17a9e49"}'
+    headers:
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 839dbb2f-7be1-49bc-9309-4af63e9570f9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "473"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 278f40ef-e408-4ffd-8b23-692bcdfd4b09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "f10e1539-d060-4a77-a048-8898d17a9e49"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_snapshot",
+      "resource_id": "f10e1539-d060-4a77-a048-8898d17a9e49"}'
+    headers:
+      Content-Length:
+      - "145"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 446837b5-fa4a-4765-89a5-c64b8bcbe30d
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: GET
+  response:
+    body: '{"id":"f10e1539-d060-4a77-a048-8898d17a9e49", "name":"cli-snp-stoic-gagarin",
+      "parent_volume":{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0", "type":"sbs_5k", "status":"in_use"}, "size":20000000000,
+      "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "created_at":"2025-01-23T13:33:02.783001Z",
+      "updated_at":"2025-01-23T13:33:02.783001Z", "references":[], "status":"available",
+      "tags":[], "class":"sbs", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "473"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30d4d96b-0ed2-4a75-9a1a-de8cc04b62ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "1789"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:08 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1f0a87a-757d-47da-a0f6-0470b36cb22d
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59efd8e0-39f6-4ad7-8216-be5108973c47
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"id":"c1ebd707-4816-4a71-941e-dcc412abc3b0", "name":"cli-srv-sharp-chaum-0",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.787744Z", "updated_at":"2025-01-23T13:33:08.787744Z",
+      "references":[{"id":"375573f8-abc8-42ba-ac16-bad8b67c8f36", "product_resource_type":"instance_server",
+      "product_resource_id":"f1f0a87a-757d-47da-a0f6-0470b36cb22d", "created_at":"2025-01-23T13:33:08.787744Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c1ebd707-4816-4a71-941e-dcc412abc3b0
+    method: GET
+  response:
+    body: '{"id":"c1ebd707-4816-4a71-941e-dcc412abc3b0", "name":"cli-srv-sharp-chaum-0",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.787744Z", "updated_at":"2025-01-23T13:33:08.787744Z",
+      "references":[{"id":"375573f8-abc8-42ba-ac16-bad8b67c8f36", "product_resource_type":"instance_server",
+      "product_resource_id":"f1f0a87a-757d-47da-a0f6-0470b36cb22d", "created_at":"2025-01-23T13:33:08.787744Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "685"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:09 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f0e519bb-f1f7-4b00-9128-bd5bce208f69
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"93526739-2385-4ae2-93bf-352acfd73215", "name":"cli-srv-sharp-chaum-1",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.938367Z", "updated_at":"2025-01-23T13:33:08.938367Z",
+      "references":[{"id":"c49a147c-6fcb-4b9a-9586-644dae698c26", "product_resource_type":"instance_server",
+      "product_resource_id":"f1f0a87a-757d-47da-a0f6-0470b36cb22d", "created_at":"2025-01-23T13:33:08.938367Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/93526739-2385-4ae2-93bf-352acfd73215
+    method: GET
+  response:
+    body: '{"id":"93526739-2385-4ae2-93bf-352acfd73215", "name":"cli-srv-sharp-chaum-1",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.938367Z", "updated_at":"2025-01-23T13:33:08.938367Z",
+      "references":[{"id":"c49a147c-6fcb-4b9a-9586-644dae698c26", "product_resource_type":"instance_server",
+      "product_resource_id":"f1f0a87a-757d-47da-a0f6-0470b36cb22d", "created_at":"2025-01-23T13:33:08.938367Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "685"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:09 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6461fc39-b4ef-44ed-98d4-df0891a186e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "54f1cb5f-d632-43bd-b324-f6a951e4a612", "name": "cli-srv-affectionate-euler",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-euler", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "f3abbb35-050c-4fd8-8568-92caf105731c", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:8f:3e:11", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-01-23T13:33:02.199501+00:00",
+      "modification_date": "2025-01-23T13:33:02.199501+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54f1cb5f-d632-43bd-b324-f6a951e4a612
+    method: GET
+  response:
+    body: '{"server": {"id": "54f1cb5f-d632-43bd-b324-f6a951e4a612", "name": "cli-srv-affectionate-euler",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-affectionate-euler", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "f3abbb35-050c-4fd8-8568-92caf105731c", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:8f:3e:11", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-01-23T13:33:02.199501+00:00",
+      "modification_date": "2025-01-23T13:33:02.199501+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "1686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1404a6a1-7eaa-47e9-aae3-dc567fb7719e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/54f1cb5f-d632-43bd-b324-f6a951e4a612
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09b3506d-434b-44f3-a284-fab351a70c21
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:02.338759Z", "updated_at":"2025-01-23T13:33:02.338759Z",
+      "references":[{"id":"e4363046-f261-417b-91da-2dd5ff612976", "product_resource_type":"instance_server",
+      "product_resource_id":"54f1cb5f-d632-43bd-b324-f6a951e4a612", "created_at":"2025-01-23T13:33:02.338759Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f3abbb35-050c-4fd8-8568-92caf105731c
+    method: GET
+  response:
+    body: '{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:02.338759Z", "updated_at":"2025-01-23T13:33:02.338759Z",
+      "references":[{"id":"e4363046-f261-417b-91da-2dd5ff612976", "product_resource_type":"instance_server",
+      "product_resource_id":"54f1cb5f-d632-43bd-b324-f6a951e4a612", "created_at":"2025-01-23T13:33:02.338759Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131",
+      "status":"in_use", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "706"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d79a556a-7b3d-4e35-9e8d-e7851c7f4ae1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:02.338759Z", "updated_at":"2025-01-23T13:33:11.659136Z",
+      "references":[], "parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:11.659136Z", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f3abbb35-050c-4fd8-8568-92caf105731c
+    method: GET
+  response:
+    body: '{"id":"f3abbb35-050c-4fd8-8568-92caf105731c", "name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0", "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:02.338759Z", "updated_at":"2025-01-23T13:33:11.659136Z",
+      "references":[], "parent_snapshot_id":"4eb9437f-8993-444a-b564-f7654add2131",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:11.659136Z", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "498"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99dcf6a4-ea73-4880-ac65-51a4ce9da7fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f3abbb35-050c-4fd8-8568-92caf105731c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd5a25d4-0738-4856-a77c-d1e646c70612
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1f0a87a-757d-47da-a0f6-0470b36cb22d
+    method: GET
+  response:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "1789"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83d32b02-5892-4f60-8485-077be184ce64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1f0a87a-757d-47da-a0f6-0470b36cb22d
+    method: GET
+  response:
+    body: '{"server": {"id": "f1f0a87a-757d-47da-a0f6-0470b36cb22d", "name": "cli-srv-sharp-chaum",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sharp-chaum", "image": {"id": "1fb9bfa4-68c3-4d6f-a362-8913a1af27b0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "4eb9437f-8993-444a-b564-f7654add2131", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2024-10-07T11:39:13.069801+00:00", "modification_date": "2024-10-07T11:39:13.069801+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "c1ebd707-4816-4a71-941e-dcc412abc3b0", "zone": "fr-par-1"}, "1": {"boot":
+      false, "volume_type": "sbs_volume", "id": "93526739-2385-4ae2-93bf-352acfd73215",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8f:3e:15",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-23T13:33:08.622596+00:00",
+      "modification_date": "2025-01-23T13:33:08.622596+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "1789"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c269339c-0b78-494b-bd2c-8e43eb3d23cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1f0a87a-757d-47da-a0f6-0470b36cb22d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bd68311-7e84-484d-8145-e0a4b55c210c
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"c1ebd707-4816-4a71-941e-dcc412abc3b0", "name":"cli-srv-sharp-chaum-0",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.787744Z", "updated_at":"2025-01-23T13:33:17.335504Z",
+      "references":[], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:17.335504Z", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c1ebd707-4816-4a71-941e-dcc412abc3b0
+    method: GET
+  response:
+    body: '{"id":"c1ebd707-4816-4a71-941e-dcc412abc3b0", "name":"cli-srv-sharp-chaum-0",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.787744Z", "updated_at":"2025-01-23T13:33:17.335504Z",
+      "references":[], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:17.335504Z", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "478"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f1ded66-07ff-4729-9a3c-124799d70aaf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/c1ebd707-4816-4a71-941e-dcc412abc3b0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b84d6390-4bba-4904-8fde-8c01b8ed1b73
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"93526739-2385-4ae2-93bf-352acfd73215", "name":"cli-srv-sharp-chaum-1",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.938367Z", "updated_at":"2025-01-23T13:33:17.417587Z",
+      "references":[], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:17.417587Z", "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/93526739-2385-4ae2-93bf-352acfd73215
+    method: GET
+  response:
+    body: '{"id":"93526739-2385-4ae2-93bf-352acfd73215", "name":"cli-srv-sharp-chaum-1",
+      "type":"sbs_5k", "size":20000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-23T13:33:08.938367Z", "updated_at":"2025-01-23T13:33:17.417587Z",
+      "references":[], "parent_snapshot_id":"f10e1539-d060-4a77-a048-8898d17a9e49",
+      "status":"available", "tags":[], "specs":{"perf_iops":5000, "class":"sbs"},
+      "last_detached_at":"2025-01-23T13:33:17.417587Z", "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "478"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4da4113-401c-4dea-bc5a-a2908aeb62e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/93526739-2385-4ae2-93bf-352acfd73215
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff1ef218-5210-4710-b901-d3b071973aed
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/f10e1539-d060-4a77-a048-8898d17a9e49
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 23 Jan 2025 13:33:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30036e89-7849-41b3-b64b-748108b8bebe
+    status: 204 No Content
+    code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-only-block-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-only-block-volumes.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:47:48 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fe6cfa4-2ae5-4b83-9e8a-df4abd5fad7f
+      - c493d95c-e172-436c-b2e6-fba24958e72a
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:47:48 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edcc247d-fdec-473d-bfd9-dcf879491979
+      - d5164fcf-e37c-44aa-96c3-463047efaeab
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:47:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5571ceea-d377-4796-b28a-7c14145fda78
+      - e3e6d178-85a2-4ccb-9650-3a55e9b56298
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:47:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,39 +1391,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9a720ad-342a-4c78-9f8d-96101fa0d5ce
+      - baef4ed8-a03e-47e0-92e8-c575850f926c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine",
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.313824Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.313824Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "420"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:47:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1788df6-29fb-4311-ae89-64aba44b68f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "ba83871f-e8a8-439a-a707-48f711f045af"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ba83871f-e8a8-439a-a707-48f711f045af
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "ba83871f-e8a8-439a-a707-48f711f045af"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:47:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08dac21a-4b80-4e2f-8dd7-f5873ca9f134
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.313824Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ba83871f-e8a8-439a-a707-48f711f045af
+    method: GET
+  response:
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.313824Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "421"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:47:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57f16202-3c68-4d6a-857c-e13602ea0a2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-cranky-goldstine", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sad-wilbur", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "07301398-de19-4351-8baa-2600d594f1ca",
+      "volumes": {"0": {"boot": false, "id": "727ebc53-4e2b-4f81-b0b7-621abc88be58",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e",
-      "name": "cli-srv-cranky-goldstine-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:6d",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ba83871f-e8a8-439a-a707-48f711f045af",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:29",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1435,49 +1546,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine",
+    body: '{"server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-cranky-goldstine", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sad-wilbur", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "07301398-de19-4351-8baa-2600d594f1ca",
+      "volumes": {"0": {"boot": false, "id": "727ebc53-4e2b-4f81-b0b7-621abc88be58",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e",
-      "name": "cli-srv-cranky-goldstine-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:6d",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ba83871f-e8a8-439a-a707-48f711f045af",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:29",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2666"
+      - "2229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:54 GMT
+      - Wed, 15 Jan 2025 16:47:50 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bddfb79a-21bb-4f95-bd33-3d1a870e154f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ca442a6-33b6-4de2-a931-47d892aace26
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1485,89 +1591,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9833f63-345e-43e5-9eac-96c6144e8cf6
+      - 95a234b1-4baa-43b8-9c91-d3380fe2bfa4
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine",
+    body: '{"server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-cranky-goldstine", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sad-wilbur", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "07301398-de19-4351-8baa-2600d594f1ca",
+      "volumes": {"0": {"boot": false, "id": "727ebc53-4e2b-4f81-b0b7-621abc88be58",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e",
-      "name": "cli-srv-cranky-goldstine-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:6d",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ba83871f-e8a8-439a-a707-48f711f045af",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:29",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bddfb79a-21bb-4f95-bd33-3d1a870e154f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ca442a6-33b6-4de2-a931-47d892aace26
     method: GET
   response:
-    body: '{"server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine",
+    body: '{"server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-cranky-goldstine", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-sad-wilbur", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "07301398-de19-4351-8baa-2600d594f1ca",
+      "volumes": {"0": {"boot": false, "id": "727ebc53-4e2b-4f81-b0b7-621abc88be58",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e",
-      "name": "cli-srv-cranky-goldstine-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "bddfb79a-21bb-4f95-bd33-3d1a870e154f", "name": "cli-srv-cranky-goldstine"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:6d",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "8ca442a6-33b6-4de2-a931-47d892aace26", "name": "cli-srv-sad-wilbur"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ba83871f-e8a8-439a-a707-48f711f045af",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:29",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:54.139013+00:00",
-      "modification_date": "2024-12-24T08:56:54.139013+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:47:49.652514+00:00",
+      "modification_date": "2025-01-15T16:47:49.652514+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2666"
+      - "2229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:47:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1575,7 +1671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc75c91d-4164-4ad6-93de-44fb8e506db9
+      - ad28e92a-1635-4da4-9a46-33c01b262a5a
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,7 +1681,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bddfb79a-21bb-4f95-bd33-3d1a870e154f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/8ca442a6-33b6-4de2-a931-47d892aace26
     method: DELETE
   response:
     body: ""
@@ -1595,9 +1691,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:54 GMT
+      - Wed, 15 Jan 2025 16:47:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1605,39 +1701,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 547f6043-2c4e-4ebf-9e79-e56cb62b03c8
+      - 1afe305e-aecd-4f6b-9a1d-df898d7df353
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e", "name": "cli-srv-cranky-goldstine-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00", "modification_date":
-      "2024-12-24T08:56:55.127296+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.728498Z",
+      "references":[{"id":"ebe5393f-71e2-463e-82da-a0528007118a", "product_resource_type":"instance_server",
+      "product_resource_id":"8ca442a6-33b6-4de2-a931-47d892aace26", "created_at":"2025-01-15T16:47:49.728498Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ff2c00e2-6e39-479f-b03c-30420b5c8c4e
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ba83871f-e8a8-439a-a707-48f711f045af
     method: GET
   response:
-    body: '{"volume": {"id": "ff2c00e2-6e39-479f-b03c-30420b5c8c4e", "name": "cli-srv-cranky-goldstine-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T08:56:54.139013+00:00", "modification_date":
-      "2024-12-24T08:56:55.127296+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:49.728498Z",
+      "references":[{"id":"ebe5393f-71e2-463e-82da-a0528007118a", "product_resource_type":"instance_server",
+      "product_resource_id":"8ca442a6-33b6-4de2-a931-47d892aace26", "created_at":"2025-01-15T16:47:49.728498Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "448"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:54 GMT
+      - Wed, 15 Jan 2025 16:47:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1645,7 +1747,49 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4019406-55fc-4255-90d3-92849a4485a3
+      - dd792ca8-9ff1-4813-ae34-e190c4b84154
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:50.666538Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:47:50.666538Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ba83871f-e8a8-439a-a707-48f711f045af
+    method: GET
+  response:
+    body: '{"id":"ba83871f-e8a8-439a-a707-48f711f045af", "name":"cli-vol-vigorous-liskov",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:47:49.313824Z", "updated_at":"2025-01-15T16:47:50.666538Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:47:50.666538Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:47:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 12a85d4d-bdd5-4971-9e7c-b0200135dd51
     status: 200 OK
     code: 200
     duration: ""
@@ -1655,7 +1799,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ff2c00e2-6e39-479f-b03c-30420b5c8c4e
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ba83871f-e8a8-439a-a707-48f711f045af
     method: DELETE
   response:
     body: ""
@@ -1665,9 +1809,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:47:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1675,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb2a2f7a-568d-48d3-a246-6236577246cd
+      - 4f0e9776-59cb-4b5b-82cb-7f89986398b8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1685,7 +1829,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/07301398-de19-4351-8baa-2600d594f1ca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/727ebc53-4e2b-4f81-b0b7-621abc88be58
     method: DELETE
   response:
     body: ""
@@ -1695,9 +1839,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:47:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1705,7 +1849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16617ad4-aa75-424a-a78a-1d5ed04e76d6
+      - 0e65f017-730c-48dd-aed3-97454a3fe689
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-only-block-volumes.golden
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-only-block-volumes.golden
@@ -2,7 +2,7 @@
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
 ✅ Success.
 🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-successfully deleted volume cli-srv-cranky-goldstine-1 (10 GB b_ssd)
+successfully deleted volume  (- sbs_volume)
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "message": "Success",

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-only-local-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-only-local-volumes.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:43:55 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93d80c49-474e-4e12-8d8d-2ca61ffae183
+      - 3d68a055-53cc-4ccf-901b-9d0803648be9
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:43:55 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00ac60a2-2abc-40db-ac4c-779518aa7260
+      - b7f7f0d4-cc24-4ff4-938a-527c49e9d551
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:43:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7f6e299-e9ee-40cf-b70a-9b0fbd4ee926
+      - 3f24e613-1476-4425-ac5b-ad88fc7ac50e
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:55 GMT
+      - Wed, 15 Jan 2025 16:43:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,39 +1391,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92344da4-35fc-430e-95ba-2e5c82671260
+      - b54e59ad-7453-4d75-bc1f-56f7991dd82b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare",
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:56.405202Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:56.405202Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "419"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:43:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4eae4883-8ab0-46e6-b36d-d2001981aff5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d4d1b23c-5f9b-46ba-9183-82bc6b2fa935
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:43:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 80982584-aaa6-414e-a994-469c4e56ef69
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:56.405202Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d4d1b23c-5f9b-46ba-9183-82bc6b2fa935
+    method: GET
+  response:
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:56.405202Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "419"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:43:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e4c0e5ad-48e4-4bca-9d37-76a14002fb61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-poincare", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-wonderful-gagarin", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac",
+      "volumes": {"0": {"boot": false, "id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "218f4584-473d-4710-a03f-172cebba7218",
-      "name": "cli-srv-xenodochial-poincare-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:71",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:f3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1435,49 +1546,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare",
+    body: '{"server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-poincare", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-wonderful-gagarin", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac",
+      "volumes": {"0": {"boot": false, "id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "218f4584-473d-4710-a03f-172cebba7218",
-      "name": "cli-srv-xenodochial-poincare-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:71",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:f3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2686"
+      - "2250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:43:57 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d3d817a7-1279-444c-b63a-7ce1d12a281c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/800cc7a2-61df-4ac9-b2af-b16da2221651
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1485,89 +1591,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dc91d2e-c0ae-48fd-a5af-82500824c93d
+      - f1f7cb10-9a47-4fa3-9a98-fed2722981c2
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare",
+    body: '{"server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-poincare", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-wonderful-gagarin", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac",
+      "volumes": {"0": {"boot": false, "id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "218f4584-473d-4710-a03f-172cebba7218",
-      "name": "cli-srv-xenodochial-poincare-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:71",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:f3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d3d817a7-1279-444c-b63a-7ce1d12a281c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/800cc7a2-61df-4ac9-b2af-b16da2221651
     method: GET
   response:
-    body: '{"server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare",
+    body: '{"server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-poincare", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-wonderful-gagarin", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac",
+      "volumes": {"0": {"boot": false, "id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "218f4584-473d-4710-a03f-172cebba7218",
-      "name": "cli-srv-xenodochial-poincare-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "d3d817a7-1279-444c-b63a-7ce1d12a281c", "name": "cli-srv-xenodochial-poincare"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:71",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "800cc7a2-61df-4ac9-b2af-b16da2221651", "name": "cli-srv-wonderful-gagarin"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "d4d1b23c-5f9b-46ba-9183-82bc6b2fa935",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:f3",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:56.490487+00:00",
-      "modification_date": "2024-12-24T08:56:56.490487+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:43:57.112586+00:00",
+      "modification_date": "2025-01-15T16:43:57.112586+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2686"
+      - "2250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:56 GMT
+      - Wed, 15 Jan 2025 16:43:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1575,7 +1671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b453cac-3251-4bda-8efb-fd1b070f10e4
+      - 76af9d5a-faba-486c-a539-4680af34dc14
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,7 +1681,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d3d817a7-1279-444c-b63a-7ce1d12a281c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/800cc7a2-61df-4ac9-b2af-b16da2221651
     method: DELETE
   response:
     body: ""
@@ -1595,9 +1691,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:43:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1605,29 +1701,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09dd07dc-7643-4c3a-9205-8ca247169961
+      - f7f98113-6aed-4a92-953d-321885c4738d
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac", "name": "Ubuntu
+    body: '{"volume": {"id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:56.490487+00:00", "modification_date": "2024-12-24T08:56:57.262625+00:00",
+      "2025-01-15T16:43:57.112586+00:00", "modification_date": "2025-01-15T16:43:57.906414+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6332766c-8e0e-4e7d-b800-ea417b5c95ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e01c4384-b2a3-4517-be9e-7dadcffb9bb5
     method: GET
   response:
-    body: '{"volume": {"id": "6332766c-8e0e-4e7d-b800-ea417b5c95ac", "name": "Ubuntu
+    body: '{"volume": {"id": "e01c4384-b2a3-4517-be9e-7dadcffb9bb5", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:56.490487+00:00", "modification_date": "2024-12-24T08:56:57.262625+00:00",
+      "2025-01-15T16:43:57.112586+00:00", "modification_date": "2025-01-15T16:43:57.906414+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -1637,9 +1733,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:43:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1647,7 +1743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d90c184d-c8e5-44dc-8cb5-b446747e5f9a
+      - 57eb55b1-4670-40bc-9d91-3ea8d464e2cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1657,7 +1753,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6332766c-8e0e-4e7d-b800-ea417b5c95ac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e01c4384-b2a3-4517-be9e-7dadcffb9bb5
     method: DELETE
   response:
     body: ""
@@ -1667,9 +1763,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:43:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1677,9 +1773,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a777f60-0da6-43c1-84a0-1b3cdcdb7c9a
+      - c12c5031-8f63-4334-a13b-c9c7bb141451
     status: 204 No Content
     code: 204
+    duration: ""
+- request:
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:58.372575Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:43:58.372575Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d4d1b23c-5f9b-46ba-9183-82bc6b2fa935
+    method: GET
+  response:
+    body: '{"id":"d4d1b23c-5f9b-46ba-9183-82bc6b2fa935", "name":"cli-vol-blissful-elion",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:43:56.405202Z", "updated_at":"2025-01-15T16:43:58.372575Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:43:58.372575Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "445"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:43:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93d54c3e-ba6f-4232-ab45-6621e0b2a05a
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -1687,7 +1825,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/218f4584-473d-4710-a03f-172cebba7218
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/d4d1b23c-5f9b-46ba-9183-82bc6b2fa935
     method: DELETE
   response:
     body: ""
@@ -1697,9 +1835,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:43:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1707,7 +1845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88ea008e-908d-464c-84f6-a136000e3a73
+      - 03b63b1b-a726-4576-a9b1-81ad3c74df41
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-with-all-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-with-all-volumes.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:51 GMT
+      - Wed, 15 Jan 2025 16:48:54 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd6d0cf7-3c17-49bf-8a70-e723aa51d962
+      - b67575bd-cc62-4b66-9bcc-464552fb54df
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:51 GMT
+      - Wed, 15 Jan 2025 16:48:54 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cb1415-18de-4b9f-8f75-a0deec85e87e
+      - d55a0438-c7ac-4041-be4d-6f9a6aa6479d
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:51 GMT
+      - Wed, 15 Jan 2025 16:48:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d9300a-b56e-4e35-adfc-2e44d9017ce7
+      - e95b1876-df0d-4058-908c-6cd2ec04efe0
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:51 GMT
+      - Wed, 15 Jan 2025 16:48:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,41 +1391,154 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1b30c8a-e7c5-4454-82bd-7c271a8fcb04
+      - 0bedec2a-022d-42d4-b9f6-37e493553095
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha",
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:54.885033Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:54.885033Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "416"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:48:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf4b194d-c5a1-4052-930f-d951dad3a326
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "656b5da7-766e-483a-b421-c4561e4b7f29"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/656b5da7-766e-483a-b421-c4561e4b7f29
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "656b5da7-766e-483a-b421-c4561e4b7f29"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:48:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19851857-8a6b-4539-af8c-6680f7088d1f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:54.885033Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/656b5da7-766e-483a-b421-c4561e4b7f29
+    method: GET
+  response:
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:54.885033Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "416"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:48:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6eb9e4b1-4060-4af9-8c83-43afb2754fea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-frosty-bhabha", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-quizzical-hertz", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "382f46f5-6b9c-41ee-a498-4514504e9388",
+      "volumes": {"0": {"boot": false, "id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82",
-      "name": "cli-srv-frosty-bhabha-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:69",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "656b5da7-766e-483a-b421-c4561e4b7f29",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:39",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encryption_ssh_key_id": null, "admin_password_encrypted_value":
+      null}}'
     form: {}
     headers:
       Content-Type:
@@ -1435,49 +1548,46 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha",
+    body: '{"server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-frosty-bhabha", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-quizzical-hertz", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "382f46f5-6b9c-41ee-a498-4514504e9388",
+      "volumes": {"0": {"boot": false, "id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82",
-      "name": "cli-srv-frosty-bhabha-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:69",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "656b5da7-766e-483a-b421-c4561e4b7f29",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:39",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encryption_ssh_key_id": null, "admin_password_encrypted_value":
+      null}}'
     headers:
       Content-Length:
-      - "2651"
+      - "2330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:52 GMT
+      - Wed, 15 Jan 2025 16:48:55 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ee16c7f-7afa-4c7c-9405-502aa7c6e113
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/85216006-4cd9-4b5e-8a95-9f2383c01cdf
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1485,89 +1595,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ecde6d7-9a5b-4ebe-945c-acee6b2f8880
+      - 3b41254f-09f5-419b-9660-0598dd679274
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha",
+    body: '{"server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-frosty-bhabha", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-quizzical-hertz", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "382f46f5-6b9c-41ee-a498-4514504e9388",
+      "volumes": {"0": {"boot": false, "id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82",
-      "name": "cli-srv-frosty-bhabha-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:69",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "656b5da7-766e-483a-b421-c4561e4b7f29",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:39",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ee16c7f-7afa-4c7c-9405-502aa7c6e113
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/85216006-4cd9-4b5e-8a95-9f2383c01cdf
     method: GET
   response:
-    body: '{"server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha",
+    body: '{"server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-frosty-bhabha", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-quizzical-hertz", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "382f46f5-6b9c-41ee-a498-4514504e9388",
+      "volumes": {"0": {"boot": false, "id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82",
-      "name": "cli-srv-frosty-bhabha-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "4ee16c7f-7afa-4c7c-9405-502aa7c6e113", "name": "cli-srv-frosty-bhabha"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:69",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "85216006-4cd9-4b5e-8a95-9f2383c01cdf", "name": "cli-srv-quizzical-hertz"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "656b5da7-766e-483a-b421-c4561e4b7f29",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:39",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:52.231260+00:00",
-      "modification_date": "2024-12-24T08:56:52.231260+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:48:55.217867+00:00",
+      "modification_date": "2025-01-15T16:48:55.217867+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2651"
+      - "2244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:52 GMT
+      - Wed, 15 Jan 2025 16:48:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1575,7 +1675,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 695e3efb-3c34-407c-9717-7c8b9d6155a3
+      - bdc4b9e8-482d-4811-9d74-52154a900095
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,7 +1685,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ee16c7f-7afa-4c7c-9405-502aa7c6e113
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/85216006-4cd9-4b5e-8a95-9f2383c01cdf
     method: DELETE
   response:
     body: ""
@@ -1595,9 +1695,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:52 GMT
+      - Wed, 15 Jan 2025 16:48:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1605,29 +1705,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e7b1938-0fab-4e1d-911b-490b76f57fb9
+      - 9c9164d4-d044-4f8b-9f47-3d159aaa3aa4
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "382f46f5-6b9c-41ee-a498-4514504e9388", "name": "Ubuntu
+    body: '{"volume": {"id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:52.231260+00:00", "modification_date": "2024-12-24T08:56:53.057617+00:00",
+      "2025-01-15T16:48:55.217867+00:00", "modification_date": "2025-01-15T16:48:55.894688+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/382f46f5-6b9c-41ee-a498-4514504e9388
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b5c647cb-cabb-42b8-9c1c-d09c49cfbf85
     method: GET
   response:
-    body: '{"volume": {"id": "382f46f5-6b9c-41ee-a498-4514504e9388", "name": "Ubuntu
+    body: '{"volume": {"id": "b5c647cb-cabb-42b8-9c1c-d09c49cfbf85", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:52.231260+00:00", "modification_date": "2024-12-24T08:56:53.057617+00:00",
+      "2025-01-15T16:48:55.217867+00:00", "modification_date": "2025-01-15T16:48:55.894688+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -1637,9 +1737,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:52 GMT
+      - Wed, 15 Jan 2025 16:48:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1647,7 +1747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96559982-17ce-483f-b7d2-4a71e2a0aea7
+      - 2d6ec487-d6b1-48be-b536-0732c6d78782
     status: 200 OK
     code: 200
     duration: ""
@@ -1657,7 +1757,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/382f46f5-6b9c-41ee-a498-4514504e9388
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b5c647cb-cabb-42b8-9c1c-d09c49cfbf85
     method: DELETE
   response:
     body: ""
@@ -1667,9 +1767,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:48:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1677,39 +1777,41 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb5957ae-ebfc-420f-91e2-c12ca1a88713
+      - 162a27c3-4633-43e4-bfc9-cb4f14a9ffed
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82", "name": "cli-srv-frosty-bhabha-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00", "modification_date":
-      "2024-12-24T08:56:53.057617+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:56.265823Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:48:56.265823Z",
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/946581e9-a5f1-4b3b-b8c1-6cb1ac833d82
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/656b5da7-766e-483a-b421-c4561e4b7f29
     method: GET
   response:
-    body: '{"volume": {"id": "946581e9-a5f1-4b3b-b8c1-6cb1ac833d82", "name": "cli-srv-frosty-bhabha-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-12-24T08:56:52.231260+00:00", "modification_date":
-      "2024-12-24T08:56:53.057617+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"id":"656b5da7-766e-483a-b421-c4561e4b7f29", "name":"cli-vol-stoic-euler",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:48:54.885033Z", "updated_at":"2025-01-15T16:48:56.265823Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:48:56.265823Z",
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "445"
+      - "442"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:48:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1717,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a7ead6d-30a4-4242-b68a-eb8ac6ec15c7
+      - 244f2b03-d191-4c08-b13d-22cb72c052ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1727,7 +1829,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/946581e9-a5f1-4b3b-b8c1-6cb1ac833d82
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/656b5da7-766e-483a-b421-c4561e4b7f29
     method: DELETE
   response:
     body: ""
@@ -1737,9 +1839,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:53 GMT
+      - Wed, 15 Jan 2025 16:48:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge01)
+      - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1747,7 +1849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afe5776c-25e8-4762-9af8-36f9f6d91652
+      - c0fbca16-e1d9-40f2-83e6-fe84fd90484b
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-with-all-volumes.golden
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-with-all-volumes.golden
@@ -3,7 +3,7 @@
 ✅ Success.
 🟥🟥🟥 STDERR️️ 🟥🟥🟥️
 successfully deleted volume Ubuntu 18.04 Bionic Beaver (10 GB l_ssd)
-successfully deleted volume cli-srv-frosty-bhabha-1 (10 GB b_ssd)
+successfully deleted volume  (- sbs_volume)
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "message": "Success",

--- a/internal/namespaces/instance/v1/testdata/test-server-delete-with-none-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-delete-with-none-volumes.cassette.yaml
@@ -919,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:41:29 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 703bb38a-497b-46bf-aa9f-fa89548e1dd3
+      - 65d88f69-daa8-4dc0-8aa3-e5ba79d527df
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:41:29 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38086a54-1ce6-4362-95e6-80bb77030530
+      - 63b378f7-4377-4428-a141-b3b5653f4df1
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,7 +1337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:41:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccd40218-b1e4-4906-81e1-c9e30c7edf62
+      - 2355be9f-48f3-443e-96c8-f92b68777944
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:57 GMT
+      - Wed, 15 Jan 2025 16:41:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1391,39 +1391,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 735c7c47-3049-4d50-9ff3-2f9811e750f4
+      - a03e7fa1-7085-43b5-9758-101b7fbf7082
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan",
+    body: '{"id":"7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c", "name":"cli-vol-bold-goldberg",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:41:30.150710Z", "updated_at":"2025-01-15T16:41:30.150710Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c", "name":"cli-vol-bold-goldberg",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:41:30.150710Z", "updated_at":"2025-01-15T16:41:30.150710Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:41:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c5e1228-d37c-4dfe-bee1-0321afd5c805
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:41:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25f6dde4-f5f7-42eb-bcc2-dae2e7ece292
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c", "name":"cli-vol-bold-goldberg",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:41:30.150710Z", "updated_at":"2025-01-15T16:41:30.150710Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c
+    method: GET
+  response:
+    body: '{"id":"7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c", "name":"cli-vol-bold-goldberg",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:41:30.150710Z", "updated_at":"2025-01-15T16:41:30.150710Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "419"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:41:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a98ef7fb-ce6f-4f04-a7d5-5b923ba67f46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-priceless-ramanujan", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-festive-goldberg", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64",
+      "volumes": {"0": {"boot": false, "id": "7b76ec5b-9387-4eec-828f-701ecd8cea83",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "04257244-9433-41dc-a2e8-cc09e38b2485",
-      "name": "cli-srv-priceless-ramanujan-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:75",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:cf",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1435,47 +1546,42 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan",
+    body: '{"server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-priceless-ramanujan", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-festive-goldberg", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64",
+      "volumes": {"0": {"boot": false, "id": "7b76ec5b-9387-4eec-828f-701ecd8cea83",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "04257244-9433-41dc-a2e8-cc09e38b2485",
-      "name": "cli-srv-priceless-ramanujan-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:75",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:cf",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2681"
+      - "2247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:58 GMT
+      - Wed, 15 Jan 2025 16:41:31 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9a0c784a-59fa-4dd8-926b-25bc3756eab4
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ac1b1b8a-31d8-4e27-907f-082693f65f94
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1485,87 +1591,77 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42dff16c-b75c-4294-898e-622e1e6413d2
+      - 6d8f3bbb-0564-4d2f-a549-31cca2d83de2
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan",
+    body: '{"server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-priceless-ramanujan", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-festive-goldberg", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64",
+      "volumes": {"0": {"boot": false, "id": "7b76ec5b-9387-4eec-828f-701ecd8cea83",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "04257244-9433-41dc-a2e8-cc09e38b2485",
-      "name": "cli-srv-priceless-ramanujan-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:75",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:cf",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9a0c784a-59fa-4dd8-926b-25bc3756eab4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ac1b1b8a-31d8-4e27-907f-082693f65f94
     method: GET
   response:
-    body: '{"server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan",
+    body: '{"server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-priceless-ramanujan", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-festive-goldberg", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64",
+      "volumes": {"0": {"boot": false, "id": "7b76ec5b-9387-4eec-828f-701ecd8cea83",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "04257244-9433-41dc-a2e8-cc09e38b2485",
-      "name": "cli-srv-priceless-ramanujan-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "9a0c784a-59fa-4dd8-926b-25bc3756eab4", "name": "cli-srv-priceless-ramanujan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:32:75",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "ac1b1b8a-31d8-4e27-907f-082693f65f94", "name": "cli-srv-festive-goldberg"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "7f9a8314-dc7f-4a9d-9d5a-03a01bd0a16c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:cf",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:56:58.430855+00:00",
-      "modification_date": "2024-12-24T08:56:58.430855+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:41:30.530881+00:00",
+      "modification_date": "2025-01-15T16:41:30.530881+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2681"
+      - "2247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:59 GMT
+      - Wed, 15 Jan 2025 16:41:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1575,7 +1671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 933dac58-3e26-437f-a46b-003184d537bb
+      - e5f61e82-5ce6-4d92-b0f8-a65c2a6dacdc
     status: 200 OK
     code: 200
     duration: ""
@@ -1585,7 +1681,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/9a0c784a-59fa-4dd8-926b-25bc3756eab4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ac1b1b8a-31d8-4e27-907f-082693f65f94
     method: DELETE
   response:
     body: ""
@@ -1595,7 +1691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:59 GMT
+      - Wed, 15 Jan 2025 16:41:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1605,29 +1701,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb677066-1828-4070-8013-518739dee168
+      - 901f6009-4237-4ec3-978a-ba6fe7a6f239
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64", "name": "Ubuntu
+    body: '{"volume": {"id": "7b76ec5b-9387-4eec-828f-701ecd8cea83", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:58.430855+00:00", "modification_date": "2024-12-24T08:56:59.281055+00:00",
+      "2025-01-15T16:41:30.530881+00:00", "modification_date": "2025-01-15T16:41:31.700933+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2285c01c-87e4-4721-bea8-55d6a9b1bf64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7b76ec5b-9387-4eec-828f-701ecd8cea83
     method: GET
   response:
-    body: '{"volume": {"id": "2285c01c-87e4-4721-bea8-55d6a9b1bf64", "name": "Ubuntu
+    body: '{"volume": {"id": "7b76ec5b-9387-4eec-828f-701ecd8cea83", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T08:56:58.430855+00:00", "modification_date": "2024-12-24T08:56:59.281055+00:00",
+      "2025-01-15T16:41:30.530881+00:00", "modification_date": "2025-01-15T16:41:31.700933+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -1637,7 +1733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:59 GMT
+      - Wed, 15 Jan 2025 16:41:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1647,7 +1743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94615d05-487b-4fec-802b-c9db722be0d6
+      - 3019545a-3353-4dbb-b931-6b4ae13479c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1657,7 +1753,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2285c01c-87e4-4721-bea8-55d6a9b1bf64
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7b76ec5b-9387-4eec-828f-701ecd8cea83
     method: DELETE
   response:
     body: ""
@@ -1667,7 +1763,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:56:59 GMT
+      - Wed, 15 Jan 2025 16:41:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
@@ -1677,7 +1773,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ac070d-0f6b-4f1b-8b1c-0da9bd702fe9
+      - 59684185-86fe-4832-b828-35967fc224bc
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-terminate-with-block.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-terminate-with-block.cassette.yaml
@@ -2,26 +2,929 @@
 version: 1
 interactions:
 - request:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
+      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
+      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
+      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
+      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
+      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
+      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
+      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
+      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
+      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
+      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
+      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
+      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
+      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
+      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}}}'
     headers:
       Content-Length:
-      - "1183"
+      - "38539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:50 GMT
+      - Wed, 15 Jan 2025 09:41:51 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -29,31 +932,458 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e94f8c4-e8cd-4074-8300-7f1f7cb1f7b8
+      - 736970cb-4bdd-480c-9c06-531120e42e24
+      X-Total-Count:
+      - "68"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
+    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
+      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
+      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
+      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
+      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
+      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
+      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
+      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
+      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
+      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
+      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
+      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
+      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
+      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
+      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
+      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
+      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
+      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
+      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
+      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
+      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
+      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
+      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
+      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
+      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
+      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
+      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
+      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
+      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
+      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
+      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
+      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
+      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
+      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
+      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}}}'
+    headers:
+      Content-Length:
+      - "14208"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:50 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 327ceffc-7d54-48ea-8efa-468f4cefa699
+      X-Total-Count:
+      - "68"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfc2c626-52e1-40f9-9378-64c6c20b7960
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cb01f4c-9cd0-4032-8ce6-325c458df811
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
     method: GET
   response:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -63,9 +1393,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:49 GMT
+      - Wed, 15 Jan 2025 09:41:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -73,1311 +1403,41 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa08e3e4-fad8-497b-a80d-6cc6837dc7be
+      - e8b65a44-b6d2-42da-89a1-89a7512ae2d1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
-      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
-    method: GET
-  response:
-    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
-      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "38026"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:50 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 649f175f-875c-45ba-b667-8907a20554e8
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
-      700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
-      350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
-      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
-      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
-      250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
-      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
-    method: GET
-  response:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
-      700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
-      350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
-      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
-      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
-      250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
-      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "12534"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:50 GMT
-      Link:
-      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
-        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57eb463f-2070-40b1-b05e-60b65dda5952
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}}'
+    body: '{"id":"ea123faa-ac3e-408c-bf20-3a4160f8736c", "name":"cli-vol-nice-joliot",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:41:51.446144Z", "updated_at":"2025-01-15T09:41:51.446144Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}}'
+    body: '{"id":"ea123faa-ac3e-408c-bf20-3a4160f8736c", "name":"cli-vol-nice-joliot",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:41:51.446144Z", "updated_at":"2025-01-15T09:41:51.446144Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "366"
+      - "416"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:50 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/eed4575b-90e5-4102-b956-df874c911e2b
+      - Wed, 15 Jan 2025 09:41:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1385,117 +1445,157 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9bd115f-b685-49a4-ba03-652d7498e00e
-    status: 201 Created
-    code: 201
+      - d46c7ec3-b457-4a50-a5b5-cc27add47680
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "ea123faa-ac3e-408c-bf20-3a4160f8736c"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/ea123faa-ac3e-408c-bf20-3a4160f8736c
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "ea123faa-ac3e-408c-bf20-3a4160f8736c"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ed96ff0-b3ec-4bc7-9051-5c51e0cd8099
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"ea123faa-ac3e-408c-bf20-3a4160f8736c", "name":"cli-vol-nice-joliot",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:41:51.446144Z", "updated_at":"2025-01-15T09:41:51.446144Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/ea123faa-ac3e-408c-bf20-3a4160f8736c
+    method: GET
+  response:
+    body: '{"id":"ea123faa-ac3e-408c-bf20-3a4160f8736c", "name":"cli-vol-nice-joliot",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T09:41:51.446144Z", "updated_at":"2025-01-15T09:41:51.446144Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "417"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc516c08-01b5-4a03-b551-762f069b8327
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"},
-      "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}],
-      "mac_address": "de:00:00:5f:a0:f9", "routed_ip_enabled": true, "ipv6": null,
-      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:37:51.424952+00:00", "modification_date":
-      "2024-07-05T12:37:51.424952+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"},
-      "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}],
-      "mac_address": "de:00:00:5f:a0:f9", "routed_ip_enabled": true, "ipv6": null,
-      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:37:51.424952+00:00", "modification_date":
-      "2024-07-05T12:37:51.424952+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3691"
+      - "2238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:51 GMT
+      - Wed, 15 Jan 2025 09:41:52 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1503,30 +1603,490 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8050a6c6-13e5-48ab-9754-7812f0f36a5d
+      - bc6169f0-e74f-4988-9480-c042366a7aa8
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"task": {"id": "1b9620b7-60f1-4966-9b54-ee609f2c7955", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action",
-      "href_result": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a", "started_at":
-      "2024-07-05T12:37:52.250509+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
+    body: '{"task": {"id": "62f97843-ce30-4abe-9a19-5970acf52b60", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/604be356-0767-4638-89ff-33cc136c3ad2/action",
+      "href_result": "/servers/604be356-0767-4638-89ff-33cc136c3ad2", "started_at":
+      "2025-01-15T09:41:53.089460+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2/action
     method: POST
   response:
-    body: '{"task": {"id": "1b9620b7-60f1-4966-9b54-ee609f2c7955", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action",
-      "href_result": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a", "started_at":
-      "2024-07-05T12:37:52.250509+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
+    body: '{"task": {"id": "62f97843-ce30-4abe-9a19-5970acf52b60", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/604be356-0767-4638-89ff-33cc136c3ad2/action",
+      "href_result": "/servers/604be356-0767-4638-89ff-33cc136c3ad2", "started_at":
+      "2025-01-15T09:41:53.089460+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:52 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/62f97843-ce30-4abe-9a19-5970acf52b60
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 991f2efc-f625-43fb-9269-f2576b76348e
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
+    method: GET
+  response:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2260"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d70cc9c-9c5a-468e-aedd-1f26d00017f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
+    method: GET
+  response:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2359"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:41:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86925a1b-9bdb-43e2-b1ce-24019166b4a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
+    method: GET
+  response:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:52.809672+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2359"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f93a71e-bf9e-4caf-b053-b9b8440d5d51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:07.559326+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
+    method: GET
+  response:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:07.559326+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c57bc00b-9590-4287-9797-29a540cb00c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:07.559326+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
+    method: GET
+  response:
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:07.559326+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 09:42:09 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0037b852-1e92-47ed-9ca4-d0c07c9b2915
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"task": {"id": "eb404186-cd59-496d-98d2-628ace2a6190", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/604be356-0767-4638-89ff-33cc136c3ad2/action",
+      "href_result": "/servers/604be356-0767-4638-89ff-33cc136c3ad2", "started_at":
+      "2025-01-15T09:42:09.723702+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2/action
+    method: POST
+  response:
+    body: '{"task": {"id": "eb404186-cd59-496d-98d2-628ace2a6190", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/604be356-0767-4638-89ff-33cc136c3ad2/action",
+      "href_result": "/servers/604be356-0767-4638-89ff-33cc136c3ad2", "started_at":
+      "2025-01-15T09:42:09.723702+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
     headers:
       Content-Length:
       - "353"
@@ -1535,11 +2095,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:52 GMT
+      - Wed, 15 Jan 2025 09:42:09 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1b9620b7-60f1-4966-9b54-ee609f2c7955
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/eb404186-cd59-496d-98d2-628ace2a6190
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1547,113 +2107,83 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a7fb5cd-8ea5-4b90-8697-6f6779b4b1e3
+      - 76ee5d73-2291-4317-8db1-f78263c3098b
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "terminating", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:09.499982+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
       ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
     method: GET
   response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
+    body: '{"server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-stoic-fermi", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
+      "volumes": {"0": {"boot": false, "id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
+      "server": {"id": "604be356-0767-4638-89ff-33cc136c3ad2", "name": "cli-srv-stoic-fermi"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:41:51.975892+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "ea123faa-ac3e-408c-bf20-3a4160f8736c",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
+      "terminating", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:71:73",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T09:41:51.975892+00:00",
+      "modification_date": "2025-01-15T09:42:09.499982+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "94", "hypervisor_id": "203", "node_id": "16"}, "maintenances": [], "allowed_actions":
       ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3713"
+      - "2353"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:51 GMT
+      - Wed, 15 Jan 2025 09:42:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1661,908 +2191,22 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91859a8b-27d6-4e0c-b2b0-5439e3d15d40
+      - 4987b45b-5b59-4927-bfc4-86207956d34d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_server",
+      "resource_id": "604be356-0767-4638-89ff-33cc136c3ad2"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/604be356-0767-4638-89ff-33cc136c3ad2
     method: GET
   response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3812"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:57 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8957e69-d143-4e92-bdc4-a01cccc5c8cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:52.074825+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3812"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01c116a6-2712-4226-9957-20dc98f7eb45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:05.998936+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:05.998936+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 500c89c1-b3de-4af7-a340-b90fb40db574
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:05.998936+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "529dab09-3756-451e-aed3-6166474c3514"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:05.998936+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3843"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1fdccf37-6630-4c85-9515-36fa72d953be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"task": {"id": "325bfd64-5913-4ad2-a80f-9795142dcca6", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action",
-      "href_result": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a", "started_at":
-      "2024-07-05T12:38:08.389229+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action
-    method: POST
-  response:
-    body: '{"task": {"id": "325bfd64-5913-4ad2-a80f-9795142dcca6", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a/action",
-      "href_result": "/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a", "started_at":
-      "2024-07-05T12:38:08.389229+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
-    headers:
-      Content-Length:
-      - "349"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:08 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/325bfd64-5913-4ad2-a80f-9795142dcca6
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff473912-42e3-43b0-8da1-aee1a2599406
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/eed4575b-90e5-4102-b956-df874c911e2b
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a94e041-3bca-4dcf-af87-077823a7d0c2
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:09 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0248bd0-7c66-413b-be31-842d06e171cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fcb6bc34-4053-47ab-8002-90c4b9e56e4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-stoic-vaughan", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780",
-      "name": "cli-srv-stoic-vaughan-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a", "name": "cli-srv-stoic-vaughan"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:37:51.424952+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopping", "protected": false, "state_detail":
-      "launching terminate task", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": true, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "bcb63d79-f0ae-4e41-b9d0-0c3c485d51e4"}], "mac_address": "de:00:00:5f:a0:f9",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:51.424952+00:00",
-      "modification_date": "2024-07-05T12:38:08.070382+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "49", "hypervisor_id": "504", "node_id": "53"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:19 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8317b293-e943-4f31-a9d5-51fa404b470c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_server",
-      "resource_id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a"}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/31ce4471-9e3f-4e97-b11d-e69e93f7547a
-    method: GET
-  response:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_server",
-      "resource_id": "31ce4471-9e3f-4e97-b11d-e69e93f7547a"}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_server",
+      "resource_id": "604be356-0767-4638-89ff-33cc136c3ad2"}'
     headers:
       Content-Length:
       - "143"
@@ -2571,9 +2215,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:38:25 GMT
+      - Wed, 15 Jan 2025 09:42:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2581,22 +2225,22 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 475d4913-2c72-42f8-ae9f-e0b181afb779
+      - f6acf8bb-e7be-4b6d-a916-167f0cd9c55f
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume",
-      "resource_id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780"}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/839fcf3a-cd4a-4bb7-994c-65b77e1c4780
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d36c5dbe-a6f6-474d-b196-ec567228f3ff
     method: GET
   response:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume",
-      "resource_id": "839fcf3a-cd4a-4bb7-994c-65b77e1c4780"}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "d36c5dbe-a6f6-474d-b196-ec567228f3ff"}'
     headers:
       Content-Length:
       - "143"
@@ -2605,9 +2249,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:38:25 GMT
+      - Wed, 15 Jan 2025 09:42:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2615,41 +2259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8c52580-744b-4bfe-bcd9-f4e730284f18
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume",
-      "resource_id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147"}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3c9e1c82-ab6b-41ea-adcd-2c1f94592147
-    method: GET
-  response:
-    body: '{"type": "not_found", "message": "resource is not found", "resource": "instance_volume",
-      "resource_id": "3c9e1c82-ab6b-41ea-adcd-2c1f94592147"}'
-    headers:
-      Content-Length:
-      - "143"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:38:25 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4682c1b3-2a36-446f-863a-d01f339b1f8c
+      - 55949d7a-b3ec-4ebd-9872-916862a0148c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-terminate-with-block.golden
+++ b/internal/namespaces/instance/v1/testdata/test-server-terminate-with-block.golden
@@ -1,8 +1,6 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
 ✅ Success.
-🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-successfully deleted ip 212.47.248.223
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "message": "Success",

--- a/internal/namespaces/instance/v1/testdata/test-server-terminate-without-block.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-terminate-without-block.cassette.yaml
@@ -2,26 +2,929 @@
 version: 1
 interactions:
 - request:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
+      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
+      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
+      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
+      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
+      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
+      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
+      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"local_images":[{"id":"55202814-315c-499a-a766-689413de411b","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"5cb01f4c-9cd0-4032-8ce6-325c458df811","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
+      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
+      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
+      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
+      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
+      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
+      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
+      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
+      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
+      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      5000000000}]}, "block_bandwidth": 838860800}}}'
     headers:
       Content-Length:
-      - "1183"
+      - "38539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:09 GMT
+      - Wed, 15 Jan 2025 16:30:46 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -29,31 +932,458 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f70a6b1-6b8f-4b2d-857f-ff6f16bb6854
+      - f367e6a4-8b28-40dd-b24b-9578adf9ef25
+      X-Total-Count:
+      - "68"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
+    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
+      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
+      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
+      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
+      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
+      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
+      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
+      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
+      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
+      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
+      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
+      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
+      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
+      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
+      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
+      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
+      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
+      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
+      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
+      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
+      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
+      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
+      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
+      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
+      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
+      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
+      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
+      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
+      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
+      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
+      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
+      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
+      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
+      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
+      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
+      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
+      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
+      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
+      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
+      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
+      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
+      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
+      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
+      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
+      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
+      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
+      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
+      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
+      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
+      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
+      1000000000}]}, "block_bandwidth": 41943040}}}'
+    headers:
+      Content-Length:
+      - "14208"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:46 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c51e8c5-6c20-46f4-88b5-a97becc82817
+      X-Total-Count:
+      - "68"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5", "arch":"arm64",
+      "zone":"fr-par-1", "compatible_commercial_types":["AMP2-C1", "AMP2-C2", "AMP2-C4",
+      "AMP2-C8", "AMP2-C12", "AMP2-C24", "AMP2-C48", "AMP2-C60", "COPARM1-2C-8G",
+      "COPARM1-4C-16G", "COPARM1-8C-32G", "COPARM1-16C-64G", "COPARM1-32C-128G"],
+      "label":"ubuntu_jammy", "type":"instance_local"}, {"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "arch":"x86_64", "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L",
+      "DEV1-M", "DEV1-S", "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS",
+      "START1-L", "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB",
+      "X64-15GB", "X64-30GB", "X64-60GB", "ENT1-XXS", "ENT1-XS", "ENT1-S", "ENT1-M",
+      "ENT1-L", "ENT1-XL", "ENT1-2XL", "PRO2-XXS", "PRO2-XS", "PRO2-S", "PRO2-M",
+      "PRO2-L", "STARDUST1-S", "PLAY2-MICRO", "PLAY2-NANO", "PLAY2-PICO", "POP2-2C-8G",
+      "POP2-4C-16G", "POP2-8C-32G", "POP2-16C-64G", "POP2-32C-128G", "POP2-64C-256G",
+      "POP2-HM-2C-16G", "POP2-HM-4C-32G", "POP2-HM-8C-64G", "POP2-HM-16C-128G", "POP2-HM-32C-256G",
+      "POP2-HM-64C-512G", "POP2-HC-2C-4G", "POP2-HC-4C-8G", "POP2-HC-8C-16G", "POP2-HC-16C-32G",
+      "POP2-HC-32C-64G", "POP2-HC-64C-128G", "POP2-HN-3", "POP2-HN-5", "POP2-HN-10"],
+      "label":"ubuntu_jammy", "type":"instance_local"}], "total_count":2}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d753e5b8-c215-449e-8fae-d1b1a2a8dba9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cb01f4c-9cd0-4032-8ce6-325c458df811
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
     method: GET
   response:
-    body: '{"image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811", "name": "Ubuntu
+    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -63,9 +1393,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:09 GMT
+      - Wed, 15 Jan 2025 16:30:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -73,1311 +1403,41 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 470f678c-f811-4772-99a0-45a47ec42f72
+      - 0bae96b5-5576-4fff-81e8-92b0bf464e18
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
-      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
-    method: GET
-  response:
-    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      252.14, "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "COPARM1-2C-8G": {"alt_names": [], "arch": "arm64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      31.1, "hourly_price": 0.0426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "COPARM1-32C-128G": {"alt_names": [], "arch": "arm64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      506.26, "hourly_price": 0.6935, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "COPARM1-4C-16G": {"alt_names": [], "arch": "arm64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      62.56, "hourly_price": 0.0857, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "COPARM1-8C-32G": {"alt_names": [], "arch": "arm64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      125.85, "hourly_price": 0.1724, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "DEV1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 3, "ram":
-      4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "DEV1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "ENT1-2XL": {"alt_names": [], "arch": "x86_64", "ncpus": 96,
-      "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2576.9, "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}}, "ENT1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "ENT1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "ENT1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "ENT1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 64,
-      "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "ENT1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "ENT1-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.655, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "GP1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}}, "GP1-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "GP1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "GP1-VIZ": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 72.0, "hourly_price": 0.1, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "GP1-XL": {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram":
-      274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}}, "GP1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 150000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64", "ncpus": 4,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      39.42, "hourly_price": 0.054, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "PLAY2-NANO": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      19.71, "hourly_price": 0.027, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "PLAY2-PICO": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      10.22, "hourly_price": 0.014, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "POP2-16C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      430.7, "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-16C-64G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64", "ncpus": 2,
-      "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      53.66, "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-2C-8G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      133.079, "hourly_price": 0.1823, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-32C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      861.4, "hourly_price": 1.18, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-32C-128G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-4C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      107.31, "hourly_price": 0.147, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-4C-16G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      265.501, "hourly_price": 0.3637, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-64C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1715.5, "hourly_price": 2.35, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-8C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      211.7, "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-8C-32G-WIN": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      528.009, "hourly_price": 0.7233, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      310.69, "hourly_price": 0.4256, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HC-2C-4G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      38.84, "hourly_price": 0.0532, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HC-32C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      621.38, "hourly_price": 0.8512, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      77.67, "hourly_price": 0.1064, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HC-64C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      155.34, "hourly_price": 0.2128, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "POP2-HM-16C-128G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      16, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      601.52, "hourly_price": 0.824, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      2, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      75.19, "hourly_price": 0.103, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}}, "POP2-HM-32C-256G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      32, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      1203.04, "hourly_price": 1.648, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      4, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      150.38, "hourly_price": 0.206, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}}, "POP2-HM-64C-512G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      64, "ram": 549755813888, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      2406.08, "hourly_price": 3.296, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64", "ncpus":
-      8, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      300.76, "hourly_price": 0.412, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}}, "PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram":
-      137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      640.21, "hourly_price": 0.877, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6000000000, "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}}, "PRO2-M": {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram":
-      68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      319.74, "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "38026"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:09 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad69f951-03fd-4eba-becc-7dde7617a20d
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
-      700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
-      350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
-      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
-      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
-      250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
-      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
-    method: GET
-  response:
-    body: '{"servers": {"PRO2-S": {"alt_names": [], "arch": "x86_64", "ncpus": 8,
-      "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      159.87, "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}}, "PRO2-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram":
-      17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      80.3, "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      700000000, "sum_internet_bandwidth": 700000000, "interfaces": [{"internal_bandwidth":
-      700000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      700000000}]}}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      40.15, "hourly_price": 0.055, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      350000000, "sum_internet_bandwidth": 350000000, "interfaces": [{"internal_bandwidth":
-      350000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      350000000}]}}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 907.098, "hourly_price": 1.2426, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64", "ncpus":
-      1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 10000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "START1-L": {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth":
-      400000000, "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 400000000}]}}, "START1-M":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 100000000000, "max_size":
-      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      14.162, "hourly_price": 0.0194, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}}, "START1-S": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus": 1,
-      "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      25000000000, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}}, "VC1L": {"alt_names": ["X64-8GB"], "arch": "x86_64", "ncpus":
-      6, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 18.0164, "hourly_price": 0.02468,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}}, "VC1M":
-      {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296,
-      "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size": 100000000000,
-      "max_size": 100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000,
-      "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal": false,
-      "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "VC1S": {"alt_names": ["X64-2GB"], "arch": "x86_64", "ncpus":
-      2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      50000000000, "max_size": 50000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 200000000000}}, "scratch_storage_max_size": null, "baremetal":
-      false, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus": 12,
-      "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      500000000000, "max_size": 1000000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 310.7902, "hourly_price": 0.42574,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1000000000,
-      "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}}, "X64-15GB": {"alt_names": [], "arch": "x86_64", "ncpus": 6,
-      "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      200000000000, "max_size": 200000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 44.0336, "hourly_price": 0.06032,
-      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
-      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth":
-      250000000, "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 250000000}]}}, "X64-30GB":
-      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0,
-      "mig_profile": null, "volumes_constraint": {"min_size": 300000000000, "max_size":
-      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
-      200000000000}}, "scratch_storage_max_size": null, "baremetal": false, "monthly_price":
-      86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}}, "X64-60GB": {"alt_names": [], "arch": "x86_64", "ncpus": 10,
-      "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      400000000000, "max_size": 700000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "baremetal": false, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities":
-      {"boot_types": ["local", "rescue"], "placement_groups": true, "block_storage":
-      true, "hot_snapshots_local_volume": true, "private_network": 8}, "network":
-      {"ipv6_support": true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth":
-      1000000000, "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 1000000000}]}}}}'
-    headers:
-      Content-Length:
-      - "12534"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:08 GMT
-      Link:
-      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
-        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 85959525-de61-4ffc-9754-0459b788f3bb
-      X-Total-Count:
-      - "66"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.059804Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "prefix": null, "reverse": null, "server": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "zone": "fr-par-1", "type":
-      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.059804Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "366"
+      - "422"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:09 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/eed4575b-90e5-4102-b956-df874c911e2b
+      - Wed, 15 Jan 2025 16:30:47 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1385,117 +1445,157 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e21cda9-9a5d-4059-aa5f-1c93c0eedf92
-    status: 201 Created
-    code: 201
+      - 77c378e2-078d-4500-899d-1a83d259eb1f
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "52ed788b-7e37-42af-b2ad-176d9717e3bf"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/52ed788b-7e37-42af-b2ad-176d9717e3bf
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "52ed788b-7e37-42af-b2ad-176d9717e3bf"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c7a8cd1-9d15-4134-bda0-93dea085433c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.059804Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52ed788b-7e37-42af-b2ad-176d9717e3bf
+    method: GET
+  response:
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.059804Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "422"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 683bcc45-9943-40bc-ad84-8edd6ba322b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"},
-      "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}],
-      "mac_address": "de:00:00:5f:a0:ef", "routed_ip_enabled": true, "ipv6": null,
-      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date":
-      "2024-07-05T12:37:10.140068+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
       "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
       null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"},
-      "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b", "address": "212.47.248.223",
-      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
-      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}],
-      "mac_address": "de:00:00:5f:a0:ef", "routed_ip_enabled": true, "ipv6": null,
-      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
-      null, "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date":
-      "2024-07-05T12:37:10.140068+00:00", "bootscript": {"id": "fdfe150f-a870-4ce4-b432-9f56b5b995c1",
-      "public": true, "title": "x86_64 mainline 4.4.230 rev1", "architecture": "x86_64",
-      "organization": "11111111-1111-4111-8111-111111111111", "project": "11111111-1111-4111-8111-111111111111",
-      "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["poweron", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "3696"
+      - "2256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:10 GMT
+      - Wed, 15 Jan 2025 16:30:47 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1503,30 +1603,490 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93bd2d42-7317-455d-930f-dd8ff1734621
+      - 2f9e751c-ee01-4ff1-bd34-d1feb3750b33
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"task": {"id": "f445a505-3ff4-4ce4-9a7d-95f0dad5ac07", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action",
-      "href_result": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691", "started_at":
-      "2024-07-05T12:37:11.026069+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
+    body: '{"task": {"id": "8d251f41-3590-4023-aa8d-e801cad46c83", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action",
+      "href_result": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1", "started_at":
+      "2025-01-15T16:30:48.252229+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action
     method: POST
   response:
-    body: '{"task": {"id": "f445a505-3ff4-4ce4-9a7d-95f0dad5ac07", "description":
-      "server_batch_poweron", "status": "pending", "href_from": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action",
-      "href_result": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691", "started_at":
-      "2024-07-05T12:37:11.026069+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
+    body: '{"task": {"id": "8d251f41-3590-4023-aa8d-e801cad46c83", "description":
+      "server_batch_poweron", "status": "pending", "href_from": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action",
+      "href_result": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1", "started_at":
+      "2025-01-15T16:30:48.252229+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "357"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:48 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/8d251f41-3590-4023-aa8d-e801cad46c83
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4822c1e3-365b-4299-9217-657a9fe6a995
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
+    method: GET
+  response:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "allocating node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["stop_in_place",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c0d780fe-21be-4930-b36f-2d1741349e2e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
+    method: GET
+  response:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a8b90c1-80fa-482e-89ed-bf93ccaa6fbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
+    method: GET
+  response:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
+      "provisioning node", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:48.085787+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:30:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf25ecf1-8b90-42bb-b6b7-95bf007b73c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:31:02.494852+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
+    method: GET
+  response:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:31:02.494852+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:31:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 575680dc-8ced-4233-89b0-c925280b0fbc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:31:02.494852+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1
+    method: GET
+  response:
+    body: '{"server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-interesting-dirac", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
+      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "cc298f3b-9cc5-4dde-bf58-6f54d372a1fd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "04011823-6621-4c43-88d5-7bdcbebe0dd1", "name": "cli-srv-interesting-dirac"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:30:47.549827+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "52ed788b-7e37-42af-b2ad-176d9717e3bf",
+      "zone": "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
+      "booting kernel", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:91:5f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:30:47.549827+00:00",
+      "modification_date": "2025-01-15T16:31:02.494852+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": {"zone_id": "par1", "platform_id": "14", "cluster_id":
+      "93", "hypervisor_id": "703", "node_id": "17"}, "maintenances": [], "allowed_actions":
+      ["poweroff", "terminate", "reboot", "stop_in_place", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:31:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfb24123-806c-4d8e-9a84-02de691c55f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"task": {"id": "c7945bb9-aab6-4b92-991e-f43bb293e067", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action",
+      "href_result": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1", "started_at":
+      "2025-01-15T16:31:04.362095+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action
+    method: POST
+  response:
+    body: '{"task": {"id": "c7945bb9-aab6-4b92-991e-f43bb293e067", "description":
+      "server_terminate", "status": "pending", "href_from": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1/action",
+      "href_result": "/servers/04011823-6621-4c43-88d5-7bdcbebe0dd1", "started_at":
+      "2025-01-15T16:31:04.362095+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
     headers:
       Content-Length:
       - "353"
@@ -1535,11 +2095,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:11 GMT
+      - Wed, 15 Jan 2025 16:31:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f445a505-3ff4-4ce4-9a7d-95f0dad5ac07
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c7945bb9-aab6-4b92-991e-f43bb293e067
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1547,113 +2107,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bc98599-7c0a-4d56-8d11-128a03ecf24d
+      - 65eac477-6dee-4d5e-8eab-0100a69129a6
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.682646Z",
+      "references":[{"id":"544df471-5e71-45e5-bf22-808b1ae415c4", "product_resource_type":"instance_server",
+      "product_resource_id":"04011823-6621-4c43-88d5-7bdcbebe0dd1", "created_at":"2025-01-15T16:30:47.682646Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52ed788b-7e37-42af-b2ad-176d9717e3bf
     method: GET
   response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "allocating node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": null, "maintenances": [], "allowed_actions":
-      ["stop_in_place", "backup"], "placement_group": null, "private_nics": [], "zone":
-      "fr-par-1"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:30:47.682646Z",
+      "references":[{"id":"544df471-5e71-45e5-bf22-808b1ae415c4", "product_resource_type":"instance_server",
+      "product_resource_id":"04011823-6621-4c43-88d5-7bdcbebe0dd1", "created_at":"2025-01-15T16:30:47.682646Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "3718"
+      - "655"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:10 GMT
+      - Wed, 15 Jan 2025 16:31:04 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1661,115 +2153,41 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9db6e7f-000f-4855-9e98-22fd1e6d1440
+      - 3b47e7c8-cb94-4e6b-ba6e-49d128c4b6eb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:31:05.656689Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:31:05.656689Z",
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52ed788b-7e37-42af-b2ad-176d9717e3bf
     method: GET
   response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"id":"52ed788b-7e37-42af-b2ad-176d9717e3bf", "name":"cli-vol-peaceful-shockley",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:30:47.059804Z", "updated_at":"2025-01-15T16:31:05.656689Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:31:05.656689Z",
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "3817"
+      - "448"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:16 GMT
+      - Wed, 15 Jan 2025 16:31:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1777,789 +2195,17 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87011fc0-cef6-457b-81b1-b7853933f092
+      - 641c94ae-0631-4955-b0db-d6f498a7fa1b
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
-    method: GET
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f0d00f95-c47b-481d-8f73-008c1eb55820
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
-    method: GET
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:26 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a8dff6e-05db-4da1-b368-d1ad6d733012
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
-    method: GET
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "starting", "protected": false, "state_detail":
-      "provisioning node", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.690107+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["stop_in_place", "backup"], "placement_group": null,
-      "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:32 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a98fc79-3cf4-411a-8fa6-a9225c4dec95
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
-    method: GET
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3848"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29107e66-7beb-4835-8999-61032b27b7df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691
-    method: GET
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "aea68797-ffce-454a-b1fd-a3673c644013",
-      "name": "cli-srv-reverent-moore-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3848"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e475e0fa-4a7c-47f4-a5f6-68394dd9ebbf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691",
-      "name": "cli-srv-reverent-moore"}, "size": 10000000000, "state": "available",
-      "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date": "2024-07-05T12:37:10.140068+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/aea68797-ffce-454a-b1fd-a3673c644013
-    method: GET
-  response:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691",
-      "name": "cli-srv-reverent-moore"}, "size": 10000000000, "state": "available",
-      "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date": "2024-07-05T12:37:10.140068+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "522"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:37 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e2acd06-d2e6-4394-b796-fb56e50d338c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/detach-volume
-    method: POST
-  response:
-    body: '{"server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-reverent-moore", "image": {"id": "5cb01f4c-9cd0-4032-8ce6-325c458df811",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "dd8f520a-d981-42e4-b336-92ce51d2320d",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-07-03T16:07:39.104245+00:00",
-      "modification_date": "2024-07-03T16:07:39.104245+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "c005d09c-6cd3-4d09-8a0f-78981c84b66a",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "98f9ffff-290f-4c69-a108-f5e3b2afc691", "name": "cli-srv-reverent-moore"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:10.140068+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "running", "protected": false, "state_detail":
-      "booting kernel", "public_ip": {"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}, "public_ips": [{"id": "eed4575b-90e5-4102-b956-df874c911e2b",
-      "address": "212.47.248.223", "dynamic": false, "gateway": "62.210.0.1", "netmask":
-      "32", "family": "inet", "provisioning_mode": "dhcp", "tags": [], "state": "attached",
-      "ipam_id": "9d0cdee1-abef-4c32-94b5-56fcd104b18b"}], "mac_address": "de:00:00:5f:a0:ef",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      true, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:34.849742+00:00", "bootscript": {"id":
-      "fdfe150f-a870-4ce4-b432-9f56b5b995c1", "public": true, "title": "x86_64 mainline
-      4.4.230 rev1", "architecture": "x86_64", "organization": "11111111-1111-4111-8111-111111111111",
-      "project": "11111111-1111-4111-8111-111111111111", "kernel": "http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230",
-      "dtb": "", "initrd": "http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz",
-      "bootcmdargs": "LINUX_COMMON scaleway boot=local nbd.max_part=16", "default":
-      true, "zone": "fr-par-1"}, "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb",
-      "name": "Default security group"}, "location": {"zone_id": "par1", "platform_id":
-      "14", "cluster_id": "40", "hypervisor_id": "401", "node_id": "27"}, "maintenances":
-      [], "allowed_actions": ["poweroff", "terminate", "reboot", "stop_in_place",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3316"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4ee1da2c-e19b-4907-ab7d-3c8de26cd0af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"task": {"id": "0db1fb84-6553-4765-aa51-f07067ba984b", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action",
-      "href_result": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691", "started_at":
-      "2024-07-05T12:37:38.601359+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action
-    method: POST
-  response:
-    body: '{"task": {"id": "0db1fb84-6553-4765-aa51-f07067ba984b", "description":
-      "server_terminate", "status": "pending", "href_from": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691/action",
-      "href_result": "/servers/98f9ffff-290f-4c69-a108-f5e3b2afc691", "started_at":
-      "2024-07-05T12:37:38.601359+00:00", "terminated_at": null, "progress": 0, "zone":
-      "par1"}}'
-    headers:
-      Content-Length:
-      - "349"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:38 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0db1fb84-6553-4765-aa51-f07067ba984b
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26d4a0a9-9f4c-47ba-8ad6-0e77e502b4f4
-    status: 202 Accepted
-    code: 202
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/eed4575b-90e5-4102-b956-df874c911e2b
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/52ed788b-7e37-42af-b2ad-176d9717e3bf
     method: DELETE
   response:
     body: ""
@@ -2569,9 +2215,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 05 Jul 2024 12:37:39 GMT
+      - Wed, 15 Jan 2025 16:31:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2579,161 +2225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f9d79f8-55de-4aca-b14d-5251313e7aa3
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "hotsyncing", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:38.042554+00:00", "tags": [], "zone":
-      "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/aea68797-ffce-454a-b1fd-a3673c644013
-    method: GET
-  response:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "hotsyncing", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:38.042554+00:00", "tags": [], "zone":
-      "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "447"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34d5d110-033d-46d7-bc15-a5485981318b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "hotsyncing", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:38.042554+00:00", "tags": [], "zone":
-      "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/aea68797-ffce-454a-b1fd-a3673c644013
-    method: GET
-  response:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "hotsyncing", "creation_date": "2024-07-05T12:37:10.140068+00:00",
-      "modification_date": "2024-07-05T12:37:38.042554+00:00", "tags": [], "zone":
-      "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "447"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:44 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aea33be6-4039-491c-9a16-aa116fe68f49
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date":
-      "2024-07-05T12:37:48.781975+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/aea68797-ffce-454a-b1fd-a3673c644013
-    method: GET
-  response:
-    body: '{"volume": {"id": "aea68797-ffce-454a-b1fd-a3673c644013", "name": "cli-srv-reverent-moore-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2024-07-05T12:37:10.140068+00:00", "modification_date":
-      "2024-07-05T12:37:48.781975+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "446"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:49 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 23001467-f7ee-47b7-8d74-d9324418258d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/aea68797-ffce-454a-b1fd-a3673c644013
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 05 Jul 2024 12:37:49 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71b10461-9bdb-48f7-98eb-0deee38eceb7
+      - eaf99a70-19de-4abc-9eb6-d767683b6f57
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-terminate-without-block.golden
+++ b/internal/namespaces/instance/v1/testdata/test-server-terminate-without-block.golden
@@ -1,9 +1,6 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
 ✅ Success.
-🟥🟥🟥 STDERR️️ 🟥🟥🟥️
-successfully detached volume cli-srv-reverent-moore-1
-successfully deleted ip 212.47.248.223
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "message": "Success",

--- a/internal/namespaces/instance/v1/testdata/test-server-update-custom-volumes-detach-all-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-update-custom-volumes-detach-all-volumes.cassette.yaml
@@ -919,7 +919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:23 GMT
+      - Wed, 15 Jan 2025 16:52:16 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea992be6-86b0-4278-89c9-7323720f0df6
+      - 19a89bc2-fd47-40fe-a06e-eb272af0fdac
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:23 GMT
+      - Wed, 15 Jan 2025 16:52:16 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d6263ce-ba40-4e74-8239-687c6ee87709
+      - aac32dc1-99af-49f9-8936-036a55b596fd
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,7 +1337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:23 GMT
+      - Wed, 15 Jan 2025 16:52:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fd4843b-66b2-42b7-9ec9-de2951b27db1
+      - 1fe14b64-cb58-4152-983c-c2adcf5cfba7
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:23 GMT
+      - Wed, 15 Jan 2025 16:52:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1391,39 +1391,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3510ea3b-e33d-4f80-8020-a7ccdcba1640
+      - bd63ab47-a6c2-4158-950a-ef839d1dfee7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.221792Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.221792Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9fea4ed8-975f-491f-b7f6-39d53d96b715
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00fa83c7-ff78-4f3a-b1d9-9e1956afdd91
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.221792Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a
+    method: GET
+  response:
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.221792Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "424"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b82aa2e-f253-48e8-984f-e025c2e04ec3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "952fb8c2-98ee-49dd-a8ae-8cfecfd74caf",
+      "volumes": {"0": {"boot": false, "id": "79395b14-7016-437f-b68b-6f67cd115f98",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "faffb66b-0b2f-4bb0-90cb-c7aa65ce7b22",
-      "name": "cli-srv-hungry-murdock-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1435,47 +1546,42 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "952fb8c2-98ee-49dd-a8ae-8cfecfd74caf",
+      "volumes": {"0": {"boot": false, "id": "79395b14-7016-437f-b68b-6f67cd115f98",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "faffb66b-0b2f-4bb0-90cb-c7aa65ce7b22",
-      "name": "cli-srv-hungry-murdock-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:24 GMT
+      - Wed, 15 Jan 2025 16:52:18 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0daf22a-2208-47ba-92f6-da4137509a95
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d7c7bd61-583d-41e6-8076-3495afe50bac
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1485,87 +1591,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a11fca14-b62f-421d-a221-bd34866dc7d4
+      - 4a5e704c-d19f-408e-a844-2ef0e0a85f19
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "952fb8c2-98ee-49dd-a8ae-8cfecfd74caf",
+      "volumes": {"0": {"boot": false, "id": "79395b14-7016-437f-b68b-6f67cd115f98",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "faffb66b-0b2f-4bb0-90cb-c7aa65ce7b22",
-      "name": "cli-srv-hungry-murdock-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encrypted_value": null}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0daf22a-2208-47ba-92f6-da4137509a95
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d7c7bd61-583d-41e6-8076-3495afe50bac
     method: GET
   response:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "952fb8c2-98ee-49dd-a8ae-8cfecfd74caf",
+      "volumes": {"0": {"boot": false, "id": "79395b14-7016-437f-b68b-6f67cd115f98",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "faffb66b-0b2f-4bb0-90cb-c7aa65ce7b22",
-      "name": "cli-srv-hungry-murdock-1", "volume_type": "b_ssd", "export_uri": null,
-      "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encrypted_value": null}}'
     headers:
       Content-Length:
-      - "2656"
+      - "2290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:24 GMT
+      - Wed, 15 Jan 2025 16:52:18 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1575,15 +1673,15 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9be8b556-487c-420c-8cc3-d44ee46c1398
+      - 2cdd6273-6227-40bb-8d4c-19dc256ef08a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
@@ -1591,11 +1689,11 @@ interactions:
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
       "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1604,13 +1702,13 @@ interactions:
       - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0daf22a-2208-47ba-92f6-da4137509a95
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d7c7bd61-583d-41e6-8076-3495afe50bac
     method: PATCH
   response:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
@@ -1618,22 +1716,22 @@ interactions:
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
       "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "1592"
+      - "1598"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:25 GMT
+      - Wed, 15 Jan 2025 16:52:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1643,7 +1741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 463ccf92-1529-43ad-8d70-8b62824801c2
+      - 5e3bd0e6-0a5c-416d-91e8-8e2e7cd8865a
     status: 200 OK
     code: 200
     duration: ""
@@ -1653,7 +1751,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/952fb8c2-98ee-49dd-a8ae-8cfecfd74caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/79395b14-7016-437f-b68b-6f67cd115f98
     method: DELETE
   response:
     body: ""
@@ -1663,7 +1761,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:25 GMT
+      - Wed, 15 Jan 2025 16:52:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1673,93 +1771,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82bc35f6-51f9-4201-bc23-060ec35e19c5
+      - 1f90930a-7a1e-42eb-9f60-a2f9d859fc18
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: ""
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.818206Z",
+      "references":[{"id":"2bf92802-5ac0-4d4d-b292-bc661a737e34", "product_resource_type":"instance_server",
+      "product_resource_id":"d7c7bd61-583d-41e6-8076-3495afe50bac", "created_at":"2025-01-15T16:52:17.818206Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/faffb66b-0b2f-4bb0-90cb-c7aa65ce7b22
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 08:52:25 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge03)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b53339a7-2382-40e7-ae43-2f1cfd89679f
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0daf22a-2208-47ba-92f6-da4137509a95
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a
     method: GET
   response:
-    body: '{"server": {"id": "f0daf22a-2208-47ba-92f6-da4137509a95", "name": "cli-srv-hungry-murdock",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-hungry-murdock", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:31:f5",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T08:52:24.164246+00:00",
-      "modification_date": "2024-12-24T08:52:24.164246+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:17.818206Z",
+      "references":[{"id":"2bf92802-5ac0-4d4d-b292-bc661a737e34", "product_resource_type":"instance_server",
+      "product_resource_id":"d7c7bd61-583d-41e6-8076-3495afe50bac", "created_at":"2025-01-15T16:52:17.818206Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1592"
+      - "657"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:25 GMT
+      - Wed, 15 Jan 2025 16:52:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1769,7 +1817,49 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b6bda8b-58e1-4423-a247-2629f07a492d
+      - 508142a9-6839-4f02-905f-3a7c46d552e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:19.589071Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:52:19.589071Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a
+    method: GET
+  response:
+    body: '{"id":"518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a", "name":"cli-vol-distracted-lamport",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:52:17.221792Z", "updated_at":"2025-01-15T16:52:19.589071Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:52:19.589071Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "449"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af21d964-d28f-4e41-a87a-bf3e941989af
     status: 200 OK
     code: 200
     duration: ""
@@ -1779,7 +1869,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f0daf22a-2208-47ba-92f6-da4137509a95
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/518c75c4-7d21-4b5f-9212-3b9ad9e6ba7a
     method: DELETE
   response:
     body: ""
@@ -1789,7 +1879,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 08:52:26 GMT
+      - Wed, 15 Jan 2025 16:52:24 GMT
       Server:
       - Scaleway API Gateway (fr-par-2;edge03)
       Strict-Transport-Security:
@@ -1799,7 +1889,103 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e24ac36e-e245-4fbc-9c38-d13b998251c2
+      - 68245453-e29c-436e-97d2-7cc652b16ab5
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d7c7bd61-583d-41e6-8076-3495afe50bac
+    method: GET
+  response:
+    body: '{"server": {"id": "d7c7bd61-583d-41e6-8076-3495afe50bac", "name": "cli-srv-recursing-mclaren",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-recursing-mclaren", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:95",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:52:17.741125+00:00",
+      "modification_date": "2025-01-15T16:52:17.741125+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "1598"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9c2ea580-d746-4faa-b585-e33f72a7f962
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d7c7bd61-583d-41e6-8076-3495afe50bac
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:52:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge03)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bde0e74f-2c6b-4664-9ab3-4c8f9bbcd6e1
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-server-volume-update-detach-simple-block-volume.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-server-volume-update-detach-simple-block-volume.cassette.yaml
@@ -919,12 +919,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:34 GMT
+      - Wed, 15 Jan 2025 16:54:19 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e111b1c9-3a9f-43be-9204-6cb4cb09134e
+      - de3f904d-2c64-4838-943a-afa0350999f1
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1282,12 +1282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:34 GMT
+      - Wed, 15 Jan 2025 16:54:19 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1295,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 899f9192-9848-41a0-9cde-5de342a03b88
+      - 75cfcf7d-c6de-4bb3-b4db-b238101ee877
       X-Total-Count:
       - "68"
     status: 200 OK
@@ -1337,9 +1337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:34 GMT
+      - Wed, 15 Jan 2025 16:54:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1347,7 +1347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad521b94-88d7-4b4a-a0e8-baa2a76eddac
+      - 4b810afc-c443-4ff2-a3e6-1429136477f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,9 +1381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:34 GMT
+      - Wed, 15 Jan 2025 16:54:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,39 +1391,150 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87de53de-dbca-4ce1-b31f-d0b79cff32e3
+      - b0710b29-7fa6-4d54-adc1-2deac32e311f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.086445Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.086445Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "420"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41832295-eea3-4e50-8ee8-83ffc3a1c9ce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "0324d653-2bfa-42c2-9d67-d21159183c84"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "0324d653-2bfa-42c2-9d67-d21159183c84"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 788b1fee-089d-4b9c-8d09-033aa27a5ae9
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.086445Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
+    method: GET
+  response:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.086445Z",
+      "references":[], "parent_snapshot_id":null, "status":"creating", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null, "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "420"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11ee7dfa-6ebe-4063-875c-1db8aee4ddf0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd",
-      "name": "cli-srv-xenodochial-golick-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "0324d653-2bfa-42c2-9d67-d21159183c84",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1435,49 +1546,44 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}, "1": {"boot": false, "id": "bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd",
-      "name": "cli-srv-xenodochial-golick-1", "volume_type": "b_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "0324d653-2bfa-42c2-9d67-d21159183c84",
+      "zone": "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2676"
+      - "2244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:35 GMT
+      - Wed, 15 Jan 2025 16:54:21 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/17634b50-29b7-4f42-8d2b-424aa92e1ea4
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4db8d717-9257-4a1a-b87b-a9182ee13bc6
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1485,41 +1591,33 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55acd176-0b69-4284-b788-4914669bea01
+      - f4fa9ea0-9f6d-4457-b816-5b641edf4b10
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"volume": {"id": "bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd", "name": "cli-srv-xenodochial-golick-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4",
-      "name": "cli-srv-xenodochial-golick"}, "size": 10000000000, "state": "available",
-      "creation_date": "2024-12-24T09:19:35.325743+00:00", "modification_date": "2024-12-24T09:19:35.325743+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "0324d653-2bfa-42c2-9d67-d21159183c84"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
     method: GET
   response:
-    body: '{"volume": {"id": "bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd", "name": "cli-srv-xenodochial-golick-1",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "project": "105bdce1-64c0-48ab-899d-868455867ecf", "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4",
-      "name": "cli-srv-xenodochial-golick"}, "size": 10000000000, "state": "available",
-      "creation_date": "2024-12-24T09:19:35.325743+00:00", "modification_date": "2024-12-24T09:19:35.325743+00:00",
-      "tags": [], "zone": "fr-par-1"}}'
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "0324d653-2bfa-42c2-9d67-d21159183c84"}'
     headers:
       Content-Length:
-      - "530"
+      - "143"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:35 GMT
+      - Wed, 15 Jan 2025 16:54:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1527,33 +1625,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b429d3f4-195d-4033-bce6-9f6611dcc955
+      - fd1981f8-f2ef-4cc0-98ee-723c583c8257
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.912265Z",
+      "references":[{"id":"1e376669-6b36-436e-a1af-d0b3546146c1", "product_resource_type":"instance_server",
+      "product_resource_id":"4db8d717-9257-4a1a-b87b-a9182ee13bc6", "created_at":"2025-01-15T16:54:20.912265Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
+    method: GET
+  response:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.912265Z",
+      "references":[{"id":"1e376669-6b36-436e-a1af-d0b3546146c1", "product_resource_type":"instance_server",
+      "product_resource_id":"4db8d717-9257-4a1a-b87b-a9182ee13bc6", "created_at":"2025-01-15T16:54:20.912265Z",
+      "type":"exclusive", "status":"attached"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "653"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d153ab6c-f9cb-4561-8449-4a2b80506ead
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     form: {}
@@ -1562,44 +1706,44 @@ interactions:
       - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/17634b50-29b7-4f42-8d2b-424aa92e1ea4/detach-volume
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4db8d717-9257-4a1a-b87b-a9182ee13bc6/detach-volume
     method: POST
   response:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
       "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
       "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
       "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
       "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
       "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
       "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
       security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
       "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "2136"
+      - "2127"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:36 GMT
+      - Wed, 15 Jan 2025 16:54:22 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1607,107 +1751,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2694cdb-29b9-41a8-928d-894932bc6d80
+      - 8a3075fd-c067-405f-888e-1c183a0ab2ee
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.912265Z",
+      "references":[{"id":"1e376669-6b36-436e-a1af-d0b3546146c1", "product_resource_type":"instance_server",
+      "product_resource_id":"4db8d717-9257-4a1a-b87b-a9182ee13bc6", "created_at":"2025-01-15T16:54:20.912265Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/bb3a320f-8a4f-453c-8d2a-3ee781ed8dfd
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Dec 2024 09:19:36 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3333df5-e9b4-467a-8a5c-f5b849335ae4
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/17634b50-29b7-4f42-8d2b-424aa92e1ea4
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
     method: GET
   response:
-    body: '{"server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "hostname": "cli-srv-xenodochial-golick", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
-      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
-      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef",
-      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
-      "server": {"id": "17634b50-29b7-4f42-8d2b-424aa92e1ea4", "name": "cli-srv-xenodochial-golick"},
-      "size": 10000000000, "state": "available", "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:89:33:b5",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2024-12-24T09:19:35.325743+00:00",
-      "modification_date": "2024-12-24T09:19:35.325743+00:00", "bootscript": null,
-      "security_group": {"id": "5881315f-2400-43a0-ac75-08adf6cb8c12", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:20.912265Z",
+      "references":[{"id":"1e376669-6b36-436e-a1af-d0b3546146c1", "product_resource_type":"instance_server",
+      "product_resource_id":"4db8d717-9257-4a1a-b87b-a9182ee13bc6", "created_at":"2025-01-15T16:54:20.912265Z",
+      "type":"exclusive", "status":"detaching"}], "parent_snapshot_id":null, "status":"in_use",
+      "tags":[], "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":null,
+      "zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2136"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:36 GMT
+      - Wed, 15 Jan 2025 16:54:22 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1715,7 +1797,49 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3da3852b-b111-4376-88f2-b1c54b2f124e
+      - 4b4d43b0-c8bb-4abb-825a-f95fcf142dad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:22.621506Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:54:22.621506Z",
+      "zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
+    method: GET
+  response:
+    body: '{"id":"0324d653-2bfa-42c2-9d67-d21159183c84", "name":"cli-vol-boring-lovelace",
+      "type":"sbs_5k", "size":10000000000, "project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "created_at":"2025-01-15T16:54:20.086445Z", "updated_at":"2025-01-15T16:54:22.621506Z",
+      "references":[], "parent_snapshot_id":null, "status":"available", "tags":[],
+      "specs":{"perf_iops":5000, "class":"sbs"}, "last_detached_at":"2025-01-15T16:54:22.621506Z",
+      "zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59e46b0a-40f9-49ab-87f9-8add0bba6459
     status: 200 OK
     code: 200
     duration: ""
@@ -1725,7 +1849,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/17634b50-29b7-4f42-8d2b-424aa92e1ea4
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/0324d653-2bfa-42c2-9d67-d21159183c84
     method: DELETE
   response:
     body: ""
@@ -1735,9 +1859,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:37 GMT
+      - Wed, 15 Jan 2025 16:54:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1745,29 +1869,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f2e8da7-5926-4929-9514-6f3ddc4a0c5e
+      - 2435a983-9232-4101-9515-ceed72a3440d
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef", "name": "Ubuntu
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encrypted_value": null}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4db8d717-9257-4a1a-b87b-a9182ee13bc6
+    method: GET
+  response:
+    body: '{"server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "hostname": "cli-srv-charming-merkle", "image": {"id": "655aeea7-8a30-418a-bc2e-3c04e3fdc8aa",
+      "name": "Ubuntu 18.04 Bionic Beaver", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "27a6459c-efe6-4327-a062-b21a17f3143d",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2023-08-08T13:36:04.744241+00:00",
+      "modification_date": "2023-08-08T13:36:04.744241+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8",
+      "name": "Ubuntu 18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+      "server": {"id": "4db8d717-9257-4a1a-b87b-a9182ee13bc6", "name": "cli-srv-charming-merkle"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:8d:92:b5",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-15T16:54:20.770365+00:00",
+      "modification_date": "2025-01-15T16:54:20.770365+00:00", "bootscript": null,
+      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "admin_password_encrypted_value": null}}'
+    headers:
+      Content-Length:
+      - "2167"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f3671ea-ad84-4437-ad4c-835ee2b75717
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4db8d717-9257-4a1a-b87b-a9182ee13bc6
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 15 Jan 2025 16:54:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 03bf4af0-9b45-4610-945f-97dce7ae5f48
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"volume": {"id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T09:19:35.325743+00:00", "modification_date": "2024-12-24T09:19:37.146753+00:00",
+      "2025-01-15T16:54:20.770365+00:00", "modification_date": "2025-01-15T16:54:27.791669+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4bce8a2-768c-4c70-a823-65fdc3d5abef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3d08e97-bdec-42a1-bf37-4f987c9792a8
     method: GET
   response:
-    body: '{"volume": {"id": "b4bce8a2-768c-4c70-a823-65fdc3d5abef", "name": "Ubuntu
+    body: '{"volume": {"id": "d3d08e97-bdec-42a1-bf37-4f987c9792a8", "name": "Ubuntu
       18.04 Bionic Beaver", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "105bdce1-64c0-48ab-899d-868455867ecf", "project": "105bdce1-64c0-48ab-899d-868455867ecf",
+      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
       "server": null, "size": 10000000000, "state": "available", "creation_date":
-      "2024-12-24T09:19:35.325743+00:00", "modification_date": "2024-12-24T09:19:37.146753+00:00",
+      "2025-01-15T16:54:20.770365+00:00", "modification_date": "2025-01-15T16:54:27.791669+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -1777,9 +2011,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:37 GMT
+      - Wed, 15 Jan 2025 16:54:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1787,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4ef4ccd-6a78-49df-ba08-d9db13fe33eb
+      - 5479a0b1-372b-4742-9ca5-4fbdebe75e38
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,7 +2031,7 @@ interactions:
     headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b4bce8a2-768c-4c70-a823-65fdc3d5abef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d3d08e97-bdec-42a1-bf37-4f987c9792a8
     method: DELETE
   response:
     body: ""
@@ -1807,9 +2041,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Dec 2024 09:19:37 GMT
+      - Wed, 15 Jan 2025 16:54:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge03)
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1817,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfde24e3-f0ea-4d62-a472-041e541329f7
+      - 2f34d28f-09c6-4abf-818f-c70876a0e32d
     status: 204 No Content
     code: 204
     duration: ""


### PR DESCRIPTION
`b` and `block` volume options are now the same as `sbs`. Instance `b_ssd` is no longer supported.