### PR TITLE
tests(instance): replace remaining b_ssd volumes by l_ssd

### DIFF
--- a/internal/namespaces/instance/v1/custom_image_test.go
+++ b/internal/namespaces/instance/v1/custom_image_test.go
@@ -244,7 +244,7 @@ func Test_ImageUpdate(t *testing.T) {
 
 	t.Run("Add extra volume", core.Test(&core.TestConfig{
 		BeforeFunc: core.BeforeFuncCombine(
-			createVolume("Volume", 20, instanceSDK.VolumeVolumeTypeBSSD),
+			createNonEmptyLocalVolume("Volume", 10),
 			core.ExecStoreBeforeCmd(
 				"SnapshotVol",
 				`scw instance snapshot create -w name=snapVol volume-id={{ .Volume.ID }}`,

--- a/internal/namespaces/instance/v1/custom_snapshot_test.go
+++ b/internal/namespaces/instance/v1/custom_snapshot_test.go
@@ -14,7 +14,7 @@ func Test_UpdateSnapshot(t *testing.T) {
 		t.Run("Change tags", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
-				createVolume("Volume", 10, instanceSDK.VolumeVolumeTypeBSSD),
+				createNonEmptyLocalVolume("Volume", 10),
 				core.ExecStoreBeforeCmd(
 					"CreateSnapshot",
 					"scw instance snapshot create volume-id={{ .Volume.ID }} name=cli-test-snapshot-update-tags tags.0=foo tags.1=bar",
@@ -42,7 +42,7 @@ func Test_UpdateSnapshot(t *testing.T) {
 		t.Run("Change name", core.Test(&core.TestConfig{
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
-				createVolume("Volume", 10, instanceSDK.VolumeVolumeTypeBSSD),
+				createNonEmptyLocalVolume("Volume", 10),
 				core.ExecStoreBeforeCmd(
 					"CreateSnapshot",
 					"scw instance snapshot create volume-id={{ .Volume.ID }} name=cli-test-snapshot-update-name tags.0=foo tags.1=bar",

--- a/internal/namespaces/instance/v1/instance_cli_test.go
+++ b/internal/namespaces/instance/v1/instance_cli_test.go
@@ -40,7 +40,7 @@ func Test_GetServer(t *testing.T) {
 func Test_CreateVolume(t *testing.T) {
 	t.Run("Simple", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance volume create name=test volume-type=b_ssd size=20G",
+		Cmd:      "scw instance volume create name=test volume-type=l_ssd size=20G",
 		Check: core.TestCheckCombine(
 			core.TestCheckExitCode(0),
 			func(t *testing.T, ctx *core.CheckFuncCtx) {
@@ -54,7 +54,7 @@ func Test_CreateVolume(t *testing.T) {
 
 	t.Run("Bad size unit", core.Test(&core.TestConfig{
 		Commands: instance.GetCommands(),
-		Cmd:      "scw instance volume create name=test volume-type=b_ssd size=20",
+		Cmd:      "scw instance volume create name=test volume-type=l_ssd size=20",
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),

--- a/internal/namespaces/instance/v1/testdata/test-create-volume-bad-size-unit.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-volume-bad-size-unit.cassette.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/internal/namespaces/instance/v1/testdata/test-create-volume-simple.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-create-volume-simple.cassette.yaml
@@ -2,25 +2,25 @@
 version: 1
 interactions:
 - request:
-    body: '{"volume": {"id": "6edefc20-4cc5-462e-a8b0-80dded76c78c", "name": "test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-10-23T12:02:48.930043+00:00", "modification_date":
-      "2024-10-23T12:02:48.930043+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "dc156514-8ba0-477b-8b27-dc3233870ef8", "name": "test",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2025-07-22T15:32:46.200346+00:00", "modification_date":
+      "2025-07-22T15:32:46.200346+00:00", "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume": {"id": "6edefc20-4cc5-462e-a8b0-80dded76c78c", "name": "test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2024-10-23T12:02:48.930043+00:00", "modification_date":
-      "2024-10-23T12:02:48.930043+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"volume": {"id": "dc156514-8ba0-477b-8b27-dc3233870ef8", "name": "test",
+      "volume_type": "l_ssd", "export_uri": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "server": null, "size": 20000000000,
+      "state": "available", "creation_date": "2025-07-22T15:32:46.200346+00:00", "modification_date":
+      "2025-07-22T15:32:46.200346+00:00", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
       - "426"
@@ -29,11 +29,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2024 12:02:48 GMT
+      - Tue, 22 Jul 2025 15:32:46 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6edefc20-4cc5-462e-a8b0-80dded76c78c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dc156514-8ba0-477b-8b27-dc3233870ef8
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -41,7 +41,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3c78bff-0132-441a-bea4-3c13456e983b
+      - 1dfd652d-918c-4055-b6f3-4f3c11445818
     status: 201 Created
     code: 201
     duration: ""
@@ -50,8 +50,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.0; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6edefc20-4cc5-462e-a8b0-80dded76c78c
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dc156514-8ba0-477b-8b27-dc3233870ef8
     method: DELETE
   response:
     body: ""
@@ -61,9 +61,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 23 Oct 2024 12:02:49 GMT
+      - Tue, 22 Jul 2025 15:32:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -71,7 +71,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5006c81d-55ca-4c43-a3fd-b54d53432122
+      - ea6a4ba9-f064-4d2e-8726-3894a128163b
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-image-update-add-extra-volume.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-image-update-add-extra-volume.cassette.yaml
@@ -2,1149 +2,965 @@
 version: 1
 interactions:
 - request:
-    body: '{"volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2025-01-29T10:22:13.803941+00:00", "modification_date":
-      "2025-01-29T10:22:13.803941+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
-    method: POST
-  response:
-    body: '{"volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2025-01-29T10:22:13.803941+00:00", "modification_date":
-      "2025-01-29T10:22:13.803941+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "430"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:13 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/172a921f-8972-4f7f-843b-bec6ed2e64ee
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77d3779d-b294-4604-b9d6-55cddfec657d
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2025-01-29T10:22:13.803941+00:00", "modification_date":
-      "2025-01-29T10:22:13.803941+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/172a921f-8972-4f7f-843b-bec6ed2e64ee
-    method: GET
-  response:
-    body: '{"volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 20000000000,
-      "state": "available", "creation_date": "2025-01-29T10:22:13.803941+00:00", "modification_date":
-      "2025-01-29T10:22:13.803941+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "430"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4fbbdcab-d019-46fd-bab2-f48a18baf12d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:14.039594+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee",
-      "name": "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null},
-      "task": {"id": "55ced4f4-169a-4e40-beaf-868f0a21c6f4", "description": "volume_snapshot",
-      "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/eee73521-749a-47f5-80ff-b617578a6af1",
-      "started_at": "2025-01-29T10:22:14.258786+00:00", "terminated_at": null, "progress":
-      0, "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-    method: POST
-  response:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:14.039594+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee",
-      "name": "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null},
-      "task": {"id": "55ced4f4-169a-4e40-beaf-868f0a21c6f4", "description": "volume_snapshot",
-      "status": "pending", "href_from": "/snapshots", "href_result": "snapshots/eee73521-749a-47f5-80ff-b617578a6af1",
-      "started_at": "2025-01-29T10:22:14.258786+00:00", "terminated_at": null, "progress":
-      0, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "815"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 09fa24c6-9e4a-4408-97e7-1c71c9f54137
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:14.039594+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee",
-      "name": "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eee73521-749a-47f5-80ff-b617578a6af1
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:14.039594+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "snapshotting", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee",
-      "name": "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "504"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a9c9e46f-472b-4ae0-8a2a-8cc3f134b49a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:17.278622+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name":
-      "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eee73521-749a-47f5-80ff-b617578a6af1
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol",
-      "volume_type": "b_ssd", "creation_date": "2025-01-29T10:22:14.039594+00:00",
-      "modification_date": "2025-01-29T10:22:17.278622+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "172a921f-8972-4f7f-843b-bec6ed2e64ee", "name":
-      "cli-test"}, "tags": [], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "501"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:19 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2543aeef-3c57-48c1-8ec7-46938557f14b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
       "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
-      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
-      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
-      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
-      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
-      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
-      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
-      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
       "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
       "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
       null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
       null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}, "block_bandwidth": 838860800}}}'
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
     body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
-      16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
       0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
       "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 671088640}, "COPARM1-2C-8G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 83886080}, "COPARM1-32C-128G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 1342177280}, "COPARM1-4C-16G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 167772160}, "COPARM1-8C-32G": {"alt_names":
-      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 335544320}, "DEV1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 80000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 36.1496, "hourly_price": 0.04952, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 209715200}, "DEV1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 3, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}, "block_bandwidth": 157286400}, "DEV1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 20000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 9.9864, "hourly_price": 0.01368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 104857600}, "DEV1-XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 12884901888, "gpu": 0, "mig_profile": null, "volumes_constraint":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
       {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
       {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 262144000}, "ENT1-2XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2576.9,
-      "hourly_price": 3.53, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 20000000000,
-      "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
-      20000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      20000000000}]}, "block_bandwidth": 21474836480}, "ENT1-L": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "ENT1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 430.7,
-      "hourly_price": 0.59, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3200000000,
-      "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "ENT1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 211.7,
-      "hourly_price": 0.29, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1600000000,
-      "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "ENT1-XL": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "ENT1-XS": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "ENT1-XXS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 53.655,
-      "hourly_price": 0.0735, "capabilities": {"boot_types": ["local", "rescue"],
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
       "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "GP1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 576.262, "hourly_price": 0.7894, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}, "block_bandwidth": 1073741824}, "GP1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 296.672, "hourly_price": 0.4064, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1500000000, "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}, "block_bandwidth": 838860800}, "GP1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 300000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 149.066, "hourly_price": 0.2042, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 524288000}, "GP1-XL": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 600000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 1220.122, "hourly_price": 1.6714, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}, "block_bandwidth": 2147483648}, "GP1-XS": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 150000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 74.168, "hourly_price": 0.1016, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 314572800}, "PLAY2-MICRO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
       "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 167772160}, "PLAY2-NANO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 83886080}, "PLAY2-PICO": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 41943040}, "POP2-16C-64G": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-16C-64G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1063.391, "hourly_price": 1.4567, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-2C-8G": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile": null,
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
       "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-2C-8G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-32C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-32C-128G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "mig_profile":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
       null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 2126.709, "hourly_price": 2.9133, "capabilities": {"boot_types":
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-4C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-4C-16G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-64C-256G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-8C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-8C-32G-WIN": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 528.009, "hourly_price": 0.7233, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HC-16C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 34359738368, "gpu": 0, "mig_profile":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
       null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HC-2C-4G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-HC-32C-64G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HC-4C-8G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-HC-64C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1242.75, "hourly_price": 1.7024, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HC-8C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HM-16C-128G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 601.52, "hourly_price": 0.824, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
-      3200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3200000000}]}, "block_bandwidth": 3355443200}, "POP2-HM-2C-16G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 2, "ram": 17179869184, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
       {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
       "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 419430400}, "POP2-HM-32C-256G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 1203.04, "hourly_price": 1.648, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
-      6400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6400000000}]}, "block_bandwidth": 6710886400}, "POP2-HM-4C-32G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 4, "ram": 34359738368, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      800000000, "sum_internet_bandwidth": 800000000, "interfaces": [{"internal_bandwidth":
-      800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      800000000}]}, "block_bandwidth": 838860800}, "POP2-HM-64C-512G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 2406.08, "hourly_price": 3.296, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
-      12800000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      12800000000}]}, "block_bandwidth": 13421772800}, "POP2-HM-8C-64G": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 8, "ram": 68719476736, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
-      1600000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1600000000}]}, "block_bandwidth": 1677721600}, "POP2-HN-10": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
-      10000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      10000000000}]}, "block_bandwidth": 838860800}, "POP2-HN-3": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      3000000000, "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}, "block_bandwidth": 419430400}, "POP2-HN-5": {"alt_names": [],
-      "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
-      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      false, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
-      5000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      5000000000}]}, "block_bandwidth": 838860800}}}'
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     headers:
       Content-Length:
-      - "38539"
+      - "39208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:19 GMT
+      - Tue, 22 Jul 2025 15:32:14 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1152,362 +968,508 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0725b32e-e529-444d-9d0e-043dacf6587d
+      - b5ec04cb-cc0a-440f-b32b-3a1907ca791e
       X-Total-Count:
-      - "68"
+      - "75"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
-      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
       true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
-      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
-      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
-      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
-      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
-      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
-      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
-      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
-      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
-      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
-      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
-      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
-      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
-      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
-      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
       {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
-      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
-      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
-      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
       true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
-      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
-      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
-      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}, "block_bandwidth": 41943040}}}'
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers": {"PRO2-L": {"alt_names": [], "arch": "x86_64", "ncpus": 32,
-      "ram": 137438953472, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
       0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "monthly_price": 640.21, "hourly_price":
-      0.877, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
       true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 6000000000,
-      "sum_internet_bandwidth": 6000000000, "interfaces": [{"internal_bandwidth":
-      6000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      6000000000}]}, "block_bandwidth": 2097152000}, "PRO2-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 319.74,
-      "hourly_price": 0.438, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 3000000000,
-      "sum_internet_bandwidth": 3000000000, "interfaces": [{"internal_bandwidth":
-      3000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      3000000000}]}, "block_bandwidth": 1048576000}, "PRO2-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 159.87,
-      "hourly_price": 0.219, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 1500000000,
-      "sum_internet_bandwidth": 1500000000, "interfaces": [{"internal_bandwidth":
-      1500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1500000000}]}, "block_bandwidth": 524288000}, "PRO2-XS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
-      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 80.3,
-      "hourly_price": 0.11, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth":
-      700000000, "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 700000000}]}, "block_bandwidth":
-      262144000}, "PRO2-XXS": {"alt_names": [], "arch": "x86_64", "ncpus": 2, "ram":
-      8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
-      0}}, "scratch_storage_max_size": null, "monthly_price": 40.15, "hourly_price":
-      0.055, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
-      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth":
-      350000000, "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 350000000}]}, "block_bandwidth":
-      131072000}, "RENDER-S": {"alt_names": [], "arch": "x86_64", "ncpus": 10, "ram":
-      45097156608, "gpu": 1, "mig_profile": null, "volumes_constraint": {"min_size":
-      0, "max_size": 400000000000}, "per_volume_constraint": {"l_ssd": {"min_size":
-      1000000000, "max_size": 800000000000}}, "scratch_storage_max_size": null, "monthly_price":
-      907.098, "hourly_price": 1.2426, "capabilities": {"boot_types": ["local", "rescue"],
-      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
-      2000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      2000000000}]}, "block_bandwidth": 2147483648}, "STARDUST1-S": {"alt_names":
-      [], "arch": "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile":
-      null, "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
       {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 52428800}, "START1-L": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 26.864, "hourly_price": 0.0368, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
-      400000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      400000000}]}, "block_bandwidth": 41943040}, "START1-M": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 100000000000, "max_size": 100000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      300000000, "sum_internet_bandwidth": 300000000, "interfaces": [{"internal_bandwidth":
-      300000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      300000000}]}, "block_bandwidth": 41943040}, "START1-S": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 7.738, "hourly_price": 0.0106, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "START1-XS": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 1, "ram": 1073741824, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 25000000000, "max_size": 25000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      100000000, "sum_internet_bandwidth": 100000000, "interfaces": [{"internal_bandwidth":
-      100000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      100000000}]}, "block_bandwidth": 41943040}, "VC1L": {"alt_names": ["X64-8GB"],
-      "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 200000000000, "max_size": 200000000000},
-      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}},
-      "scratch_storage_max_size": null, "monthly_price": 18.0164, "hourly_price":
-      0.02468, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
       true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
-      8}, "network": {"ipv6_support": true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth":
-      200000000, "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth":
-      null}, {"internal_bandwidth": null, "internet_bandwidth": 200000000}]}, "block_bandwidth":
-      41943040}, "VC1M": {"alt_names": ["X64-4GB"], "arch": "x86_64", "ncpus": 4,
-      "ram": 4294967296, "gpu": 0, "mig_profile": null, "volumes_constraint": {"min_size":
-      100000000000, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
-      {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 11.3515, "hourly_price": 0.01555, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "VC1S": {"alt_names": ["X64-2GB"],
-      "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "mig_profile": null,
-      "volumes_constraint": {"min_size": 50000000000, "max_size": 50000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 6.2926, "hourly_price": 0.00862, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
-      200000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      200000000}]}, "block_bandwidth": 41943040}, "X64-120GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 12, "ram": 128849018880, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 500000000000, "max_size": 1000000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
       null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
       ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
       1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}, "block_bandwidth": 41943040}, "X64-15GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 200000000000, "max_size": 200000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 44.0336, "hourly_price": 0.06032, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      250000000, "sum_internet_bandwidth": 250000000, "interfaces": [{"internal_bandwidth":
-      250000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      250000000}]}, "block_bandwidth": 41943040}, "X64-30GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 300000000000, "max_size": 400000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 86.9138, "hourly_price": 0.11906, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
-      500000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      500000000}]}, "block_bandwidth": 41943040}, "X64-60GB": {"alt_names": [], "arch":
-      "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "mig_profile": null, "volumes_constraint":
-      {"min_size": 400000000000, "max_size": 700000000000}, "per_volume_constraint":
-      {"l_ssd": {"min_size": 1000000000, "max_size": 200000000000}}, "scratch_storage_max_size":
-      null, "monthly_price": 155.49, "hourly_price": 0.213, "capabilities": {"boot_types":
-      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
-      true, "private_network": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
-      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
-      1000000000, "internet_bandwidth": null}, {"internal_bandwidth": null, "internet_bandwidth":
-      1000000000}]}, "block_bandwidth": 41943040}}}'
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
     headers:
       Content-Length:
-      - "14208"
+      - "19730"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:19 GMT
+      - Tue, 22 Jul 2025 15:32:14 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1515,33 +1477,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b79ee1-93b4-476a-b29f-c8287db2e641
+      - dd471e3c-1992-44a2-bcfe-0541a6331304
       X-Total-Count:
-      - "68"
+      - "75"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"id":"2982a1c0-be7e-4114-af3d-a8af8aa7aec5","arch":"arm64","zone":"fr-par-1","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"label":"ubuntu_jammy","type":"instance_local"},{"id":"bc50e86c-a6c7-401a-8fbb-2ef17ce87aee","arch":"x86_64","zone":"fr-par-1","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G","POP2-HN-3","POP2-HN-5","POP2-HN-10"],"label":"ubuntu_jammy","type":"instance_local"}],"total_count":2}'
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
     headers:
       Content-Length:
-      - "1220"
+      - "423"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:19 GMT
+      - Tue, 22 Jul 2025 15:32:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1549,43 +1521,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73c68ec7-4865-43fc-9e3a-4a27e855ab9a
+      - 7d4908df-3de6-47fe-8a45-18e3d2095ba5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/bc50e86c-a6c7-401a-8fbb-2ef17ce87aee
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cf1c79e-46b5-40d7-8eaa-51f76f099837
     method: GET
   response:
-    body: '{"image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee", "name": "Ubuntu
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
       22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "620"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:19 GMT
+      - Tue, 22 Jul 2025 15:32:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1593,81 +1565,137 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61d0757f-fb11-4673-896b-da8b1e52a6e5
+      - b28e1673-de17-4a58-adb9-44dfc97dfef2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes",
-      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-serene-archimedes", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "149590ae-d115-41dd-99ac-310c02882658",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:7f:01",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "bootscript": null,
-      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+    body: '{"ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}}'
+    headers:
+      Content-Length:
+      - "365"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:14 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4edebbd5-3cf5-4456-a7bc-5740fd941af6
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e07d7a81-b5bd-4420-a442-1efe1eb29acb
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "89954d20-7fb4-495e-a78d-253a488861cd",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:15.195480+00:00",
+      "modification_date": "2025-07-22T15:32:15.195480+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes",
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-serene-archimedes", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "149590ae-d115-41dd-99ac-310c02882658",
+      "volumes": {"0": {"boot": false, "id": "89954d20-7fb4-495e-a78d-253a488861cd",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:15.195480+00:00",
+      "modification_date": "2025-07-22T15:32:15.195480+00:00", "tags": [], "zone":
       "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:7f:01",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "bootscript": null,
-      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "2139"
+      - "2694"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:20 GMT
+      - Tue, 22 Jul 2025 15:32:15 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c125304-e5d7-4262-a809-85ca86d6def8
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/cbac7b10-174f-4465-94f8-ed394de7d17c
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1675,43 +1703,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7eb63c9e-973f-4bb7-bf43-b3f1abb3d0ef
+      - e2067ee6-c828-48f0-889b-0ea50ec77321
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name": "Ubuntu
+    body: '{"volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name": "Ubuntu
       22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:15.195480+00:00",
+      "modification_date": "2025-07-22T15:32:15.195480+00:00", "tags": [], "zone":
       "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/149590ae-d115-41dd-99ac-310c02882658
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89954d20-7fb4-495e-a78d-253a488861cd
     method: GET
   response:
-    body: '{"volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name": "Ubuntu
+    body: '{"volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name": "Ubuntu
       22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:15.195480+00:00",
+      "modification_date": "2025-07-22T15:32:15.195480+00:00", "tags": [], "zone":
       "fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "525"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:20 GMT
+      - Tue, 22 Jul 2025 15:32:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1719,225 +1747,161 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6e4b481-bd47-4340-b337-0664303ccaed
+      - 9e621117-a019-4c1f-a26a-676f856f422a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "creation_date": "2025-01-29T10:22:20.918566+00:00",
-      "modification_date": "2025-01-29T10:22:20.918566+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name":
-      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "7c75e97d-bc60-4409-a812-e2838ecc20f8", "description":
-      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "started_at": "2025-01-29T10:22:21.264224+00:00",
-      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
-    method: POST
-  response:
-    body: '{"snapshot": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "creation_date": "2025-01-29T10:22:20.918566+00:00",
-      "modification_date": "2025-01-29T10:22:20.918566+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 20000000000, "state":
-      "available", "base_volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name":
-      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "7c75e97d-bc60-4409-a812-e2838ecc20f8", "description":
-      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
-      "snapshots/173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "started_at": "2025-01-29T10:22:21.264224+00:00",
-      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "847"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d8f021f-4c17-474f-8fa8-1a56ec6a8cdf
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
-    method: POST
-  response:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
-      false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "607"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:21 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/0ea456b2-61dd-4fc5-be61-1a4348c2c5a3
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d60c976-2df2-43fc-b415-fa87003c8c28
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol", "volume_type": "b_ssd",
-      "size": 20000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/0ea456b2-61dd-4fc5-be61-1a4348c2c5a3
-    method: PATCH
-  response:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol", "volume_type": "b_ssd",
-      "size": 20000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
-      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 29 Jan 2025 10:22:21 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4a634a78-3b2f-442f-8c8e-78b36283d5b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes",
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-serene-archimedes", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "149590ae-d115-41dd-99ac-310c02882658",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:7f:01",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "bootscript": null,
-      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/cbac7b10-174f-4465-94f8-ed394de7d17c/detach-volume
+    method: POST
+  response:
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
+    headers:
+      Content-Length:
+      - "2161"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb8fea7e-fbd6-49d8-b0bf-d80c3686ca5f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c125304-e5d7-4262-a809-85ca86d6def8
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/cbac7b10-174f-4465-94f8-ed394de7d17c
     method: GET
   response:
-    body: '{"server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes",
+    body: '{"server": {"id": "cbac7b10-174f-4465-94f8-ed394de7d17c", "name": "cli-srv-bold-chatelet",
       "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "hostname": "cli-srv-serene-archimedes", "image": {"id": "bc50e86c-a6c7-401a-8fbb-2ef17ce87aee",
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-bold-chatelet", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
       "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
-      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "f1efdd5c-375b-431e-ac06-daaf1518369b",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "unified", "size": 10000000000},
-      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2024-10-07T11:39:08.941837+00:00",
-      "modification_date": "2024-10-07T11:39:08.941837+00:00", "default_bootscript":
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
-      "volumes": {"0": {"boot": false, "id": "149590ae-d115-41dd-99ac-310c02882658",
-      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
-      null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": {"id": "4c125304-e5d7-4262-a809-85ca86d6def8", "name": "cli-srv-serene-archimedes"},
-      "size": 20000000000, "state": "available", "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "tags": [], "zone":
-      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
-      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:90:7f:01",
-      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
-      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-01-29T10:22:20.015769+00:00",
-      "modification_date": "2025-01-29T10:22:20.015769+00:00", "bootscript": null,
-      "security_group": {"id": "0fe819c3-274d-472a-b3f5-ddb258d2d8bb", "name": "Default
-      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
-      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1"}}'
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"},
+      "public_ips": [{"id": "4edebbd5-3cf5-4456-a7bc-5740fd941af6", "address": "51.15.231.168",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "e09def23-d7b0-4ef6-b2bd-0524c8d823ee"}],
+      "mac_address": "de:00:00:c0:77:9b", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:15.195480+00:00", "modification_date":
+      "2025-07-22T15:32:15.195480+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "2139"
+      - "2161"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:21 GMT
+      - Tue, 22 Jul 2025 15:32:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1945,7 +1909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bff8fd1-1a2b-4894-88eb-fc230cd68b58
+      - 2dce551e-a263-4690-8346-7714629f0d90
     status: 200 OK
     code: 200
     duration: ""
@@ -1954,8 +1918,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4c125304-e5d7-4262-a809-85ca86d6def8
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/cbac7b10-174f-4465-94f8-ed394de7d17c
     method: DELETE
   response:
     body: ""
@@ -1965,9 +1929,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:21 GMT
+      - Tue, 22 Jul 2025 15:32:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1975,29 +1939,29 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 114605d9-47cf-411c-87e5-b8d83337ed95
+      - 84a0aeb2-4efc-4f06-92ed-7e461568046a
     status: 204 No Content
     code: 204
     duration: ""
 - request:
-    body: '{"volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name": "Ubuntu
+    body: '{"volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name": "Ubuntu
       22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": null, "size": 20000000000, "state": "available", "creation_date":
-      "2025-01-29T10:22:20.015769+00:00", "modification_date": "2025-01-29T10:22:21.965643+00:00",
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:15.195480+00:00", "modification_date": "2025-07-22T15:32:15.776222+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/149590ae-d115-41dd-99ac-310c02882658
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89954d20-7fb4-495e-a78d-253a488861cd
     method: GET
   response:
-    body: '{"volume": {"id": "149590ae-d115-41dd-99ac-310c02882658", "name": "Ubuntu
+    body: '{"volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name": "Ubuntu
       22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
-      "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "server": null, "size": 20000000000, "state": "available", "creation_date":
-      "2025-01-29T10:22:20.015769+00:00", "modification_date": "2025-01-29T10:22:21.965643+00:00",
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:15.195480+00:00", "modification_date": "2025-07-22T15:32:15.776222+00:00",
       "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
@@ -2007,9 +1971,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2017,29 +1981,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72cbad53-e707-4ea3-b531-78435131ddf8
+      - a666cf5d-756d-4564-9f23-eaa557a56a6d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"snapshot": {"id": "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:16.586052+00:00",
+      "modification_date": "2025-07-22T15:32:16.586052+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "50ccf648-1904-483a-ada2-650bc6b9ad27", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ed47263f-b747-4c96-abd1-7e0429196fa7", "started_at": "2025-07-22T15:32:16.858812+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/149590ae-d115-41dd-99ac-310c02882658
-    method: DELETE
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
   response:
-    body: ""
+    body: '{"snapshot": {"id": "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:16.586052+00:00",
+      "modification_date": "2025-07-22T15:32:16.586052+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "50ccf648-1904-483a-ada2-650bc6b9ad27", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ed47263f-b747-4c96-abd1-7e0429196fa7", "started_at": "2025-07-22T15:32:16.858812+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
     headers:
+      Content-Length:
+      - "832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2047,45 +2033,1611 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8883dc5-66de-453f-90a2-ea888be065db
-    status: 204 No Content
-    code: 204
+      - 74df4cde-6d05-414c-b5d0-5bef61e1f5f8
+    status: 201 Created
+    code: 201
     duration: ""
 - request:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol", "volume_type": "b_ssd",
-      "size": 20000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
+    body: '{"snapshot": {"id": "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:16.586052+00:00",
+      "modification_date": "2025-07-22T15:32:16.586052+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/ed47263f-b747-4c96-abd1-7e0429196fa7
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:16.586052+00:00",
+      "modification_date": "2025-07-22T15:32:16.586052+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "89954d20-7fb4-495e-a78d-253a488861cd", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}}'
+    headers:
+      Content-Length:
+      - "521"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20f2326f-d690-4302-8a29-2198d44d7d2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
+  response:
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
+    headers:
+      Content-Length:
+      - "39208"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:17 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b992ec7a-1dd6-40f3-b3b9-fa90641caf72
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    headers:
+      Content-Length:
+      - "19730"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:17 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4a49073-9f99-4598-9b06-ee27507b6625
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 397a2080-18d1-4b67-8c9b-4f5b948662f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/0ea456b2-61dd-4fc5-be61-1a4348c2c5a3
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cf1c79e-46b5-40d7-8eaa-51f76f099837
     method: GET
   response:
-    body: '{"image": {"id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3", "name": "cli-img-pedantic-wiles",
-      "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "root_volume": {"id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd", "name": "cli-snp-hungry-taussig",
-      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
-      "eee73521-749a-47f5-80ff-b617578a6af1", "name": "snapVol", "volume_type": "b_ssd",
-      "size": 20000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-01-29T10:22:21.476820+00:00",
-      "modification_date": "2025-01-29T10:22:21.476820+00:00", "default_bootscript":
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
       null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
     headers:
       Content-Length:
-      - "722"
+      - "618"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2093,7 +3645,363 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a47446b4-3fd3-4c09-9cb6-84f0ecc5a882
+      - a7eb75e4-6b8a-441a-91c0-f0021faf03a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-fervent-shannon", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:c0:77:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "bootscript": null,
+      "security_group": {"id": "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-fervent-shannon", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:c0:77:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "bootscript": null,
+      "security_group": {"id": "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:17 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1dae96c7-ea92-41a3-9793-06afe583cd41
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ea1e475-f407-45ea-b717-868fcdadeb94
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4b88e773-60fe-4afd-92c6-f22bcab69fd0
+    method: GET
+  response:
+    body: '{"volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "527"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4946dc40-6736-489e-91c9-a779378552de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:17.924196+00:00",
+      "modification_date": "2025-07-22T15:32:17.924196+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "f9ec98c3-ef6c-43eb-8fdd-f266690eb1b8", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ac2f2110-81f6-49b7-a758-22df9c98078c", "started_at": "2025-07-22T15:32:18.216402+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:17.924196+00:00",
+      "modification_date": "2025-07-22T15:32:17.924196+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 20000000000, "state":
+      "available", "base_volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": [], "zone": "fr-par-1", "error_details":
+      null}, "task": {"id": "f9ec98c3-ef6c-43eb-8fdd-f266690eb1b8", "description":
+      "volume_snapshot", "status": "pending", "href_from": "/snapshots", "href_result":
+      "snapshots/ac2f2110-81f6-49b7-a758-22df9c98078c", "started_at": "2025-07-22T15:32:18.216402+00:00",
+      "terminated_at": null, "progress": 0, "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "843"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea6acfde-c994-4a3e-bad8-ef650e4ba388
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
+      false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
+    method: POST
+  response:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {}, "public":
+      false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "602"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b387b0dc-f00f-47c8-9e4e-cba700f447ef
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 265b4112-0a2c-41bc-9283-9f1a6a42dc0d
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
+      "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol", "volume_type": "l_ssd",
+      "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b387b0dc-f00f-47c8-9e4e-cba700f447ef
+    method: PATCH
+  response:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
+      "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol", "volume_type": "l_ssd",
+      "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 770d2f8c-e1c4-4dfa-8281-a6467018ed8d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-fervent-shannon", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:c0:77:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "bootscript": null,
+      "security_group": {"id": "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1dae96c7-ea92-41a3-9793-06afe583cd41
+    method: GET
+  response:
+    body: '{"server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-fervent-shannon", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "1dae96c7-ea92-41a3-9793-06afe583cd41", "name": "cli-srv-fervent-shannon"},
+      "size": 20000000000, "state": "available", "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": null, "public_ips": [], "mac_address": "de:00:00:c0:77:9f",
+      "routed_ip_enabled": true, "ipv6": null, "extra_networks": [], "dynamic_ip_required":
+      false, "enable_ipv6": false, "private_ip": null, "creation_date": "2025-07-22T15:32:17.503296+00:00",
+      "modification_date": "2025-07-22T15:32:17.503296+00:00", "bootscript": null,
+      "security_group": {"id": "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default
+      security group"}, "location": null, "maintenances": [], "allowed_actions": ["poweron",
+      "backup"], "placement_group": null, "private_nics": [], "zone": "fr-par-1",
+      "filesystems": [], "end_of_service": false}}'
+    headers:
+      Content-Length:
+      - "2175"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6be1b23a-ed0c-450b-a051-d445fef68065
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,8 +4010,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/0ea456b2-61dd-4fc5-be61-1a4348c2c5a3
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1dae96c7-ea92-41a3-9793-06afe583cd41
     method: DELETE
   response:
     body: ""
@@ -2113,9 +4021,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2123,7 +4031,155 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 451f0c10-cb40-4f5e-95be-1d08b01bec03
+      - 2128a14e-2185-48cc-9ece-b415c880b90f
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 20000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:17.503296+00:00", "modification_date": "2025-07-22T15:32:18.686557+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4b88e773-60fe-4afd-92c6-f22bcab69fd0
+    method: GET
+  response:
+    body: '{"volume": {"id": "4b88e773-60fe-4afd-92c6-f22bcab69fd0", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 20000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:17.503296+00:00", "modification_date": "2025-07-22T15:32:18.686557+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 755cc411-865e-40b8-9c70-e2fe17d7c53f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4b88e773-60fe-4afd-92c6-f22bcab69fd0
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c689b3d4-ba39-4c72-b72b-07f142c1f3c1
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
+      "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol", "volume_type": "l_ssd",
+      "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b387b0dc-f00f-47c8-9e4e-cba700f447ef
+    method: GET
+  response:
+    body: '{"image": {"id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef", "name": "cli-img-admiring-borg",
+      "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "root_volume": {"id": "ac2f2110-81f6-49b7-a758-22df9c98078c", "name": "cli-snp-cool-moser",
+      "volume_type": "l_ssd", "size": 20000000000}, "extra_volumes": {"1": {"id":
+      "ed47263f-b747-4c96-abd1-7e0429196fa7", "name": "snapVol", "volume_type": "l_ssd",
+      "size": 10000000000}}, "public": false, "arch": "x86_64", "creation_date": "2025-07-22T15:32:18.340959+00:00",
+      "modification_date": "2025-07-22T15:32:18.340959+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c481108-1842-4feb-a292-e0064af90d7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/b387b0dc-f00f-47c8-9e4e-cba700f447ef
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fda653df-8bfd-4d5e-867b-88524aae1c41
     status: 204 No Content
     code: 204
     duration: ""
@@ -2132,8 +4188,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/173dd9a3-ac95-4070-b4b0-4a812a9c13fd
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/ac2f2110-81f6-49b7-a758-22df9c98078c
     method: DELETE
   response:
     body: ""
@@ -2143,9 +4199,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2153,7 +4209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd374fb2-c7f3-4d5c-8543-f358caa86fb0
+      - 34be9493-fb54-4fb3-bba5-366b989e7ef7
     status: 204 No Content
     code: 204
     duration: ""
@@ -2162,8 +4218,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eee73521-749a-47f5-80ff-b617578a6af1
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/ed47263f-b747-4c96-abd1-7e0429196fa7
     method: DELETE
   response:
     body: ""
@@ -2173,9 +4229,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2183,7 +4239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9010237-bbfb-4174-a471-3bdd86804c57
+      - e6c59fd6-c146-44ac-bfcb-9359a070e800
     status: 204 No Content
     code: 204
     duration: ""
@@ -2192,8 +4248,8 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.23.4; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/172a921f-8972-4f7f-843b-bec6ed2e64ee
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/89954d20-7fb4-495e-a78d-253a488861cd
     method: DELETE
   response:
     body: ""
@@ -2203,9 +4259,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 29 Jan 2025 10:22:22 GMT
+      - Tue, 22 Jul 2025 15:32:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-2;edge02)
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2213,7 +4269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b98184da-2c72-48ec-8431-845894e0c9e7
+      - f54e93e0-2946-4fad-9a6c-0c36e0c28726
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-image-update-add-extra-volume.golden
+++ b/internal/namespaces/instance/v1/testdata/test-image-update-add-extra-volume.golden
@@ -1,34 +1,34 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-Image.ID                0ea456b2-61dd-4fc5-be61-1a4348c2c5a3
-Image.Name              cli-img-pedantic-wiles
+Image.ID                b387b0dc-f00f-47c8-9e4e-cba700f447ef
+Image.Name              cli-img-admiring-borg
 Image.Arch              x86_64
 Image.CreationDate      few seconds ago
 Image.ModificationDate  few seconds ago
 Image.ExtraVolumes      1
 Image.FromServer        -
-Image.Organization      ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
+Image.Organization      fa1e3217-dc80-42ac-85c3-3f034b78b552
 Image.Public            false
-Image.RootVolume        173dd9a3-ac95-4070-b4b0-4a812a9c13fd
+Image.RootVolume        ac2f2110-81f6-49b7-a758-22df9c98078c
 Image.State             available
-Image.Project           ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
+Image.Project           fa1e3217-dc80-42ac-85c3-3f034b78b552
 Image.Zone              fr-par-1
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
   "image": {
-    "id": "0ea456b2-61dd-4fc5-be61-1a4348c2c5a3",
-    "name": "cli-img-pedantic-wiles",
+    "id": "b387b0dc-f00f-47c8-9e4e-cba700f447ef",
+    "name": "cli-img-admiring-borg",
     "arch": "x86_64",
     "creation_date": "1970-01-01T00:00:00.0Z",
     "modification_date": "1970-01-01T00:00:00.0Z",
     "default_bootscript": null,
     "extra_volumes": {
       "1": {
-        "id": "eee73521-749a-47f5-80ff-b617578a6af1",
+        "id": "ed47263f-b747-4c96-abd1-7e0429196fa7",
         "name": "snapVol",
         "export_uri": null,
-        "size": 20000000000,
-        "volume_type": "b_ssd",
+        "size": 10000000000,
+        "volume_type": "l_ssd",
         "creation_date": null,
         "modification_date": null,
         "organization": "",
@@ -40,16 +40,16 @@ Image.Zone              fr-par-1
       }
     },
     "from_server": "",
-    "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+    "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
     "public": false,
     "root_volume": {
-      "id": "173dd9a3-ac95-4070-b4b0-4a812a9c13fd",
-      "name": "cli-snp-hungry-taussig",
+      "id": "ac2f2110-81f6-49b7-a758-22df9c98078c",
+      "name": "cli-snp-cool-moser",
       "size": 20000000000,
       "volume_type": "l_ssd"
     },
     "state": "available",
-    "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+    "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
     "tags": [],
     "zone": "fr-par-1"
   }

--- a/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-name.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-name.cassette.yaml
@@ -2,38 +2,1604 @@
 version: 1
 interactions:
 - request:
-    body: '{"volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.932832+00:00", "modification_date":
-      "2023-12-14T14:00:00.932832+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
-    method: POST
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
   response:
-    body: '{"volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.932832+00:00", "modification_date":
-      "2023-12-14T14:00:00.932832+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     headers:
       Content-Length:
-      - "430"
+      - "39208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:00 GMT
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34105eec-9063-4351-9080-efd6f7c06fb9
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    headers:
+      Content-Length:
+      - "19730"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9830e29f-fff0-41bd-84d2-05be3247eb57
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c18cb6c-e00f-4718-983d-7d38a7c7adee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cf1c79e-46b5-40d7-8eaa-51f76f099837
+    method: GET
+  response:
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "618"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cf7b7956-be16-4610-899f-160800a86599
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}}'
+    headers:
+      Content-Length:
+      - "363"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dfc990a0-2ba8-405d-807b-b4ce02cf484e
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/da64854c-83be-4cd6-bdc1-1ca3bfa5b844
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -41,91 +1607,95 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50908e88-6f10-43b0-b92a-3d313540a08f
+      - 5ec37af9-4015-4eb6-8142-1e00a1770b51
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.932832+00:00", "modification_date":
-      "2023-12-14T14:00:00.932832+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dfc990a0-2ba8-405d-807b-b4ce02cf484e
-    method: GET
-  response:
-    body: '{"volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.932832+00:00", "modification_date":
-      "2023-12-14T14:00:00.932832+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "430"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f55d982d-fbad-4645-b435-9ed192687a9c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.150505+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "0ce29c7c-5415-4720-acd5-baf08a0026af", "description":
-      "snapshot_0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "status": "pending", "href_from":
-      "/snapshots", "href_result": "snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad",
-      "started_at": "2023-12-14T14:00:01.655761+00:00", "terminated_at": null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "36de93d9-7385-4e94-a595-1eb8240f4704",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:29.021936+00:00",
+      "modification_date": "2025-07-22T15:32:29.021936+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.150505+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "0ce29c7c-5415-4720-acd5-baf08a0026af", "description":
-      "snapshot_0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "status": "pending", "href_from":
-      "/snapshots", "href_result": "snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad",
-      "started_at": "2023-12-14T14:00:01.655761+00:00", "terminated_at": null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "36de93d9-7385-4e94-a595-1eb8240f4704",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:29.021936+00:00",
+      "modification_date": "2025-07-22T15:32:29.021936+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "844"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/076d6e13-7ee6-48d0-876e-0029186f1e71
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,45 +1703,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efce2842-a69e-4d61-94ac-5c6feedb060c
+      - 07e926b5-21fc-4bdd-8e2d-269cac6778f7
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:29.021936+00:00",
+      "modification_date": "2025-07-22T15:32:29.021936+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
-    method: PATCH
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/36de93d9-7385-4e94-a595-1eb8240f4704
+    method: GET
   response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:29.021936+00:00",
+      "modification_date": "2025-07-22T15:32:29.021936+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
     headers:
       Content-Length:
-      - "546"
+      - "527"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -179,43 +1747,81 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33bd0231-fc83-4066-9cef-44023ec42f28
+      - 60210055-cbdc-4613-8f79-e9b607917d35
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
-    method: GET
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/076d6e13-7ee6-48d0-876e-0029186f1e71/detach-volume
+    method: POST
   response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "546"
+      - "2161"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:02 GMT
+      - Tue, 22 Jul 2025 15:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -223,43 +1829,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45276ce3-4d97-4d19-a914-247112885eeb
+      - 9f09ee6a-e558-4e44-adf0-954cb9f0a4d3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/076d6e13-7ee6-48d0-876e-0029186f1e71
     method: GET
   response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "076d6e13-7ee6-48d0-876e-0029186f1e71", "name": "cli-srv-blissful-turing",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-blissful-turing", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"},
+      "public_ips": [{"id": "da64854c-83be-4cd6-bdc1-1ca3bfa5b844", "address": "51.15.208.2",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "22116e03-04e5-4e19-af94-7c626b907fcf"}],
+      "mac_address": "de:00:00:c0:77:a9", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:29.021936+00:00", "modification_date":
+      "2025-07-22T15:32:29.021936+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "546"
+      - "2161"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:07 GMT
+      - Tue, 22 Jul 2025 15:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -267,93 +1909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23d258fb-ec7d-48ee-aab3-2f2bceb43b95
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:01.925156+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "546"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40469a77-808f-49e5-88e7-6873af9162f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:16.107061+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name":
-      "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details": null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad", "name": "cli-test-snapshot-update-name-updated",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.150505+00:00",
-      "modification_date": "2023-12-14T14:00:16.107061+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e", "name":
-      "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "543"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19d44280-f617-4446-96d9-5cd88be77713
+      - 1482c922-e2f0-479c-b8c4-7704ccaba653
     status: 200 OK
     code: 200
     duration: ""
@@ -362,18 +1918,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0d4bb79c-06ef-4fa1-809c-d103cb1efdad
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/076d6e13-7ee6-48d0-876e-0029186f1e71
     method: DELETE
   response:
     body: ""
     headers:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
+      - Tue, 22 Jul 2025 15:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,7 +1939,223 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c55d6ee0-5293-4a2e-b1ce-a508f00b4d3a
+      - 956f538a-c77b-444a-9b61-ca7e029713d7
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:29.021936+00:00", "modification_date": "2025-07-22T15:32:29.676424+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/36de93d9-7385-4e94-a595-1eb8240f4704
+    method: GET
+  response:
+    body: '{"volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:29.021936+00:00", "modification_date": "2025-07-22T15:32:29.676424+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42c1b466-1aa7-48db-a96c-192f15c88e28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.671345+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}, "task": {"id": "52c8b88d-e8ea-424f-b4ad-8f2da841f232",
+      "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots",
+      "href_result": "snapshots/3b05ac16-ad9f-468b-beb7-63c68671ebf7", "started_at":
+      "2025-07-22T15:32:30.880307+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.671345+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}, "task": {"id": "52c8b88d-e8ea-424f-b4ad-8f2da841f232",
+      "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots",
+      "href_result": "snapshots/3b05ac16-ad9f-468b-beb7-63c68671ebf7", "started_at":
+      "2025-07-22T15:32:30.880307+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "866"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20ad85b0-e72b-4dd3-8eaf-05d83f9e72a4
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name-updated",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.958543+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/3b05ac16-ad9f-468b-beb7-63c68671ebf7
+    method: PATCH
+  response:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name-updated",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.958543+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}}'
+    headers:
+      Content-Length:
+      - "563"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8ef3232-8085-4c33-bb87-f4cda1a5fb11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name-updated",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.958543+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/3b05ac16-ad9f-468b-beb7-63c68671ebf7
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7", "name": "cli-test-snapshot-update-name-updated",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:30.671345+00:00",
+      "modification_date": "2025-07-22T15:32:30.958543+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "36de93d9-7385-4e94-a595-1eb8240f4704", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}}'
+    headers:
+      Content-Length:
+      - "563"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ae6a1a3-49a7-4398-a5ff-43fff16afb23
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/3b05ac16-ad9f-468b-beb7-63c68671ebf7
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c0736b7-77cd-4459-8d09-116cc60be5f6
     status: 204 No Content
     code: 204
     duration: ""
@@ -390,18 +2164,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/dfc990a0-2ba8-405d-807b-b4ce02cf484e
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/36de93d9-7385-4e94-a595-1eb8240f4704
     method: DELETE
   response:
     body: ""
     headers:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
+      - Tue, 22 Jul 2025 15:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -409,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f60ccc-f5e4-4684-87aa-7510b95aeb7c
+      - 52a20300-b193-4bfb-9f50-521adb9716a6
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-name.golden
+++ b/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-name.golden
@@ -1,35 +1,35 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-ID                0d4bb79c-06ef-4fa1-809c-d103cb1efdad
+ID                3b05ac16-ad9f-468b-beb7-63c68671ebf7
 Name              cli-test-snapshot-update-name-updated
-Organization      ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
-Project           ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
+Organization      fa1e3217-dc80-42ac-85c3-3f034b78b552
+Project           fa1e3217-dc80-42ac-85c3-3f034b78b552
 Tags.0            foo
 Tags.1            bar
-VolumeType        b_ssd
+VolumeType        l_ssd
 Size              10 GB
 State             available
-BaseVolume.ID     dfc990a0-2ba8-405d-807b-b4ce02cf484e
-BaseVolume.Name   cli-test
+BaseVolume.ID     36de93d9-7385-4e94-a595-1eb8240f4704
+BaseVolume.Name   Ubuntu 22.04 Jammy Jellyfish
 CreationDate      few seconds ago
 ModificationDate  few seconds ago
 Zone              fr-par-1
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
-  "id": "0d4bb79c-06ef-4fa1-809c-d103cb1efdad",
+  "id": "3b05ac16-ad9f-468b-beb7-63c68671ebf7",
   "name": "cli-test-snapshot-update-name-updated",
-  "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-  "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+  "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+  "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
   "tags": [
     "foo",
     "bar"
   ],
-  "volume_type": "b_ssd",
+  "volume_type": "l_ssd",
   "size": 10000000000,
   "state": "available",
   "base_volume": {
-    "id": "dfc990a0-2ba8-405d-807b-b4ce02cf484e",
-    "name": "cli-test"
+    "id": "36de93d9-7385-4e94-a595-1eb8240f4704",
+    "name": "Ubuntu 22.04 Jammy Jellyfish"
   },
   "creation_date": "1970-01-01T00:00:00.0Z",
   "modification_date": "1970-01-01T00:00:00.0Z",

--- a/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-tags.cassette.yaml
+++ b/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-tags.cassette.yaml
@@ -2,38 +2,1604 @@
 version: 1
 interactions:
 - request:
-    body: '{"volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.949529+00:00", "modification_date":
-      "2023-12-14T14:00:00.949529+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
-    method: POST
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
   response:
-    body: '{"volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.949529+00:00", "modification_date":
-      "2023-12-14T14:00:00.949529+00:00", "tags": [], "zone": "fr-par-1"}}'
+    body: '{"servers": {"COPARM1-16C-64G": {"alt_names": [], "arch": "arm64", "ncpus":
+      16, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 252.14,
+      "hourly_price": 0.3454, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 671088640, "end_of_service": false}, "COPARM1-2C-8G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 31.1, "hourly_price": 0.0426, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "COPARM1-32C-128G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 506.26, "hourly_price": 0.6935, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 1342177280, "end_of_service": false}, "COPARM1-4C-16G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 62.56, "hourly_price": 0.0857, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "COPARM1-8C-32G": {"alt_names":
+      [], "arch": "arm64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 125.85, "hourly_price": 0.1724, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 335544320, "end_of_service": false}, "DEV1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 80000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 36.1496, "hourly_price":
+      0.04952, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 209715200,
+      "end_of_service": false}, "DEV1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      3, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 40000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 18.6588, "hourly_price": 0.02556, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 157286400, "end_of_service": false}, "DEV1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 20000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 9.9864, "hourly_price": 0.01368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 104857600,
+      "end_of_service": false}, "DEV1-XL": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 12884901888, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 120000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 53.3484, "hourly_price": 0.07308, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "ENT1-2XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 96, "ram": 412316860416, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 2576.9, "hourly_price": 3.53, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 20000000000, "sum_internet_bandwidth": 20000000000,
+      "interfaces": [{"internal_bandwidth": 20000000000, "internet_bandwidth": 20000000000}]},
+      "block_bandwidth": 21474836480, "end_of_service": true}, "ENT1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": true}, "ENT1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": true}, "ENT1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": true}, "ENT1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": true}, "ENT1-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.655, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": true}, "GP1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 576.262,
+      "hourly_price": 0.7894, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 1073741824, "end_of_service": false}, "GP1-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 296.672,
+      "hourly_price": 0.4064, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "GP1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      300000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 149.066,
+      "hourly_price": 0.2042, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "GP1-XL": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 48, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      600000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 1220.122,
+      "hourly_price": 1.6714, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 2147483648, "end_of_service": false}, "GP1-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      150000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 74.168, "hourly_price":
+      0.1016, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      500000000, "sum_internet_bandwidth": 500000000, "interfaces": [{"internal_bandwidth":
+      500000000, "internet_bandwidth": 500000000}]}, "block_bandwidth": 314572800,
+      "end_of_service": false}, "L4-1-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      8, "ram": 51539607552, "gpu": 1, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 547.5,
+      "hourly_price": 0.75, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2500000000, "sum_internet_bandwidth": 2500000000, "interfaces": [{"internal_bandwidth":
+      2500000000, "internet_bandwidth": 2500000000}]}, "block_bandwidth": 1048576000,
+      "end_of_service": false}, "L4-2-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      16, "ram": 103079215104, "gpu": 2, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1095.0,
+      "hourly_price": 1.5, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      5000000000, "sum_internet_bandwidth": 5000000000, "interfaces": [{"internal_bandwidth":
+      5000000000, "internet_bandwidth": 5000000000}]}, "block_bandwidth": 1572864000,
+      "end_of_service": false}, "L4-4-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      32, "ram": 206158430208, "gpu": 4, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 2190.0,
+      "hourly_price": 3.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      10000000000, "sum_internet_bandwidth": 10000000000, "interfaces": [{"internal_bandwidth":
+      10000000000, "internet_bandwidth": 10000000000}]}, "block_bandwidth": 2621440000,
+      "end_of_service": false}, "L4-8-24G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      64, "ram": 412316860416, "gpu": 8, "gpu_info": {"gpu_manufacturer": "NVIDIA",
+      "gpu_name": "L4", "gpu_memory": 25769803776}, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 4380.0,
+      "hourly_price": 6.0, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      20000000000, "sum_internet_bandwidth": 20000000000, "interfaces": [{"internal_bandwidth":
+      20000000000, "internet_bandwidth": 20000000000}]}, "block_bandwidth": 5242880000,
+      "end_of_service": false}, "PLAY2-MICRO": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 39.42, "hourly_price": 0.054, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 167772160, "end_of_service": false}, "PLAY2-NANO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 19.71, "hourly_price": 0.027, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 83886080, "end_of_service": false}, "PLAY2-PICO": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 1, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 10.22, "hourly_price": 0.014, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": false}, "POP2-16C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 430.7, "hourly_price": 0.59, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-16C-64G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1063.391, "hourly_price":
+      1.4567, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-2C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 53.66, "hourly_price": 0.0735, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-2C-8G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 133.079, "hourly_price": 0.1823, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-32C-128G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 861.4, "hourly_price": 1.18, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-32C-128G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2126.709, "hourly_price":
+      2.9133, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-48C-192G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 48, "ram": 206158430208, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 1274.4, "hourly_price": 1.77, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 12}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 9600000000, "sum_internet_bandwidth": 9600000000,
+      "interfaces": [{"internal_bandwidth": 9600000000, "internet_bandwidth": 9600000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-4C-16G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 107.31, "hourly_price": 0.147, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-4C-16G-WIN": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 265.501, "hourly_price": 0.3637, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-64C-256G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 64, "ram": 274877906944, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 1715.5, "hourly_price": 2.35, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 16}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 12800000000, "sum_internet_bandwidth": 12800000000,
+      "interfaces": [{"internal_bandwidth": 12800000000, "internet_bandwidth": 12800000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-8C-32G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 211.7, "hourly_price": 0.29, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-8C-32G-WIN":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0,
+      "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size": 0,
+      "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 528.009, "hourly_price":
+      0.7233, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1600000000, "sum_internet_bandwidth": 1600000000, "interfaces": [{"internal_bandwidth":
+      1600000000, "internet_bandwidth": 1600000000}]}, "block_bandwidth": 1677721600,
+      "end_of_service": false}, "POP2-HC-16C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 16, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile":
+      null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 310.69, "hourly_price": 0.4256, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 4}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3200000000, "sum_internet_bandwidth": 3200000000,
+      "interfaces": [{"internal_bandwidth": 3200000000, "internet_bandwidth": 3200000000}]},
+      "block_bandwidth": 3355443200, "end_of_service": false}, "POP2-HC-2C-4G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 38.84, "hourly_price": 0.0532, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HC-32C-64G": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 621.38, "hourly_price": 0.8512, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 8}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6400000000, "sum_internet_bandwidth": 6400000000,
+      "interfaces": [{"internal_bandwidth": 6400000000, "internet_bandwidth": 6400000000}]},
+      "block_bandwidth": 5905580032, "end_of_service": false}, "POP2-HC-48C-96G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 48, "ram": 103079215104, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 914.4, "hourly_price":
+      1.27, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-4C-8G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 77.67, "hourly_price": 0.1064, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HC-64C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1242.75, "hourly_price":
+      1.7024, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HC-8C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 155.34, "hourly_price": 0.2128, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HM-16C-128G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 16, "ram": 137438953472, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 601.52, "hourly_price":
+      0.824, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 4}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      3200000000, "sum_internet_bandwidth": 3200000000, "interfaces": [{"internal_bandwidth":
+      3200000000, "internet_bandwidth": 3200000000}]}, "block_bandwidth": 3355443200,
+      "end_of_service": false}, "POP2-HM-2C-16G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 2, "ram": 17179869184, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 75.19, "hourly_price": 0.103, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 400000000, "sum_internet_bandwidth": 400000000,
+      "interfaces": [{"internal_bandwidth": 400000000, "internet_bandwidth": 400000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HM-32C-256G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 32, "ram": 274877906944, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 1203.04, "hourly_price":
+      1.648, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 8}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      6400000000, "sum_internet_bandwidth": 6400000000, "interfaces": [{"internal_bandwidth":
+      6400000000, "internet_bandwidth": 6400000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}}}'
     headers:
       Content-Length:
-      - "430"
+      - "39208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:00 GMT
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90c60e9a-90e9-41f8-8afa-5d4f466f7922
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers": {"POP2-HM-48C-384G": {"alt_names": [], "arch": "x86_64", "ncpus":
+      48, "ram": 412316860416, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size":
+      0, "max_size": 0}}, "scratch_storage_max_size": null, "monthly_price": 1778.4,
+      "hourly_price": 2.47, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 12}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      9600000000, "sum_internet_bandwidth": 9600000000, "interfaces": [{"internal_bandwidth":
+      9600000000, "internet_bandwidth": 9600000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-4C-32G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 4, "ram": 34359738368, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 150.38, "hourly_price": 0.206, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 800000000, "sum_internet_bandwidth": 800000000,
+      "interfaces": [{"internal_bandwidth": 800000000, "internet_bandwidth": 800000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HM-64C-512G":
+      {"alt_names": [], "arch": "x86_64", "ncpus": 64, "ram": 549755813888, "gpu":
+      0, "gpu_info": null, "mig_profile": null, "volumes_constraint": {"min_size":
+      0, "max_size": 0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size":
+      0}}, "scratch_storage_max_size": null, "monthly_price": 2406.08, "hourly_price":
+      3.296, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": false, "private_network":
+      8, "max_file_systems": 16}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      12800000000, "sum_internet_bandwidth": 12800000000, "interfaces": [{"internal_bandwidth":
+      12800000000, "internet_bandwidth": 12800000000}]}, "block_bandwidth": 5905580032,
+      "end_of_service": false}, "POP2-HM-8C-64G": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 8, "ram": 68719476736, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 300.76, "hourly_price": 0.412, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 2}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1600000000, "sum_internet_bandwidth": 1600000000,
+      "interfaces": [{"internal_bandwidth": 1600000000, "internet_bandwidth": 1600000000}]},
+      "block_bandwidth": 1677721600, "end_of_service": false}, "POP2-HN-10": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 530.29, "hourly_price": 0.7264, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 10000000000, "sum_internet_bandwidth": 10000000000,
+      "interfaces": [{"internal_bandwidth": 10000000000, "internet_bandwidth": 10000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "POP2-HN-3": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 4294967296, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 186.49, "hourly_price": 0.2554, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 419430400, "end_of_service": false}, "POP2-HN-5": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 330.29, "hourly_price": 0.4524, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 1}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 5000000000, "sum_internet_bandwidth": 5000000000,
+      "interfaces": [{"internal_bandwidth": 5000000000, "internet_bandwidth": 5000000000}]},
+      "block_bandwidth": 838860800, "end_of_service": false}, "PRO2-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 32, "ram": 137438953472, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 640.21, "hourly_price": 0.877, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 6000000000, "sum_internet_bandwidth": 6000000000,
+      "interfaces": [{"internal_bandwidth": 6000000000, "internet_bandwidth": 6000000000}]},
+      "block_bandwidth": 2097152000, "end_of_service": false}, "PRO2-M": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 16, "ram": 68719476736, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 319.74, "hourly_price": 0.438, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 3000000000, "sum_internet_bandwidth": 3000000000,
+      "interfaces": [{"internal_bandwidth": 3000000000, "internet_bandwidth": 3000000000}]},
+      "block_bandwidth": 1048576000, "end_of_service": false}, "PRO2-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 34359738368, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 159.87, "hourly_price": 0.219, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1500000000, "sum_internet_bandwidth": 1500000000,
+      "interfaces": [{"internal_bandwidth": 1500000000, "internet_bandwidth": 1500000000}]},
+      "block_bandwidth": 524288000, "end_of_service": false}, "PRO2-XS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 4, "ram": 17179869184, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      0}, "per_volume_constraint": {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size":
+      null, "monthly_price": 80.3, "hourly_price": 0.11, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 700000000, "sum_internet_bandwidth": 700000000,
+      "interfaces": [{"internal_bandwidth": 700000000, "internet_bandwidth": 700000000}]},
+      "block_bandwidth": 262144000, "end_of_service": false}, "PRO2-XXS": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 0}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 0, "max_size": 0}}, "scratch_storage_max_size": null,
+      "monthly_price": 40.15, "hourly_price": 0.055, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      false, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 350000000, "sum_internet_bandwidth": 350000000,
+      "interfaces": [{"internal_bandwidth": 350000000, "internet_bandwidth": 350000000}]},
+      "block_bandwidth": 131072000, "end_of_service": false}, "RENDER-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 45097156608, "gpu": 1, "gpu_info":
+      {"gpu_manufacturer": "NVIDIA", "gpu_name": "P100", "gpu_memory": 17179869184},
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 400000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 907.098, "hourly_price":
+      1.2426, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      2000000000, "sum_internet_bandwidth": 2000000000, "interfaces": [{"internal_bandwidth":
+      2000000000, "internet_bandwidth": 2000000000}]}, "block_bandwidth": 2147483648,
+      "end_of_service": false}, "STARDUST1-S": {"alt_names": [], "arch": "x86_64",
+      "ncpus": 1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null,
+      "volumes_constraint": {"min_size": 0, "max_size": 10000000000}, "per_volume_constraint":
+      {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 3.3507, "hourly_price": 0.00459, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 52428800, "end_of_service": false}, "START1-L": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 8589934592, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 200000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 26.864, "hourly_price": 0.0368,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      400000000, "sum_internet_bandwidth": 400000000, "interfaces": [{"internal_bandwidth":
+      400000000, "internet_bandwidth": 400000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-M": {"alt_names": [], "arch": "x86_64", "ncpus":
+      4, "ram": 4294967296, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 100000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 14.162, "hourly_price": 0.0194, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 300000000, "sum_internet_bandwidth": 300000000,
+      "interfaces": [{"internal_bandwidth": 300000000, "internet_bandwidth": 300000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "START1-S": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info": null,
+      "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size": 50000000000},
+      "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size": 800000000000}},
+      "scratch_storage_max_size": null, "monthly_price": 7.738, "hourly_price": 0.0106,
+      "capabilities": {"boot_types": ["local", "rescue"], "placement_groups": true,
+      "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "START1-XS": {"alt_names": [], "arch": "x86_64", "ncpus":
+      1, "ram": 1073741824, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 25000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 4.526, "hourly_price": 0.0062, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 100000000, "sum_internet_bandwidth": 100000000,
+      "interfaces": [{"internal_bandwidth": 100000000, "internet_bandwidth": 100000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1L": {"alt_names":
+      ["X64-8GB"], "arch": "x86_64", "ncpus": 6, "ram": 8589934592, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 18.0164,
+      "hourly_price": 0.02468, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1M": {"alt_names":
+      ["X64-4GB"], "arch": "x86_64", "ncpus": 4, "ram": 4294967296, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      100000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 11.3515,
+      "hourly_price": 0.01555, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 200000000, "sum_internet_bandwidth": 200000000,
+      "interfaces": [{"internal_bandwidth": 200000000, "internet_bandwidth": 200000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "VC1S": {"alt_names":
+      ["X64-2GB"], "arch": "x86_64", "ncpus": 2, "ram": 2147483648, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      50000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 6.2926, "hourly_price":
+      0.00862, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      200000000, "sum_internet_bandwidth": 200000000, "interfaces": [{"internal_bandwidth":
+      200000000, "internet_bandwidth": 200000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}, "X64-120GB": {"alt_names": [], "arch": "x86_64", "ncpus":
+      12, "ram": 128849018880, "gpu": 0, "gpu_info": null, "mig_profile": null, "volumes_constraint":
+      {"min_size": 0, "max_size": 800000000000}, "per_volume_constraint": {"l_ssd":
+      {"min_size": 1000000000, "max_size": 800000000000}}, "scratch_storage_max_size":
+      null, "monthly_price": 310.7902, "hourly_price": 0.42574, "capabilities": {"boot_types":
+      ["local", "rescue"], "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 1000000000, "sum_internet_bandwidth": 1000000000,
+      "interfaces": [{"internal_bandwidth": 1000000000, "internet_bandwidth": 1000000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-15GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 6, "ram": 16106127360, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      200000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 44.0336,
+      "hourly_price": 0.06032, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 250000000, "sum_internet_bandwidth": 250000000,
+      "interfaces": [{"internal_bandwidth": 250000000, "internet_bandwidth": 250000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-30GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 8, "ram": 32212254720, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      400000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 86.9138,
+      "hourly_price": 0.11906, "capabilities": {"boot_types": ["local", "rescue"],
+      "placement_groups": true, "block_storage": true, "hot_snapshots_local_volume":
+      true, "private_network": 8, "max_file_systems": 0}, "network": {"ipv6_support":
+      true, "sum_internal_bandwidth": 500000000, "sum_internet_bandwidth": 500000000,
+      "interfaces": [{"internal_bandwidth": 500000000, "internet_bandwidth": 500000000}]},
+      "block_bandwidth": 41943040, "end_of_service": true}, "X64-60GB": {"alt_names":
+      [], "arch": "x86_64", "ncpus": 10, "ram": 64424509440, "gpu": 0, "gpu_info":
+      null, "mig_profile": null, "volumes_constraint": {"min_size": 0, "max_size":
+      700000000000}, "per_volume_constraint": {"l_ssd": {"min_size": 1000000000, "max_size":
+      800000000000}}, "scratch_storage_max_size": null, "monthly_price": 155.49, "hourly_price":
+      0.213, "capabilities": {"boot_types": ["local", "rescue"], "placement_groups":
+      true, "block_storage": true, "hot_snapshots_local_volume": true, "private_network":
+      8, "max_file_systems": 0}, "network": {"ipv6_support": true, "sum_internal_bandwidth":
+      1000000000, "sum_internet_bandwidth": 1000000000, "interfaces": [{"internal_bandwidth":
+      1000000000, "internet_bandwidth": 1000000000}]}, "block_bandwidth": 41943040,
+      "end_of_service": true}}}'
+    headers:
+      Content-Length:
+      - "19730"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e2f21ce-3ea8-4519-b092-93a3d19125e5
+      X-Total-Count:
+      - "75"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=type_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"id":"5cf1c79e-46b5-40d7-8eaa-51f76f099837", "arch":"x86_64",
+      "zone":"fr-par-1", "compatible_commercial_types":["DEV1-L", "DEV1-M", "DEV1-S",
+      "DEV1-XL", "GP1-L", "GP1-M", "GP1-S", "GP1-XL", "GP1-XS", "STARDUST1-S", "START1-L",
+      "START1-M", "START1-S", "START1-XS", "VC1L", "VC1M", "VC1S", "X64-120GB", "X64-15GB",
+      "X64-30GB", "X64-60GB"], "label":"ubuntu_jammy", "type":"instance_local"}],
+      "total_count":1}'
+    headers:
+      Content-Length:
+      - "423"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 43da1ffe-2b2d-43bf-921b-f57070884c0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/5cf1c79e-46b5-40d7-8eaa-51f76f099837
+    method: GET
+  response:
+    body: '{"image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "618"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a65b9c9b-a54d-4b36-bfdb-a2d705bec79b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "prefix": null, "reverse": null, "server": null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "zone": "fr-par-1", "type":
+      "routed_ipv4", "state": "detached", "tags": [], "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}}'
+    headers:
+      Content-Length:
+      - "365"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/eb1a9658-31f8-454a-851f-4e3569203d4b
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/528cb17b-a54a-4f98-9ef2-3f3c2551873e
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -41,91 +1607,95 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ac53f09-7a96-4e37-a659-2c754f6db05d
+      - c0c3ec93-6551-4d9c-81dc-5d18888a649d
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.949529+00:00", "modification_date":
-      "2023-12-14T14:00:00.949529+00:00", "tags": [], "zone": "fr-par-1"}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/eb1a9658-31f8-454a-851f-4e3569203d4b
-    method: GET
-  response:
-    body: '{"volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name": "cli-test",
-      "volume_type": "b_ssd", "export_uri": null, "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "server": null, "size": 10000000000,
-      "state": "available", "creation_date": "2023-12-14T14:00:00.949529+00:00", "modification_date":
-      "2023-12-14T14:00:00.949529+00:00", "tags": [], "zone": "fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "430"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b07e2ac-c3bf-42d8-8773-908f0f2b2d1e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.157397+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "8f7e60e6-5bca-4a99-a3b3-22a52acb5080", "description":
-      "snapshot_f8cf3efd-885d-46bd-b390-f3ce21df07eb", "status": "pending", "href_from":
-      "/snapshots", "href_result": "snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb",
-      "started_at": "2023-12-14T14:00:01.377312+00:00", "terminated_at": null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1d0291b3-c7e2-403b-91e0-3cf32e274582",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:28.711029+00:00",
+      "modification_date": "2025-07-22T15:32:28.711029+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.157397+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["foo", "bar"], "zone": "fr-par-1", "error_details":
-      null}, "task": {"id": "8f7e60e6-5bca-4a99-a3b3-22a52acb5080", "description":
-      "snapshot_f8cf3efd-885d-46bd-b390-f3ce21df07eb", "status": "pending", "href_from":
-      "/snapshots", "href_result": "snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb",
-      "started_at": "2023-12-14T14:00:01.377312+00:00", "terminated_at": null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {"0": {"boot": false, "id": "1d0291b3-c7e2-403b-91e0-3cf32e274582",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri":
+      null, "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:28.711029+00:00",
+      "modification_date": "2025-07-22T15:32:28.711029+00:00", "tags": [], "zone":
+      "fr-par-1"}}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "844"
+      - "2718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18703f64-f52b-4fbf-8d86-3f65a28df76c
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,45 +1703,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2ae1de6-bb36-4a2d-8c6e-64fccaf05a43
+      - 8760f9e5-d46b-4ddd-a8f5-452d8b0b2223
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:28.711029+00:00",
+      "modification_date": "2025-07-22T15:32:28.711029+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
-    method: PATCH
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d0291b3-c7e2-403b-91e0-3cf32e274582
+    method: GET
   response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter"},
+      "size": 10000000000, "state": "available", "creation_date": "2025-07-22T15:32:28.711029+00:00",
+      "modification_date": "2025-07-22T15:32:28.711029+00:00", "tags": [], "zone":
+      "fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -179,43 +1747,81 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c712745-de1f-4bb3-95b2-1877dbe7fd75
+      - 9faeb786-d465-4ae3-a95f-f794c1f6b9e7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
-    method: GET
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18703f64-f52b-4fbf-8d86-3f65a28df76c/detach-volume
+    method: POST
   response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "538"
+      - "2177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:01 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -223,43 +1829,79 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7a65851-df88-4a03-8297-93b8b1345483
+      - 57d4ad4a-17d0-484d-801c-0069f0ffa94d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18703f64-f52b-4fbf-8d86-3f65a28df76c
     method: GET
   response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
+    body: '{"server": {"id": "18703f64-f52b-4fbf-8d86-3f65a28df76c", "name": "cli-srv-determined-hofstadter",
+      "arch": "x86_64", "commercial_type": "DEV1-S", "boot_type": "local", "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "hostname": "cli-srv-determined-hofstadter", "image": {"id": "5cf1c79e-46b5-40d7-8eaa-51f76f099837",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "organization": "51b656e3-4865-41e8-adbc-0c45bdd780db",
+      "project": "51b656e3-4865-41e8-adbc-0c45bdd780db", "root_volume": {"id": "2973ed60-b18f-46a0-8be5-671a5345ee7b",
+      "name": "Ubuntu 22.04 Jammy Jellyfish", "volume_type": "l_ssd", "size": 10000000000},
+      "extra_volumes": {}, "public": true, "arch": "x86_64", "creation_date": "2025-06-25T15:22:42.795139+00:00",
+      "modification_date": "2025-06-25T15:22:42.795139+00:00", "default_bootscript":
+      null, "from_server": "", "state": "available", "tags": [], "zone": "fr-par-1"},
+      "volumes": {}, "tags": [], "state": "stopped", "protected": false, "state_detail":
+      "", "public_ip": {"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"},
+      "public_ips": [{"id": "528cb17b-a54a-4f98-9ef2-3f3c2551873e", "address": "51.15.141.110",
+      "dynamic": false, "gateway": "62.210.0.1", "netmask": "32", "family": "inet",
+      "provisioning_mode": "dhcp", "tags": [], "state": "attached", "ipam_id": "648471e2-1b37-4e27-aaeb-9efb892649a5"}],
+      "mac_address": "de:00:00:c0:77:a3", "routed_ip_enabled": true, "ipv6": null,
+      "extra_networks": [], "dynamic_ip_required": true, "enable_ipv6": false, "private_ip":
+      null, "creation_date": "2025-07-22T15:32:28.711029+00:00", "modification_date":
+      "2025-07-22T15:32:28.711029+00:00", "bootscript": null, "security_group": {"id":
+      "da505169-540e-4c2b-b0da-c854139224e0", "name": "Default security group"}, "location":
+      null, "maintenances": [], "allowed_actions": ["poweron", "backup"], "placement_group":
+      null, "private_nics": [], "zone": "fr-par-1", "filesystems": [], "end_of_service":
+      false}}'
     headers:
       Content-Length:
-      - "538"
+      - "2177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:06 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -267,93 +1909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd6f272b-ad89-45bf-9b9b-c7e05dcd0571
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:01.768008+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "snapshotting", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-      "name": "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details":
-      null}}'
-    headers:
-      Content-Length:
-      - "538"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f7d59ca-c411-45c8-8333-31f2a604233e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:15.229731+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name":
-      "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details": null}}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
-    method: GET
-  response:
-    body: '{"snapshot": {"id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb", "name": "cli-test-snapshot-update-tags",
-      "volume_type": "b_ssd", "creation_date": "2023-12-14T14:00:01.157397+00:00",
-      "modification_date": "2023-12-14T14:00:15.229731+00:00", "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-      "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b", "size": 10000000000, "state":
-      "available", "base_volume": {"id": "eb1a9658-31f8-454a-851f-4e3569203d4b", "name":
-      "cli-test"}, "tags": ["bar", "foo"], "zone": "fr-par-1", "error_details": null}}'
-    headers:
-      Content-Length:
-      - "535"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92942318-407d-4a93-830b-96ea98b4e52c
+      - 2498a603-04d9-48d3-be7a-0fef91cdbd71
     status: 200 OK
     code: 200
     duration: ""
@@ -362,18 +1918,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/f8cf3efd-885d-46bd-b390-f3ce21df07eb
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/18703f64-f52b-4fbf-8d86-3f65a28df76c
     method: DELETE
   response:
     body: ""
     headers:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
+      - Tue, 22 Jul 2025 15:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,7 +1939,223 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4691d6e-debb-4627-b556-02da80858f35
+      - 45099d28-d17d-4b9b-bca8-53a2b2040c8a
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:28.711029+00:00", "modification_date": "2025-07-22T15:32:29.231924+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d0291b3-c7e2-403b-91e0-3cf32e274582
+    method: GET
+  response:
+    body: '{"volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name": "Ubuntu
+      22.04 Jammy Jellyfish", "volume_type": "l_ssd", "export_uri": null, "organization":
+      "fa1e3217-dc80-42ac-85c3-3f034b78b552", "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "server": null, "size": 10000000000, "state": "available", "creation_date":
+      "2025-07-22T15:32:28.711029+00:00", "modification_date": "2025-07-22T15:32:29.231924+00:00",
+      "tags": [], "zone": "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "450"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3273697-8a4b-46aa-869b-02992e05d023
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:29.958951+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}, "task": {"id": "fcf410eb-9e03-4ec3-8cdf-73f774df2b72",
+      "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots",
+      "href_result": "snapshots/c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "started_at":
+      "2025-07-22T15:32:30.204385+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
+    method: POST
+  response:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:29.958951+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["foo", "bar"], "zone": "fr-par-1",
+      "error_details": null}, "task": {"id": "fcf410eb-9e03-4ec3-8cdf-73f774df2b72",
+      "description": "volume_snapshot", "status": "pending", "href_from": "/snapshots",
+      "href_result": "snapshots/c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "started_at":
+      "2025-07-22T15:32:30.204385+00:00", "terminated_at": null, "progress": 0, "zone":
+      "fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "866"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e61500da-066e-4e02-bc1d-9a88797ea63e
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:30.262794+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["bar", "foo"], "zone": "fr-par-1",
+      "error_details": null}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3
+    method: PATCH
+  response:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:30.262794+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["bar", "foo"], "zone": "fr-par-1",
+      "error_details": null}}'
+    headers:
+      Content-Length:
+      - "555"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36f65466-b4d5-4964-8144-30384c87e77e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:30.262794+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["bar", "foo"], "zone": "fr-par-1",
+      "error_details": null}}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3
+    method: GET
+  response:
+    body: '{"snapshot": {"id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3", "name": "cli-test-snapshot-update-tags",
+      "volume_type": "l_ssd", "creation_date": "2025-07-22T15:32:29.958951+00:00",
+      "modification_date": "2025-07-22T15:32:30.262794+00:00", "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552", "size": 10000000000, "state":
+      "available", "base_volume": {"id": "1d0291b3-c7e2-403b-91e0-3cf32e274582", "name":
+      "Ubuntu 22.04 Jammy Jellyfish"}, "tags": ["bar", "foo"], "zone": "fr-par-1",
+      "error_details": null}}'
+    headers:
+      Content-Length:
+      - "555"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5028eee-825c-4f80-bb46-d67ae3f59da3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Jul 2025 15:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10ab2e07-aeb2-4918-85f6-1ec144fe6cd4
     status: 204 No Content
     code: 204
     duration: ""
@@ -390,18 +2164,20 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) cli-e2e-test
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/eb1a9658-31f8-454a-851f-4e3569203d4b
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d0291b3-c7e2-403b-91e0-3cf32e274582
     method: DELETE
   response:
     body: ""
     headers:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
       Date:
-      - Thu, 14 Dec 2023 14:00:17 GMT
+      - Tue, 22 Jul 2025 15:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -409,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d16aaa7-4403-4f1b-ae64-67da61c342dc
+      - 1470a971-3563-46e6-81ab-8b1acf56a09e
     status: 204 No Content
     code: 204
     duration: ""

--- a/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-tags.golden
+++ b/internal/namespaces/instance/v1/testdata/test-update-snapshot-simple-change-tags.golden
@@ -1,35 +1,35 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-ID                f8cf3efd-885d-46bd-b390-f3ce21df07eb
+ID                c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3
 Name              cli-test-snapshot-update-tags
-Organization      ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
-Project           ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b
+Organization      fa1e3217-dc80-42ac-85c3-3f034b78b552
+Project           fa1e3217-dc80-42ac-85c3-3f034b78b552
 Tags.0            bar
 Tags.1            foo
-VolumeType        b_ssd
+VolumeType        l_ssd
 Size              10 GB
 State             available
-BaseVolume.ID     eb1a9658-31f8-454a-851f-4e3569203d4b
-BaseVolume.Name   cli-test
+BaseVolume.ID     1d0291b3-c7e2-403b-91e0-3cf32e274582
+BaseVolume.Name   Ubuntu 22.04 Jammy Jellyfish
 CreationDate      few seconds ago
 ModificationDate  few seconds ago
 Zone              fr-par-1
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
-  "id": "f8cf3efd-885d-46bd-b390-f3ce21df07eb",
+  "id": "c944f2e0-25bd-4e0e-91d7-ab8dcbf929f3",
   "name": "cli-test-snapshot-update-tags",
-  "organization": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
-  "project": "ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b",
+  "organization": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+  "project": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
   "tags": [
     "bar",
     "foo"
   ],
-  "volume_type": "b_ssd",
+  "volume_type": "l_ssd",
   "size": 10000000000,
   "state": "available",
   "base_volume": {
-    "id": "eb1a9658-31f8-454a-851f-4e3569203d4b",
-    "name": "cli-test"
+    "id": "1d0291b3-c7e2-403b-91e0-3cf32e274582",
+    "name": "Ubuntu 22.04 Jammy Jellyfish"
   },
   "creation_date": "1970-01-01T00:00:00.0Z",
   "modification_date": "1970-01-01T00:00:00.0Z",


### PR DESCRIPTION
Some tests from the Instance scope were still using deprecated `b_ssd` volumes, therefore they could not be recorded anymore. This PR changes all remaining occurrences to use `l_ssd` instead and has to be merged before any other change to the cassette system or the tests can be made.