### PR TITLE
fix(rdb): prevent crash when updating user without password

### DIFF
--- a/internal/namespaces/rdb/v1/custom_user.go
+++ b/internal/namespaces/rdb/v1/custom_user.go
@@ -183,6 +183,10 @@ func userUpdateBuilder(c *core.Command) *core.Command {
 			fmt.Printf("\n")
 		}
 
+		if !customRequest.GeneratePassword && customRequest.Password == nil {
+			return nil, fmt.Errorf("you must provide a password when generate-password is set to false")
+		}
+
 		user, err := api.UpdateUser(updateUserRequest)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
close [#4684](https://github.com/scaleway/scaleway-cli/issues/4684)
