### PR TITLE
fix(docs): downgrade awscli version for docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install curl unzip -y
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.20.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
           ./aws/install
 


### PR DESCRIPTION
New integrity headers on PUT & POST requests break Actions workflow, workaround is to downgrade to a functional release (tested with this specific use case).

[Related Scaleway status](https://status.scaleway.com/incidents/pfxfkq48n8q6)

```release-note
NONE
```
