### PR TITLE
fix(instance): EoS warning: filter products list by offer_id

### DIFF
--- a/internal/namespaces/instance/v1/helpers_types.go
+++ b/internal/namespaces/instance/v1/helpers_types.go
@@ -121,10 +121,9 @@ func getEndOfServiceDate(
 	}
 
 	for _, product := range products.Products {
-		if strings.HasPrefix(product.Product, commercialType) {
-			if product.Locality.Zone != nil && *product.Locality.Zone == zone {
-				return product.EndOfLifeAt.Format(time.DateOnly), nil
-			}
+		if product.Properties != nil && product.Properties.Instance != nil &&
+			product.Properties.Instance.OfferID == commercialType {
+			return product.EndOfLifeAt.Format(time.DateOnly), nil
 		}
 	}
 


### PR DESCRIPTION
The function to get the End of Service date of a commercial type to display a warning if it's about to be deprecated was filtering results from the Product Catalog according to the `product` field. But the content of this field might change in the future, whereas the `offer_id` nested attribute will not, therefore we should use this field as a filter instead.