### PR TITLE
fix: bump sdk-go to enable the new custom transport interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/buildkit v0.13.2
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250724124529-b7da019858b2
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250724124529-b7da019858b2 h1:DrORi0blh9INIc+Lt7EYKYJQtkt8rwYANC/nTW4cGgo=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250724124529-b7da019858b2/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06 h1:HLJAN1hyivE7jP5/0TRh4cNVWiVKJFjihBWGajSLLOk=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbmfHkLguCE9laoZCUzEEpIZXA=


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
