### PR TITLE
fix(instance): add zone to update volume request

### DIFF
--- a/internal/namespaces/instance/v1/custom_server_create_builder.go
+++ b/internal/namespaces/instance/v1/custom_server_create_builder.go
@@ -749,6 +749,7 @@ func (vb *VolumeBuilder) ExecutePostCreationSetup(
 		_, err := apiBlock.UpdateVolume(&block.UpdateVolumeRequest{
 			VolumeID: volumeID,
 			PerfIops: vb.IOPS,
+			Zone:     vb.Zone,
 		},
 			scw.WithContext(ctx),
 		)


### PR DESCRIPTION
## Issue cmd

scw instance server create name=test image=ubuntu_noble type=PLAY2-NANO zone=fr-par-2 root-volume=sbs:10G:15000 additional-volumes.0=sbs:10G:15000 --wait -ojson --debug

## Response

---------- Scaleway SDK REQUEST 10 (a24063ba) : ----------
PATCH /block/v1alpha1/zones/fr-par-1/volumes/xxxxxxxxx HTTP/1.1
Host: api.scaleway.com
User-Agent: scaleway-sdk-go/v1.0.0-beta.33.0.20250422095315-6f998f4655ec (go1.24.1; darwin; arm64) scaleway-cli/2.0.0+dev
Content-Length: 19
Content-Type: application/json
X-Auth-Token: dd0f2cd8-xxxx-xxxx-xxxx-xxxxxxxxxxxx
Accept-Encoding: gzip

{"perf_iops":15000}
---------------------------------------------------------

---------- Scaleway SDK RESPONSE 10 (a24063ba) : ----------
HTTP/2.0 500 Internal Server Error
Content-Length: 28
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
Content-Type: application/json
Date: Mon, 12 May 2025 09:18:36 GMT
Server: Scaleway API Gateway (fr-par-1;edge03)
Strict-Transport-Security: max-age=63072000
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-Request-Id: 57432a0a-7048-45d8-80d9-bb36a60c7efd

{"message":"internal error"}


## Root Cause

The CLI command targets zone=fr-par-2, but a volume operation is mistakenly attempted in fr-par-1. This zone mismatch triggers a 500 Internal Server Error.

Expected behavior: The API should return a 404 Not Found when attempting to operate on a resource in the wrong zone. This will be corrected in a future update.