### PR TITLE
fix(instance): display sbs volumes' size in `instance image list` details

### DIFF
--- a/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-additional-volumes.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-additional-volumes.cassette.yaml
@@ -1,0 +1,2667 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
+  response:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}}}'
+    headers:
+      Content-Length:
+      - "38951"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5ced034-a20c-48a2-bc9f-94e3f7d5f33c
+      X-Total-Count:
+      - "71"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 530.29,
+      "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 530.29,
+      "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    headers:
+      Content-Length:
+      - "16613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06cbb1e0-3a5e-4137-bfa3-eb05b35ab25d
+      X-Total-Count:
+      - "71"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"e17b585e-c52f-44b0-97f6-07c18bb5bb86","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["START1-XS","X64-60GB","GP1-M","DEV1-L","GP1-XL","GP1-XS","DEV1-XL","START1-M","DEV1-M","DEV1-S","VC1M","GP1-L","START1-S","X64-30GB","VC1L","VC1S","STARDUST1-S","GP1-S","X64-120GB","X64-15GB","START1-L"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":1}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"e17b585e-c52f-44b0-97f6-07c18bb5bb86","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["START1-XS","X64-60GB","GP1-M","DEV1-L","GP1-XL","GP1-XS","DEV1-XL","START1-M","DEV1-M","DEV1-S","VC1M","GP1-L","START1-S","X64-30GB","VC1L","VC1S","STARDUST1-S","GP1-S","X64-120GB","X64-15GB","START1-L"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7e08d592-c29c-4049-9c4e-2ea2ac45b99b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e17b585e-c52f-44b0-97f6-07c18bb5bb86
+    method: GET
+  response:
+    body: '{"image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "620"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 559b955c-d182-444c-8020-b96fd24e9705
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.002780Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.002780Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "405"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b139a7f9-37ec-41ec-a58e-b06c7c165133
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.158989Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
+    method: POST
+  response:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.158989Z","references":[],"parent_snapshot_id":null,"status":"creating","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "410"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d90de38-9c10-429e-8c2b-3b2c4ec5923d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/46908dfd-f939-4d23-89ed-8b7f5cdc2ed6
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2dcc775e-ab5e-4f57-89bc-a762cd48dd5d
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.002780Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/46908dfd-f939-4d23-89ed-8b7f5cdc2ed6
+    method: GET
+  response:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.002780Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "406"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ff17e29-3a7d-446a-85a7-f2fcab18c97d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "8f537821-0ad1-4134-be0e-b6f3dd408678"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/8f537821-0ad1-4134-be0e-b6f3dd408678
+    method: GET
+  response:
+    body: '{"message": "resource is not found", "type": "not_found", "resource": "instance_volume",
+      "resource_id": "8f537821-0ad1-4134-be0e-b6f3dd408678"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f78c5871-59dd-4575-b199-1851a44a53cd
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.158989Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/8f537821-0ad1-4134-be0e-b6f3dd408678
+    method: GET
+  response:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.158989Z","references":[],"parent_snapshot_id":null,"status":"available","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "411"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d13e98c0-56ca-491d-9d8c-349e9ee8f859
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-jovial-carson", "image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8f537821-0ad1-4134-be0e-b6f3dd408678", "zone": "fr-par-1"}}, "tags": [], "state":
+      "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips":
+      [], "mac_address": "de:00:00:b3:14:ef", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-06-03T15:31:43.577097+00:00", "modification_date":
+      "2025-06-03T15:31:43.577097+00:00", "bootscript": null, "security_group": {"id":
+      "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-jovial-carson", "image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8f537821-0ad1-4134-be0e-b6f3dd408678", "zone": "fr-par-1"}}, "tags": [], "state":
+      "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips":
+      [], "mac_address": "de:00:00:b3:14:ef", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-06-03T15:31:43.577097+00:00", "modification_date":
+      "2025-06-03T15:31:43.577097+00:00", "bootscript": null, "security_group": {"id":
+      "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    headers:
+      Content-Length:
+      - "2405"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ad1991b-24dd-4d02-afc1-9bca67bb943b
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ac2251b-92ee-45f2-bc21-f5d1622fa6b5
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.684457Z","references":[{"id":"68c170a4-fc2e-4bd5-b303-0a7b448355b3","product_resource_type":"instance_server","product_resource_id":"4ad1991b-24dd-4d02-afc1-9bca67bb943b","created_at":"2025-06-03T15:31:43.684457Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/46908dfd-f939-4d23-89ed-8b7f5cdc2ed6
+    method: PATCH
+  response:
+    body: '{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.002780Z","updated_at":"2025-06-03T15:31:43.684457Z","references":[{"id":"68c170a4-fc2e-4bd5-b303-0a7b448355b3","product_resource_type":"instance_server","product_resource_id":"4ad1991b-24dd-4d02-afc1-9bca67bb943b","created_at":"2025-06-03T15:31:43.684457Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "633"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71ddc7bf-6862-4eb3-a2a7-7e4e630a039d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.772572Z","references":[{"id":"3507c9ee-bc03-4696-a513-9d5b9c52a8cc","product_resource_type":"instance_server","product_resource_id":"4ad1991b-24dd-4d02-afc1-9bca67bb943b","created_at":"2025-06-03T15:31:43.772572Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/8f537821-0ad1-4134-be0e-b6f3dd408678
+    method: PATCH
+  response:
+    body: '{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.158989Z","updated_at":"2025-06-03T15:31:43.772572Z","references":[{"id":"3507c9ee-bc03-4696-a513-9d5b9c52a8cc","product_resource_type":"instance_server","product_resource_id":"4ad1991b-24dd-4d02-afc1-9bca67bb943b","created_at":"2025-06-03T15:31:43.772572Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":null,"status":"in_use","tags":[],"specs":{"perf_iops":15000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "638"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3bb2f173-85c9-489e-a897-b87377524fd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-jovial-carson", "image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8f537821-0ad1-4134-be0e-b6f3dd408678", "zone": "fr-par-1"}}, "tags": [], "state":
+      "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips":
+      [], "mac_address": "de:00:00:b3:14:ef", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-06-03T15:31:43.577097+00:00", "modification_date":
+      "2025-06-03T15:31:43.577097+00:00", "bootscript": null, "security_group": {"id":
+      "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4ad1991b-24dd-4d02-afc1-9bca67bb943b
+    method: GET
+  response:
+    body: '{"server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-jovial-carson", "image": {"id": "e17b585e-c52f-44b0-97f6-07c18bb5bb86",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "8a8a8e59-526e-4da1-ac2b-2b7bb088e9be",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-02-03T13:22:29.238802+00:00",
+      "modification_date": "2025-02-03T13:22:29.238802+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}, "1": {"boot": false, "volume_type": "sbs_volume", "id": "46908dfd-f939-4d23-89ed-8b7f5cdc2ed6",
+      "zone": "fr-par-1"}, "2": {"boot": false, "volume_type": "sbs_volume", "id":
+      "8f537821-0ad1-4134-be0e-b6f3dd408678", "zone": "fr-par-1"}}, "tags": [], "state":
+      "stopped", "protected": false, "state_detail": "", "public_ip": null, "public_ips":
+      [], "mac_address": "de:00:00:b3:14:ef", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-06-03T15:31:43.577097+00:00", "modification_date":
+      "2025-06-03T15:31:43.577097+00:00", "bootscript": null, "security_group": {"id":
+      "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    headers:
+      Content-Length:
+      - "2405"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42809ba3-c734-4cdb-a071-22ff5bfa6b7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/98e89cfd-1fe3-4d23-8545-9b0304c69e79
+    method: GET
+  response:
+    body: '{"volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "4ad1991b-24dd-4d02-afc1-9bca67bb943b", "name": "cli-srv-jovial-carson"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-06-03T15:31:43.577097+00:00",
+      "modification_date": "2025-06-03T15:31:43.577097+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "525"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db596b78-8d7b-4bb7-8a09-32e00b9c32b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "creation_date": "2025-06-03T15:31:44.762620+00:00",
+      "modification_date": "2025-06-03T15:31:44.762620+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "d1412f4a-4f6e-48a5-be58-14b5fd7348da", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/80418a4a-46f8-4e0c-8a1a-870c04552d86", "started_at": "2025-06-03T15:31:45.045351+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "creation_date": "2025-06-03T15:31:44.762620+00:00",
+      "modification_date": "2025-06-03T15:31:44.762620+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "d1412f4a-4f6e-48a5-be58-14b5fd7348da", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/80418a4a-46f8-4e0c-8a1a-870c04552d86", "started_at": "2025-06-03T15:31:45.045351+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "848"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f852591-eb11-446c-96c1-10be9468271f
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "creation_date": "2025-06-03T15:31:44.762620+00:00",
+      "modification_date": "2025-06-03T15:31:44.762620+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/80418a4a-46f8-4e0c-8a1a-870c04552d86
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "creation_date": "2025-06-03T15:31:44.762620+00:00",
+      "modification_date": "2025-06-03T15:31:44.762620+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "98e89cfd-1fe3-4d23-8545-9b0304c69e79", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "537"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b109fbee-1087-44a5-8150-5d9dd725d1af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "440"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c887507d-b7ea-48d5-b627-ed9450ab73b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/908ce9c6-6c9f-4d74-be35-4371dd67f48a
+    method: GET
+  response:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "440"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8d54a21-1df8-45c1-a3b3-26542e545e24
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/908ce9c6-6c9f-4d74-be35-4371dd67f48a
+    method: GET
+  response:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:45.318935Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "441"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c0ec4953-ddf2-4fe4-a0f5-94343f512305
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "445"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7825cbdf-13f6-4c38-91de-9ac156170591
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/08af1e24-3935-460d-a252-63bee7693554
+    method: GET
+  response:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "445"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58f818ed-7992-4154-8a32-51f4c767a7d1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/08af1e24-3935-460d-a252-63bee7693554
+    method: GET
+  response:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:50.921901Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:56 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79b7f7cb-2825-4d4a-a9c2-893742ea92a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+    method: POST
+  response:
+    body: '{"image": {"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "823"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:56 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/54092d38-1e6a-4c1c-85bc-601b0bab6f47
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51421e40-f230-4abd-909a-ac4945428abb
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"images": [{"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}]}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?page=1&public=false
+    method: GET
+  response:
+    body: '{"images": [{"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "826"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Link:
+      - </images?page=1&per_page=50&public=false>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59ad1a6c-aa54-4510-8f4f-d793abcb3c64
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:56.492286Z","references":[{"id":"49e11f43-bd7c-4111-8d0a-b43fce0c3f9a","product_resource_type":"instance_image","product_resource_id":"54092d38-1e6a-4c1c-85bc-601b0bab6f47","created_at":"2025-06-03T15:31:56.492286Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/908ce9c6-6c9f-4d74-be35-4371dd67f48a
+    method: GET
+  response:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:56.492286Z","references":[{"id":"49e11f43-bd7c-4111-8d0a-b43fce0c3f9a","product_resource_type":"instance_image","product_resource_id":"54092d38-1e6a-4c1c-85bc-601b0bab6f47","created_at":"2025-06-03T15:31:56.492286Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "662"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73a798a0-aeed-452a-add7-6602d656432c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:56.664671Z","references":[{"id":"33b4896c-285c-464e-ad11-90eb2415d9e9","product_resource_type":"instance_image","product_resource_id":"54092d38-1e6a-4c1c-85bc-601b0bab6f47","created_at":"2025-06-03T15:31:56.664671Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/08af1e24-3935-460d-a252-63bee7693554
+    method: GET
+  response:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:56.664671Z","references":[{"id":"33b4896c-285c-464e-ad11-90eb2415d9e9","product_resource_type":"instance_image","product_resource_id":"54092d38-1e6a-4c1c-85bc-601b0bab6f47","created_at":"2025-06-03T15:31:56.664671Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ecd5f1dd-7bbf-4eab-8ecd-cc15f4e36ecb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/54092d38-1e6a-4c1c-85bc-601b0bab6f47
+    method: GET
+  response:
+    body: '{"image": {"id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47", "name": "cli-img-optimistic-joliot",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "80418a4a-46f8-4e0c-8a1a-870c04552d86", "name": "cli-snp-blissful-clarke",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"volume_type":
+      "sbs_snapshot", "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a", "size": 0, "name":
+      ""}, "2": {"volume_type": "sbs_snapshot", "id": "08af1e24-3935-460d-a252-63bee7693554",
+      "size": 0, "name": ""}}, "public": false, "arch": "x86_64", "creation_date":
+      "2025-06-03T15:31:56.398448+00:00", "modification_date": "2025-06-03T15:31:56.398448+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "823"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e286af4e-30d0-4773-92ea-f2053d0a680a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/54092d38-1e6a-4c1c-85bc-601b0bab6f47
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff5df5e2-da02-4e69-8639-4e37f16e4c35
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/80418a4a-46f8-4e0c-8a1a-870c04552d86
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cd8d36f-4e5f-439a-b332-9488aee84a39
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:58.973817Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/908ce9c6-6c9f-4d74-be35-4371dd67f48a
+    method: GET
+  response:
+    body: '{"id":"908ce9c6-6c9f-4d74-be35-4371dd67f48a","name":"cli-snp-recursing-borg","parent_volume":{"id":"46908dfd-f939-4d23-89ed-8b7f5cdc2ed6","name":"cli-vol-vigorous-booth","type":"sbs_5k","status":"in_use"},"size":10000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:45.318935Z","updated_at":"2025-06-03T15:31:58.973817Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "441"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adec0aef-9ddb-40f3-a3d4-175ff3c6321e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/908ce9c6-6c9f-4d74-be35-4371dd67f48a
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae0379da-2701-4aa3-8589-2df00ba79342
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:59.073171Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/08af1e24-3935-460d-a252-63bee7693554
+    method: GET
+  response:
+    body: '{"id":"08af1e24-3935-460d-a252-63bee7693554","name":"cli-snp-amazing-maxwell","parent_volume":{"id":"8f537821-0ad1-4134-be0e-b6f3dd408678","name":"cli-vol-elated-mcclintock","type":"sbs_15k","status":"in_use"},"size":15000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:50.921901Z","updated_at":"2025-06-03T15:31:59.073171Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1ee9a3b-286f-499b-a9b2-1d18770966d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/08af1e24-3935-460d-a252-63bee7693554
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd826836-d735-48cf-99e6-4f83cf3514c0
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-additional-volumes.golden
+++ b/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-additional-volumes.golden
@@ -1,0 +1,62 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+ID                                    NAME                       STATE      PUBLIC  ZONE      VOLUMES              SERVER NAME  SERVER ID  ARCH    ORGANIZATION ID                       PROJECT ID                            CREATION DATE    MODIFICATION DATE
+54092d38-1e6a-4c1c-85bc-601b0bab6f47  cli-img-optimistic-joliot  available  false   fr-par-1  20 GB, 10 GB, 15 GB  -            -          x86_64  fa1e3217-dc80-42ac-85c3-3f034b78b552  fa1e3217-dc80-42ac-85c3-3f034b78b552  few seconds ago  few seconds ago
+🟩🟩🟩 JSON STDOUT 🟩🟩🟩
+[
+  {
+    "id": "54092d38-1e6a-4c1c-85bc-601b0bab6f47",
+    "name": "cli-img-optimistic-joliot",
+    "arch": "x86_64",
+    "creation_date": "1970-01-01T00:00:00.0Z",
+    "modification_date": "1970-01-01T00:00:00.0Z",
+    "default_bootscript": null,
+    "extra_volumes": {
+      "1": {
+        "id": "908ce9c6-6c9f-4d74-be35-4371dd67f48a",
+        "name": "",
+        "export_uri": null,
+        "size": 10000000000,
+        "volume_type": "sbs_snapshot",
+        "creation_date": null,
+        "modification_date": null,
+        "organization": "",
+        "project": "",
+        "tags": null,
+        "server": null,
+        "state": "available",
+        "zone": ""
+      },
+      "2": {
+        "id": "08af1e24-3935-460d-a252-63bee7693554",
+        "name": "",
+        "export_uri": null,
+        "size": 15000000000,
+        "volume_type": "sbs_snapshot",
+        "creation_date": null,
+        "modification_date": null,
+        "organization": "",
+        "project": "",
+        "tags": null,
+        "server": null,
+        "state": "available",
+        "zone": ""
+      }
+    },
+    "from_server": "",
+    "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    "public": false,
+    "root_volume": {
+      "id": "80418a4a-46f8-4e0c-8a1a-870c04552d86",
+      "name": "cli-snp-blissful-clarke",
+      "size": 20000000000,
+      "volume_type": "l_ssd"
+    },
+    "state": "available",
+    "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    "tags": [],
+    "zone": "fr-par-1",
+    "server_id": "",
+    "server_name": ""
+  }
+]

--- a/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-root-volume.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-root-volume.cassette.yaml
@@ -1,0 +1,2073 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
+  response:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1778.4, "hourly_price": 2.47, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}}}'
+    headers:
+      Content-Length:
+      - "38951"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 123f0d56-ebe6-4b98-bcde-12bc1f4e2940
+      X-Total-Count:
+      - "71"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 530.29,
+      "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"POP2-HN-10": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 530.29,
+      "hourly_price": 0.7264, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    headers:
+      Content-Length:
+      - "16613"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6ef2602-19c2-4719-a5a9-7c1672557c25
+      X-Total-Count:
+      - "71"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"3b131f0d-7075-494e-9c86-b2c424007a0a","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_sbs"},{"id":"63d40353-5519-46d0-9172-ccf4885954e1","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10","POP2-48C-192G","POP2-HC-48C-96G","POP2-HM-48C-384G"],"label":"ubuntu_jammy","type":"instance_sbs"}],"total_count":2}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_sbs&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"3b131f0d-7075-494e-9c86-b2c424007a0a","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_sbs"},{"id":"63d40353-5519-46d0-9172-ccf4885954e1","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10","POP2-48C-192G","POP2-HC-48C-96G","POP2-HM-48C-384G"],"label":"ubuntu_jammy","type":"instance_sbs"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1269"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b20cdcf2-1839-4714-ae21-269344d306ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/63d40353-5519-46d0-9172-ccf4885954e1
+    method: GET
+  response:
+    body: '{"image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "587"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3364440-087d-49f5-a6f9-4c700cd26e5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "630f46e1-a421-4671-8413-189aae545e9f", "name": "cli-srv-friendly-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-friendly-shannon", "image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "76718a97-5989-415e-a353-3746c20b0364", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:b3:14:ed", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-06-03T15:31:43.206809+00:00",
+      "modification_date": "2025-06-03T15:31:43.206809+00:00", "bootscript": null,
+      "security_group": {"id": "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "630f46e1-a421-4671-8413-189aae545e9f", "name": "cli-srv-friendly-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-friendly-shannon", "image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "76718a97-5989-415e-a353-3746c20b0364", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:b3:14:ed", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-06-03T15:31:43.206809+00:00",
+      "modification_date": "2025-06-03T15:31:43.206809+00:00", "bootscript": null,
+      "security_group": {"id": "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/630f46e1-a421-4671-8413-189aae545e9f
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e700310c-35bf-4b30-954d-7115db99512b
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0","type":"sbs_5k","size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.338041Z","updated_at":"2025-06-03T15:31:43.338041Z","references":[{"id":"4a472d19-c811-43b8-bc4e-5d725c14ff42","product_resource_type":"instance_server","product_resource_id":"630f46e1-a421-4671-8413-189aae545e9f","created_at":"2025-06-03T15:31:43.338041Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"905845fc-a6eb-4401-8e9d-5810071b7119","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/76718a97-5989-415e-a353-3746c20b0364
+    method: PATCH
+  response:
+    body: '{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu 22.04 Jammy
+      Jellyfish_sbs_volume_0","type":"sbs_5k","size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:43.338041Z","updated_at":"2025-06-03T15:31:43.338041Z","references":[{"id":"4a472d19-c811-43b8-bc4e-5d725c14ff42","product_resource_type":"instance_server","product_resource_id":"630f46e1-a421-4671-8413-189aae545e9f","created_at":"2025-06-03T15:31:43.338041Z","type":"exclusive","status":"attached"}],"parent_snapshot_id":"905845fc-a6eb-4401-8e9d-5810071b7119","status":"in_use","tags":[],"specs":{"perf_iops":5000,"class":"sbs"},"last_detached_at":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7628d91a-fd15-45fe-a484-2cc0b851ebc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "630f46e1-a421-4671-8413-189aae545e9f", "name": "cli-srv-friendly-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-friendly-shannon", "image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "76718a97-5989-415e-a353-3746c20b0364", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:b3:14:ed", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-06-03T15:31:43.206809+00:00",
+      "modification_date": "2025-06-03T15:31:43.206809+00:00", "bootscript": null,
+      "security_group": {"id": "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/630f46e1-a421-4671-8413-189aae545e9f
+    method: GET
+  response:
+    body: '{"server": {"id": "630f46e1-a421-4671-8413-189aae545e9f", "name": "cli-srv-friendly-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-friendly-shannon", "image": {"id": "63d40353-5519-46d0-9172-ccf4885954e1",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"volume_type":
+      "sbs_snapshot", "id": "905845fc-a6eb-4401-8e9d-5810071b7119", "size": 0, "name":
+      ""}, "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date":
+      "2025-02-03T13:22:53.227105+00:00", "modification_date": "2025-02-03T13:22:53.227105+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}, "volumes": {"0": {"boot": false, "volume_type": "sbs_volume",
+      "id": "76718a97-5989-415e-a353-3746c20b0364", "zone": "fr-par-1"}}, "tags":
+      [], "state": "stopped", "protected": false, "state_detail": "", "public_ip":
+      null, "public_ips": [], "mac_address": "de:00:00:b3:14:ed", "routed_ip_enabled":
+      true, "ipv6": null, "extra_networks": [], "dynamic_ip_required": false, "enable_ipv6":
+      false, "private_ip": null, "creation_date": "2025-06-03T15:31:43.206809+00:00",
+      "modification_date": "2025-06-03T15:31:43.206809+00:00", "bootscript": null,
+      "security_group": {"id": "dccbeacb-b588-4c47-8eaf-b05d1469d3cb", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "1726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14786204-f5d9-4ae2-b883-8ac4a1818a96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53cfa62b-c29a-41cc-9d7f-95ccff914ab7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: GET
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"creating","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "462"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1f5f698-c385-41ff-88c6-7232a499b7fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: GET
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:44.237150Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a5e38d7-2fc5-49c0-850f-561e56fffbd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+    method: POST
+  response:
+    body: '{"image": {"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "578"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:50 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/022d8dcc-e8c5-4e4a-92b1-8bf1a699814a
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9f917a3e-7b3e-4d1b-83de-177c1405d39a
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"images": [{"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}]}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images?page=1&public=false
+    method: GET
+  response:
+    body: '{"images": [{"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "581"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:50 GMT
+      Link:
+      - </images?page=1&per_page=50&public=false>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b20f67d-016b-4a5a-9c22-a0e9890b2b20
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:49.835243Z","references":[{"id":"d1f81975-0606-42b3-b468-e9b825f2513c","product_resource_type":"instance_image","product_resource_id":"022d8dcc-e8c5-4e4a-92b1-8bf1a699814a","created_at":"2025-06-03T15:31:49.835243Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: GET
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:49.835243Z","references":[{"id":"d1f81975-0606-42b3-b468-e9b825f2513c","product_resource_type":"instance_image","product_resource_id":"022d8dcc-e8c5-4e4a-92b1-8bf1a699814a","created_at":"2025-06-03T15:31:49.835243Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "684"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94722e52-a72e-43cf-a51d-3b442521feae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/022d8dcc-e8c5-4e4a-92b1-8bf1a699814a
+    method: GET
+  response:
+    body: '{"image": {"id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a", "name": "cli-img-nifty-jang",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"volume_type": "sbs_snapshot", "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "size": 0, "name": ""}, "extra_volumes": {}, "public": false, "arch": "x86_64",
+      "creation_date": "2025-06-03T15:31:49.795722+00:00", "modification_date": "2025-06-03T15:31:49.795722+00:00",
+      "default_bootscript": null, "from_server": "", "state": "available", "tags":
+      [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "578"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5d96029f-48a1-474f-828b-73428ef93695
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/022d8dcc-e8c5-4e4a-92b1-8bf1a699814a
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33b58f7b-8837-46cb-a452-08bdb9deca1c
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:49.835243Z","references":[{"id":"d1f81975-0606-42b3-b468-e9b825f2513c","product_resource_type":"instance_image","product_resource_id":"022d8dcc-e8c5-4e4a-92b1-8bf1a699814a","created_at":"2025-06-03T15:31:49.835243Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: GET
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:49.835243Z","references":[{"id":"d1f81975-0606-42b3-b468-e9b825f2513c","product_resource_type":"instance_image","product_resource_id":"022d8dcc-e8c5-4e4a-92b1-8bf1a699814a","created_at":"2025-06-03T15:31:49.835243Z","type":"link","status":"attached"}],"status":"in_use","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "684"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5354ef62-ba0b-4e9e-ba0d-0f688499c1f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:51.985707Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: GET
+  response:
+    body: '{"id":"55306964-344f-45f8-9b72-d064d991512d","name":"cli-snp-dreamy-hofstadter","parent_volume":{"id":"76718a97-5989-415e-a353-3746c20b0364","name":"Ubuntu
+      22.04 Jammy Jellyfish_sbs_volume_0","type":"sbs_5k","status":"in_use"},"size":20000000000,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","created_at":"2025-06-03T15:31:44.237150Z","updated_at":"2025-06-03T15:31:51.985707Z","references":[],"status":"available","tags":[],"class":"sbs","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "463"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0219f8af-80f6-4a78-9ead-93ef1059b2c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/snapshots/55306964-344f-45f8-9b72-d064d991512d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jun 2025 15:31:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1331a92c-80f3-4cfa-9915-b0c3de09b145
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-root-volume.golden
+++ b/internal/namespaces/instance/v1/testdata/test-image-list-with-sbs-root-volume.golden
@@ -1,0 +1,31 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+ID                                    NAME                STATE      PUBLIC  ZONE      VOLUMES  SERVER NAME  SERVER ID  ARCH    ORGANIZATION ID                       PROJECT ID                            CREATION DATE    MODIFICATION DATE
+022d8dcc-e8c5-4e4a-92b1-8bf1a699814a  cli-img-nifty-jang  available  false   fr-par-1  20 GB    -            -          x86_64  fa1e3217-dc80-42ac-85c3-3f034b78b552  fa1e3217-dc80-42ac-85c3-3f034b78b552  few seconds ago  few seconds ago
+🟩🟩🟩 JSON STDOUT 🟩🟩🟩
+[
+  {
+    "id": "022d8dcc-e8c5-4e4a-92b1-8bf1a699814a",
+    "name": "cli-img-nifty-jang",
+    "arch": "x86_64",
+    "creation_date": "1970-01-01T00:00:00.0Z",
+    "modification_date": "1970-01-01T00:00:00.0Z",
+    "default_bootscript": null,
+    "extra_volumes": {},
+    "from_server": "",
+    "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    "public": false,
+    "root_volume": {
+      "id": "55306964-344f-45f8-9b72-d064d991512d",
+      "name": "",
+      "size": 20000000000,
+      "volume_type": "sbs_snapshot"
+    },
+    "state": "available",
+    "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+    "tags": [],
+    "zone": "fr-par-1",
+    "server_id": "",
+    "server_name": ""
+  }
+]


### PR DESCRIPTION
The command `scw instance image list` now fetches volume information from the SBS API to display the correct size of the underlying snapshots.
