### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
       - -X main.GitCommit={{ .ShortCommit }}
 
 archives:
-  - format: binary
+  - formats: [binary]
 
 checksum:
   name_template: 'SHA256SUMS'


### PR DESCRIPTION
### Community Note
This small PR updates the GoReleaser configuration to resolve the following warnings: 
```
DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```
Fixed #4859.

```release-note
update GoReleaser configurations
```
