### PR TITLE
feat(core): support positional args as dynamic args as well

### DIFF
--- a/core/arg_specs.go
+++ b/core/arg_specs.go
@@ -14,13 +14,11 @@ var AllLocalities = "all"
 
 type ArgSpecs []*ArgSpec
 
+// GetPositionalArg returns the last positional argument from the arg specs.
 func (s ArgSpecs) GetPositionalArg() *ArgSpec {
 	var positionalArg *ArgSpec
 	for _, argSpec := range s {
 		if argSpec.Positional {
-			if positionalArg != nil {
-				panic(fmt.Errorf("more than one positional parameter detected: %s and %s are flagged as positional arg", positionalArg.Name, argSpec.Name))
-			}
 			positionalArg = argSpec
 		}
 	}

--- a/core/cobra_utils_test.go
+++ b/core/cobra_utils_test.go
@@ -17,6 +17,11 @@ type testType struct {
 	Tag    string
 }
 
+type testTypeManyTags struct {
+	NameID string
+	Tags   []string
+}
+
 type testDate struct {
 	Date *time.Time
 }
@@ -74,6 +79,45 @@ func testGetCommands() *core.Commands {
 			AcceptMultiplePositionalArgs: true,
 			AllowAnonymousClient:         true,
 			ArgsType:                     reflect.TypeOf(testAcceptMultiPositionalArgsType{}),
+			Run: func(_ context.Context, argsI interface{}) (i interface{}, e error) {
+				return argsI, nil
+			},
+		},
+		&core.Command{
+			Namespace: "test",
+			Resource:  "many-positional",
+			ArgSpecs: core.ArgSpecs{
+				{
+					Name:       "name-id",
+					Positional: true,
+				},
+				{
+					Name:       "tag",
+					Positional: true,
+				},
+			},
+			AllowAnonymousClient: true,
+			ArgsType:             reflect.TypeOf(testType{}),
+			Run: func(_ context.Context, argsI interface{}) (i interface{}, e error) {
+				return argsI, nil
+			},
+		},
+		&core.Command{
+			Namespace: "test",
+			Resource:  "many-multi-positional",
+			ArgSpecs: core.ArgSpecs{
+				{
+					Name:       "name-id",
+					Positional: true,
+				},
+				{
+					Name:       "tags",
+					Positional: true,
+				},
+			},
+			AcceptMultiplePositionalArgs: true,
+			AllowAnonymousClient:         true,
+			ArgsType:                     reflect.TypeOf(testTypeManyTags{}),
 			Run: func(_ context.Context, argsI interface{}) (i interface{}, e error) {
 				return argsI, nil
 			},
@@ -196,47 +240,29 @@ func Test_PositionalArg(t *testing.T) {
 				}),
 			),
 		}))
-
-		t.Run("Invalid1", core.Test(&core.TestConfig{
-			Commands: testGetCommands(),
-			Cmd:      "scw test positional name-id=plop tag=world",
-			Check: core.TestCheckCombine(
-				core.TestCheckExitCode(1),
-				core.TestCheckError(&core.CliError{
-					Err:  errors.New("a positional argument is required for this command"),
-					Hint: "Try running: scw test positional plop tag=world",
-				}),
-			),
-		}))
-
-		t.Run("Invalid2", core.Test(&core.TestConfig{
-			Commands: testGetCommands(),
-			Cmd:      "scw test positional tag=world name-id=plop",
-			Check: core.TestCheckCombine(
-				core.TestCheckExitCode(1),
-				core.TestCheckError(&core.CliError{
-					Err:  errors.New("a positional argument is required for this command"),
-					Hint: "Try running: scw test positional plop tag=world",
-				}),
-			),
-		}))
-
-		t.Run("Invalid3", core.Test(&core.TestConfig{
-			Commands: testGetCommands(),
-			Cmd:      "scw test positional plop name-id=plop",
-			Check: core.TestCheckCombine(
-				core.TestCheckExitCode(1),
-				core.TestCheckError(&core.CliError{
-					Err:  errors.New("a positional argument is required for this command"),
-					Hint: "Try running: scw test positional plop",
-				}),
-			),
-		}))
 	})
 
 	t.Run("simple", core.Test(&core.TestConfig{
 		Commands: testGetCommands(),
 		Cmd:      "scw test positional plop",
+		Check:    core.TestCheckExitCode(0),
+	}))
+
+	t.Run("simple2", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test positional name-id=plop tag=world",
+		Check:    core.TestCheckExitCode(0),
+	}))
+
+	t.Run("simple3", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test positional tag=world name-id=plop",
+		Check:    core.TestCheckExitCode(0),
+	}))
+
+	t.Run("simple4", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test positional plop name-id=plop",
 		Check:    core.TestCheckExitCode(0),
 	}))
 
@@ -270,6 +296,41 @@ func Test_PositionalArg(t *testing.T) {
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),
 			core.TestCheckGolden(),
+		),
+	}))
+
+	t.Run("many positional", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test many-positional tag1 name-id=plop",
+		Check:    core.TestCheckExitCode(0),
+	}))
+
+	t.Run("many positional", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test many-positional tag1 name-id=plop",
+		Check: core.TestCheckCombine(
+			core.TestCheckExitCode(0),
+			func(t *testing.T, ctx *core.CheckFuncCtx) {
+				t.Helper()
+				res := ctx.Result.(*testType)
+				assert.Equal(t, "plop", res.NameID)
+				assert.Equal(t, "tag1", res.Tag)
+			},
+		),
+	}))
+
+	t.Run("many multi-positional", core.Test(&core.TestConfig{
+		Commands: testGetCommands(),
+		Cmd:      "scw test many-multi-positional pos1 pos2 name-id=plop",
+		Check: core.TestCheckCombine(
+			core.TestCheckExitCode(0),
+			func(t *testing.T, ctx *core.CheckFuncCtx) {
+				t.Helper()
+				res := ctx.Result.(*testTypeManyTags)
+				assert.Equal(t, "plop", res.NameID)
+				assert.Equal(t, "pos1", res.Tags[0])
+				assert.Equal(t, "pos2", res.Tags[1])
+			},
 		),
 	}))
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Support different arguments with positional=true
- When multiple positional args are used, the last one of the ArgSpecs is actually positional, others are dymanic
- If a positional arg is passed dymanically `arg=value`, the value is used and no error are thrown
```
