### PR TITLE
chore(vpc): use TryDeletingPrivateNetwork function from the sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/moby/buildkit v0.13.2
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250729162034-8db00eaf9654
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUz
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06 h1:HLJAN1hyivE7jP5/0TRh4cNVWiVKJFjihBWGajSLLOk=
-github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250725144419-de749e386a06/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250729162034-8db00eaf9654 h1:G5/4vYAsx2lv3FKJFho58m9aE3wgBrbyn7Z/Fds4opU=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.34.0.20250729162034-8db00eaf9654/go.mod h1:fw6BmcfYRs2BEHYW0c3/rR0JgZHvdx6uMYqpeUJx3Bc=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbmfHkLguCE9laoZCUzEEpIZXA=

--- a/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.cassette.yaml
+++ b/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.cassette.yaml
@@ -5,18 +5,18 @@ interactions:
     body: '{"cluster_types":[{"name":"kapsule", "availability":"available", "max_nodes":150,
       "commitment_delay":"0s", "sla":0, "resiliency":"standard", "memory":4000000000,
       "dedicated":false, "audit_logs_supported":false, "max_etcd_size":55000000},
-      {"name":"kapsule-dedicated-4", "availability":"shortage", "max_nodes":250, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":4000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-8",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":8000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-16",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":16000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"multicloud",
-      "availability":"available", "max_nodes":150, "commitment_delay":"0s", "sla":0,
-      "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
-      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"shortage",
+      {"name":"kapsule-dedicated-4", "availability":"available", "max_nodes":250,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-8", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":8000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-16", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":16000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"multicloud", "availability":"available", "max_nodes":150, "commitment_delay":"0s",
+      "sla":0, "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
+      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"available",
       "max_nodes":250, "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
       "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
       {"name":"multicloud-dedicated-8", "availability":"available", "max_nodes":500,
@@ -29,25 +29,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/cluster-types
     method: GET
   response:
     body: '{"cluster_types":[{"name":"kapsule", "availability":"available", "max_nodes":150,
       "commitment_delay":"0s", "sla":0, "resiliency":"standard", "memory":4000000000,
       "dedicated":false, "audit_logs_supported":false, "max_etcd_size":55000000},
-      {"name":"kapsule-dedicated-4", "availability":"shortage", "max_nodes":250, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":4000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-8",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":8000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-16",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":16000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"multicloud",
-      "availability":"available", "max_nodes":150, "commitment_delay":"0s", "sla":0,
-      "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
-      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"shortage",
+      {"name":"kapsule-dedicated-4", "availability":"available", "max_nodes":250,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-8", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":8000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-16", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":16000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"multicloud", "availability":"available", "max_nodes":150, "commitment_delay":"0s",
+      "sla":0, "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
+      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"available",
       "max_nodes":250, "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
       "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
       {"name":"multicloud-dedicated-8", "availability":"available", "max_nodes":500,
@@ -59,13 +59,13 @@ interactions:
       "total_count":8}'
     headers:
       Content-Length:
-      - "1983"
+      - "1985"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:27 GMT
+      - Wed, 30 Jul 2025 13:43:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -75,53 +75,53 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32eb248f-9813-42ee-ae96-e6d615a8fc89
+      - fba5d25b-bcac-4f14-a1b7-7195880152e5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b", "name":"pn-serene-franklin",
-      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "created_at":"2025-05-14T11:50:27.623895Z", "updated_at":"2025-05-14T11:50:27.623895Z",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "subnets":[{"id":"14d3529b-9a78-4d41-b0bd-296f2cf2d767",
-      "created_at":"2025-05-14T11:50:27.623895Z", "updated_at":"2025-05-14T11:50:27.623895Z",
-      "subnet":"172.16.12.0/22", "project_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b", "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"},
-      {"id":"91e0a486-1baf-4236-a485-d3b873aba16c", "created_at":"2025-05-14T11:50:27.623895Z",
-      "updated_at":"2025-05-14T11:50:27.623895Z", "subnet":"fdd2:c09a:9672:8e1d::/64",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"}], "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e",
-      "dhcp_enabled":true, "region":"fr-par"}'
+    body: '{"id":"463a6351-e4e2-491c-bb76-aebc7aabf253", "name":"pn-confident-khorana",
+      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "created_at":"2025-07-30T13:43:08.082758Z", "updated_at":"2025-07-30T13:43:08.082758Z",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"af78d69e-65df-4437-b025-595cce233b29",
+      "created_at":"2025-07-30T13:43:08.082758Z", "updated_at":"2025-07-30T13:43:08.082758Z",
+      "subnet":"172.16.20.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253", "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},
+      {"id":"f3cadde2-1ab0-4c2a-a3da-548f41916396", "created_at":"2025-07-30T13:43:08.082758Z",
+      "updated_at":"2025-07-30T13:43:08.082758Z", "subnet":"fd63:256c:45f7:72ee::/64",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}], "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c",
+      "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b", "name":"pn-serene-franklin",
-      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "created_at":"2025-05-14T11:50:27.623895Z", "updated_at":"2025-05-14T11:50:27.623895Z",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "subnets":[{"id":"14d3529b-9a78-4d41-b0bd-296f2cf2d767",
-      "created_at":"2025-05-14T11:50:27.623895Z", "updated_at":"2025-05-14T11:50:27.623895Z",
-      "subnet":"172.16.12.0/22", "project_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b", "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"},
-      {"id":"91e0a486-1baf-4236-a485-d3b873aba16c", "created_at":"2025-05-14T11:50:27.623895Z",
-      "updated_at":"2025-05-14T11:50:27.623895Z", "subnet":"fdd2:c09a:9672:8e1d::/64",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"}], "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e",
-      "dhcp_enabled":true, "region":"fr-par"}'
+    body: '{"id":"463a6351-e4e2-491c-bb76-aebc7aabf253", "name":"pn-confident-khorana",
+      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "created_at":"2025-07-30T13:43:08.082758Z", "updated_at":"2025-07-30T13:43:08.082758Z",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"af78d69e-65df-4437-b025-595cce233b29",
+      "created_at":"2025-07-30T13:43:08.082758Z", "updated_at":"2025-07-30T13:43:08.082758Z",
+      "subnet":"172.16.20.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253", "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},
+      {"id":"f3cadde2-1ab0-4c2a-a3da-548f41916396", "created_at":"2025-07-30T13:43:08.082758Z",
+      "updated_at":"2025-07-30T13:43:08.082758Z", "subnet":"fd63:256c:45f7:72ee::/64",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}], "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c",
+      "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
     headers:
       Content-Length:
-      - "1095"
+      - "1140"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:28 GMT
+      - Wed, 30 Jul 2025 13:43:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -131,59 +131,61 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84cd9057-90ff-4fa2-bee9-7d5382147c44
+      - 7625c287-5fef-4f41-bf7c-440928ac658f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:28.417953Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:08.838639Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:28.417953Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:08.838639Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1439"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:28 GMT
+      - Wed, 30 Jul 2025 13:43:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -193,57 +195,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a4db9f5-b014-44e2-83ed-536ea79b92b0
+      - bfb7f22d-5539-4f26-a214-09b55cf16346
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:28.417953Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:08.838639Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/01e9681f-4250-499c-9404-193c057ebbda
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f1e8452c-2434-4cf8-a594-bf8f5abf44fb
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:28.417953Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:08.838639Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1439"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:29 GMT
+      - Wed, 30 Jul 2025 13:43:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -253,43 +257,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab29042-9a34-49bd-b698-ac92003c420f
+      - e692599c-c901-44e7-b4c2-7b316406a0e7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"03b8c28f-94a4-491f-b746-83789e1d24f0",
-      "cluster_id":"01e9681f-4250-499c-9404-193c057ebbda", "created_at":"2025-05-14T11:50:28.258953Z",
-      "updated_at":"2025-05-14T11:50:28.258953Z", "name":"default", "status":"scaling",
+    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"c63e3bfd-7a81-4e1c-8182-faf02c53ebe9",
+      "cluster_id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "created_at":"2025-07-30T13:43:08.685249Z",
+      "updated_at":"2025-07-30T13:43:08.685249Z", "name":"default", "status":"scaling",
       "version":"1.32.3", "node_type":"dev1_m", "autoscaling":false, "size":1, "min_size":0,
       "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[],
       "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1,
       "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd", "root_volume_size":40000000000,
-      "public_ip_disabled":false}]}'
+      "public_ip_disabled":false, "new_images_enabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}]}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/01e9681f-4250-499c-9404-193c057ebbda/pools?order_by=created_at_asc&status=unknown
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f1e8452c-2434-4cf8-a594-bf8f5abf44fb/pools?order_by=created_at_asc&status=unknown
     method: GET
   response:
-    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"03b8c28f-94a4-491f-b746-83789e1d24f0",
-      "cluster_id":"01e9681f-4250-499c-9404-193c057ebbda", "created_at":"2025-05-14T11:50:28.258953Z",
-      "updated_at":"2025-05-14T11:50:28.258953Z", "name":"default", "status":"scaling",
+    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"c63e3bfd-7a81-4e1c-8182-faf02c53ebe9",
+      "cluster_id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "created_at":"2025-07-30T13:43:08.685249Z",
+      "updated_at":"2025-07-30T13:43:08.685249Z", "name":"default", "status":"scaling",
       "version":"1.32.3", "node_type":"dev1_m", "autoscaling":false, "size":1, "min_size":0,
       "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[],
       "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1,
       "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd", "root_volume_size":40000000000,
-      "public_ip_disabled":false}]}'
+      "public_ip_disabled":false, "new_images_enabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}]}'
     headers:
       Content-Length:
-      - "647"
+      - "735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:29 GMT
+      - Wed, 30 Jul 2025 13:43:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -299,57 +303,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f844e286-1661-418b-b01e-8f1a8de216b4
+      - af338d29-0848-475d-92ae-bdb785ed3c00
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:29.177049Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:09.454288Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/01e9681f-4250-499c-9404-193c057ebbda?with_additional_resources=true
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f1e8452c-2434-4cf8-a594-bf8f5abf44fb?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:29.177049Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:09.454288Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1439"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:29 GMT
+      - Wed, 30 Jul 2025 13:43:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -359,57 +365,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b51a4fd-95de-4997-9ded-394a4b2453ab
+      - b842f3a2-3c55-44b8-882c-c951592bd570
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:29.177049Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:09.454288Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/01e9681f-4250-499c-9404-193c057ebbda
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f1e8452c-2434-4cf8-a594-bf8f5abf44fb
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"01e9681f-4250-499c-9404-193c057ebbda", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:28.417953Z",
-      "updated_at":"2025-05-14T11:50:29.177049Z", "type":"kapsule", "name":"cli-test-get-cluster",
+    body: '{"region":"fr-par", "id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:43:08.838639Z",
+      "updated_at":"2025-07-30T13:43:09.454288Z", "type":"kapsule", "name":"cli-test-get-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
-      "commitment_ends_at":"2025-05-14T11:50:28.417962Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"463a6351-e4e2-491c-bb76-aebc7aabf253",
+      "commitment_ends_at":"2025-07-30T13:43:08.838648Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1439"
+      - "1521"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:29 GMT
+      - Wed, 30 Jul 2025 13:43:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -419,20 +427,20 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 589cb6d6-5f6f-473a-932c-4722f80b2ed5
+      - 7b3e1e55-aeda-41d5-bfc0-916449515070
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"01e9681f-4250-499c-9404-193c057ebbda","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb","type":"not_found"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/01e9681f-4250-499c-9404-193c057ebbda
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/f1e8452c-2434-4cf8-a594-bf8f5abf44fb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"01e9681f-4250-499c-9404-193c057ebbda","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"f1e8452c-2434-4cf8-a594-bf8f5abf44fb","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -441,7 +449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:34 GMT
+      - Wed, 30 Jul 2025 13:43:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -451,7 +459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70893fd8-2cb2-440f-99a9-4fcc74bf53e0
+      - 11779ddf-4394-4b27-b35a-93d252db4ac9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.golden
+++ b/internal/namespaces/k8s/v1/testdata/test-get-cluster-simple.golden
@@ -1,24 +1,27 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-ID                01e9681f-4250-499c-9404-193c057ebbda
+ID                f1e8452c-2434-4cf8-a594-bf8f5abf44fb
 Type              kapsule
 Name              cli-test-get-cluster
 Status            creating
 Version           1.32.3
 Region            fr-par
-OrganizationID    6867048b-fe12-4e96-835e-41c79a39604b
-ProjectID         6867048b-fe12-4e96-835e-41c79a39604b
+OrganizationID    fa1e3217-dc80-42ac-85c3-3f034b78b552
+ProjectID         fa1e3217-dc80-42ac-85c3-3f034b78b552
 Cni               cilium
 Description       -
-ClusterURL        https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443
-DNSWildcard       *.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud
+ClusterURL        https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443
+DNSWildcard       *.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud
 CreatedAt         few seconds ago
 UpdatedAt         few seconds ago
-UpgradeAvailable  false
-PrivateNetworkID  13118fe8-dbbf-42b2-b83e-dabab5b7f92b
+UpgradeAvailable  true
+PrivateNetworkID  463a6351-e4e2-491c-bb76-aebc7aabf253
 CommitmentEndsAt  few seconds ago
 ACLAvailable      true
 IamNodesGroupID   -
+NewImagesEnabled  false
+PodCidr           -
+ServiceCidr       -
 
 Autoscaler configuration:
 ScaleDownDisabled              false
@@ -46,22 +49,22 @@ GroupsPrefix    -
 
 Pools:
 ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN SIZE  SIZE  MAX SIZE  AUTOSCALING  AUTOHEALING  ZONE
-03b8c28f-94a4-491f-b746-83789e1d24f0  default  scaling  1.32.3   dev1_m     0         1     1         false        false        fr-par-1
+c63e3bfd-7a81-4e1c-8182-faf02c53ebe9  default  scaling  1.32.3   dev1_m     0         1     1         false        false        fr-par-1
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
-  "id": "01e9681f-4250-499c-9404-193c057ebbda",
+  "id": "f1e8452c-2434-4cf8-a594-bf8f5abf44fb",
   "type": "kapsule",
   "name": "cli-test-get-cluster",
   "status": "creating",
   "version": "1.32.3",
   "region": "fr-par",
-  "organization_id": "6867048b-fe12-4e96-835e-41c79a39604b",
-  "project_id": "6867048b-fe12-4e96-835e-41c79a39604b",
+  "organization_id": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+  "project_id": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
   "tags": [],
   "cni": "cilium",
   "description": "",
-  "cluster_url": "https://01e9681f-4250-499c-9404-193c057ebbda.api.k8s.fr-par.scw.cloud:6443",
-  "dns_wildcard": "*.01e9681f-4250-499c-9404-193c057ebbda.nodes.k8s.fr-par.scw.cloud",
+  "cluster_url": "https://f1e8452c-2434-4cf8-a594-bf8f5abf44fb.api.k8s.fr-par.scw.cloud:6443",
+  "dns_wildcard": "*.f1e8452c-2434-4cf8-a594-bf8f5abf44fb.nodes.k8s.fr-par.scw.cloud",
   "created_at": "1970-01-01T00:00:00.0Z",
   "updated_at": "1970-01-01T00:00:00.0Z",
   "autoscaler_config": {
@@ -83,7 +86,7 @@ ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN 
       "day": "any"
     }
   },
-  "upgrade_available": false,
+  "upgrade_available": true,
   "feature_gates": [],
   "admission_plugins": [],
   "open_id_connect_config": {
@@ -96,13 +99,17 @@ ID                                    NAME     STATUS   VERSION  NODE TYPE  MIN 
     "required_claim": []
   },
   "apiserver_cert_sans": [],
-  "private_network_id": "13118fe8-dbbf-42b2-b83e-dabab5b7f92b",
+  "private_network_id": "463a6351-e4e2-491c-bb76-aebc7aabf253",
   "commitment_ends_at": "1970-01-01T00:00:00.0Z",
   "acl_available": true,
   "iam_nodes_group_id": "",
+  "new_images_enabled": false,
+  "pod_cidr": "",
+  "service_cidr": "",
+  "service_dns_ip": "",
   "pools": [
     {
-      "id": "03b8c28f-94a4-491f-b746-83789e1d24f0",
+      "id": "c63e3bfd-7a81-4e1c-8182-faf02c53ebe9",
       "name": "default",
       "status": "scaling",
       "version": "1.32.3",

--- a/internal/namespaces/k8s/v1/testdata/test-wait-cluster-wait-for-pools.cassette.yaml
+++ b/internal/namespaces/k8s/v1/testdata/test-wait-cluster-wait-for-pools.cassette.yaml
@@ -5,18 +5,18 @@ interactions:
     body: '{"cluster_types":[{"name":"kapsule", "availability":"available", "max_nodes":150,
       "commitment_delay":"0s", "sla":0, "resiliency":"standard", "memory":4000000000,
       "dedicated":false, "audit_logs_supported":false, "max_etcd_size":55000000},
-      {"name":"kapsule-dedicated-4", "availability":"shortage", "max_nodes":250, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":4000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-8",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":8000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-16",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":16000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"multicloud",
-      "availability":"available", "max_nodes":150, "commitment_delay":"0s", "sla":0,
-      "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
-      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"shortage",
+      {"name":"kapsule-dedicated-4", "availability":"available", "max_nodes":250,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-8", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":8000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-16", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":16000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"multicloud", "availability":"available", "max_nodes":150, "commitment_delay":"0s",
+      "sla":0, "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
+      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"available",
       "max_nodes":250, "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
       "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
       {"name":"multicloud-dedicated-8", "availability":"available", "max_nodes":500,
@@ -29,25 +29,25 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/cluster-types
     method: GET
   response:
     body: '{"cluster_types":[{"name":"kapsule", "availability":"available", "max_nodes":150,
       "commitment_delay":"0s", "sla":0, "resiliency":"standard", "memory":4000000000,
       "dedicated":false, "audit_logs_supported":false, "max_etcd_size":55000000},
-      {"name":"kapsule-dedicated-4", "availability":"shortage", "max_nodes":250, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":4000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-8",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":8000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"kapsule-dedicated-16",
-      "availability":"available", "max_nodes":500, "commitment_delay":"2592000s",
-      "sla":99.5, "resiliency":"high_availability", "memory":16000000000, "dedicated":true,
-      "audit_logs_supported":true, "max_etcd_size":200000000}, {"name":"multicloud",
-      "availability":"available", "max_nodes":150, "commitment_delay":"0s", "sla":0,
-      "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
-      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"shortage",
+      {"name":"kapsule-dedicated-4", "availability":"available", "max_nodes":250,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-8", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":8000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"kapsule-dedicated-16", "availability":"available", "max_nodes":500,
+      "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
+      "memory":16000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
+      {"name":"multicloud", "availability":"available", "max_nodes":150, "commitment_delay":"0s",
+      "sla":0, "resiliency":"standard", "memory":4000000000, "dedicated":false, "audit_logs_supported":false,
+      "max_etcd_size":55000000}, {"name":"multicloud-dedicated-4", "availability":"available",
       "max_nodes":250, "commitment_delay":"2592000s", "sla":99.5, "resiliency":"high_availability",
       "memory":4000000000, "dedicated":true, "audit_logs_supported":true, "max_etcd_size":200000000},
       {"name":"multicloud-dedicated-8", "availability":"available", "max_nodes":500,
@@ -59,13 +59,13 @@ interactions:
       "total_count":8}'
     headers:
       Content-Length:
-      - "1983"
+      - "1985"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:34 GMT
+      - Wed, 30 Jul 2025 13:48:40 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -75,53 +75,53 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30d2591a-2b83-4303-aaae-693b9a8a97bd
+      - f5989e8e-1966-4d93-9635-64a8b12d2af6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":"82d14678-d815-412b-ac75-2134d5df987b", "name":"pn-flamboyant-fermi",
-      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "created_at":"2025-05-14T11:50:34.500032Z", "updated_at":"2025-05-14T11:50:34.500032Z",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "subnets":[{"id":"102749aa-0768-45c7-a1f6-b36a9b1a3415",
-      "created_at":"2025-05-14T11:50:34.500032Z", "updated_at":"2025-05-14T11:50:34.500032Z",
-      "subnet":"172.16.12.0/22", "project_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b", "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"},
-      {"id":"ca3d260b-fc0e-4130-aec5-2b89b522ecce", "created_at":"2025-05-14T11:50:34.500032Z",
-      "updated_at":"2025-05-14T11:50:34.500032Z", "subnet":"fdd2:c09a:9672:290a::/64",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"}], "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e",
-      "dhcp_enabled":true, "region":"fr-par"}'
+    body: '{"id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc", "name":"pn-silly-dewdney",
+      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "created_at":"2025-07-30T13:48:40.810981Z", "updated_at":"2025-07-30T13:48:40.810981Z",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"915bf62c-cbb3-44be-99f8-f80345893ed5",
+      "created_at":"2025-07-30T13:48:40.810981Z", "updated_at":"2025-07-30T13:48:40.810981Z",
+      "subnet":"172.16.16.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc", "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},
+      {"id":"6b4885fb-344c-47fd-acb0-ec8c9992769f", "created_at":"2025-07-30T13:48:40.810981Z",
+      "updated_at":"2025-07-30T13:48:40.810981Z", "subnet":"fd63:256c:45f7:33f::/64",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}], "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c",
+      "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"id":"82d14678-d815-412b-ac75-2134d5df987b", "name":"pn-flamboyant-fermi",
-      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "created_at":"2025-05-14T11:50:34.500032Z", "updated_at":"2025-05-14T11:50:34.500032Z",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "subnets":[{"id":"102749aa-0768-45c7-a1f6-b36a9b1a3415",
-      "created_at":"2025-05-14T11:50:34.500032Z", "updated_at":"2025-05-14T11:50:34.500032Z",
-      "subnet":"172.16.12.0/22", "project_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b", "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"},
-      {"id":"ca3d260b-fc0e-4130-aec5-2b89b522ecce", "created_at":"2025-05-14T11:50:34.500032Z",
-      "updated_at":"2025-05-14T11:50:34.500032Z", "subnet":"fdd2:c09a:9672:290a::/64",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e"}], "vpc_id":"f563b340-475d-466c-bc25-e100e067e38e",
-      "dhcp_enabled":true, "region":"fr-par"}'
+    body: '{"id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc", "name":"pn-silly-dewdney",
+      "tags":["created-along-with-k8s-cluster", "created-by-cli"], "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "created_at":"2025-07-30T13:48:40.810981Z", "updated_at":"2025-07-30T13:48:40.810981Z",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "subnets":[{"id":"915bf62c-cbb3-44be-99f8-f80345893ed5",
+      "created_at":"2025-07-30T13:48:40.810981Z", "updated_at":"2025-07-30T13:48:40.810981Z",
+      "subnet":"172.16.16.0/22", "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc", "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"},
+      {"id":"6b4885fb-344c-47fd-acb0-ec8c9992769f", "created_at":"2025-07-30T13:48:40.810981Z",
+      "updated_at":"2025-07-30T13:48:40.810981Z", "subnet":"fd63:256c:45f7:33f::/64",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}], "vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c",
+      "dhcp_enabled":true, "default_route_propagation_enabled":false, "region":"fr-par"}'
     headers:
       Content-Length:
-      - "1096"
+      - "1135"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:35 GMT
+      - Wed, 30 Jul 2025 13:48:41 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -131,59 +131,61 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b1a2566-2d3c-492a-9c62-59ddcf9b9ef4
+      - 00f6e136-4d55-49f1-b9e0-5055fcdff829
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:35.218849Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:41.594300Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
     url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters
     method: POST
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:35.218849Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:41.594300Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1440"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:35 GMT
+      - Wed, 30 Jul 2025 13:48:42 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -193,57 +195,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a460e575-da88-4de5-ac0f-67c461c0ea48
+      - 652e5702-b080-40e5-b31f-835bed319068
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:35.218849Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:41.594300Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:35.218849Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:41.594300Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":""}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1440"
+      - "1522"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:35 GMT
+      - Wed, 30 Jul 2025 13:48:42 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -253,57 +257,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56ced391-baff-43f2-b7b6-c70efbd83882
+      - 8f1a9596-3208-4975-9f76-d3e7987d5bb0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:40 GMT
+      - Wed, 30 Jul 2025 13:48:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -313,57 +319,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59e650eb-b4d0-41ae-b067-b820358dcfd8
+      - 1c41d540-3ceb-4b34-8747-7497158999a8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:45 GMT
+      - Wed, 30 Jul 2025 13:48:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -373,57 +381,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 146afdb7-faf4-4a72-be77-712acb8c1b96
+      - 2a91ebea-0381-4937-8a1a-23097252f6af
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:50 GMT
+      - Wed, 30 Jul 2025 13:48:57 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -433,57 +443,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14b1665d-53d2-43a7-9dad-9dcfa0593827
+      - 8f2e0439-37ac-4a24-bdd8-fe7d2db1899e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:50:56 GMT
+      - Wed, 30 Jul 2025 13:49:02 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -493,57 +505,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f17e0a9-ede2-42ff-a520-6517f00b7d5f
+      - f43a5d18-76ce-48a9-a41f-2616d3a65df3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:01 GMT
+      - Wed, 30 Jul 2025 13:49:07 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -553,57 +567,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee102562-5dcd-4bce-84ce-c5a69704da46
+      - d3f6cbf7-774f-448a-847b-82163592140f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:06 GMT
+      - Wed, 30 Jul 2025 13:49:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -613,57 +629,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6a707e8-b505-4589-ab5d-c9f69f212eaa
+      - 2ef523df-f3ce-4166-9942-9ff9ad00d9c7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:11 GMT
+      - Wed, 30 Jul 2025 13:49:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -673,57 +691,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 089605fb-f200-4026-b60d-cb531e06e91d
+      - f7a0adcf-1ea5-422f-9780-1df62e6139de
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:16 GMT
+      - Wed, 30 Jul 2025 13:49:22 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -733,57 +753,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aff2b51-4ace-49cf-b591-adb558fefb47
+      - 335e0875-6f67-48f2-a24b-9313f6870bdf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:22 GMT
+      - Wed, 30 Jul 2025 13:49:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -793,57 +815,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08246f8c-a7d3-4a45-9520-51abccaa9533
+      - a4fc37c6-64c1-4905-a861-2ceb026b97cf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:27 GMT
+      - Wed, 30 Jul 2025 13:49:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -853,57 +877,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b10563e-57b5-4fc0-97b9-be232b379650
+      - 94fe24f7-bc02-4f02-876f-510fd9f0f5e9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:32 GMT
+      - Wed, 30 Jul 2025 13:49:37 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -913,57 +939,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5efc3737-6e3e-4c15-8a28-39305411b8b4
+      - 14a25c00-d0aa-42ca-9ee6-d35b2e2390fd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:37 GMT
+      - Wed, 30 Jul 2025 13:49:42 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -973,57 +1001,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02d14ed8-0343-43c6-af8b-88860f1297df
+      - 110d89f3-d5ad-4cb6-94cb-f606a529989f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:42 GMT
+      - Wed, 30 Jul 2025 13:49:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1033,57 +1063,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8375cf20-9d44-435a-ad68-1c98ac031d87
+      - 18fe48a6-e195-4c4a-bd97-b861acde2ac4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:47 GMT
+      - Wed, 30 Jul 2025 13:49:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1093,57 +1125,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eac51ae-cc74-406d-a380-86c8876babbd
+      - 045759aa-eb3b-4557-82d3-c122274b7f9c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:52 GMT
+      - Wed, 30 Jul 2025 13:49:57 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1153,57 +1187,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d41407a2-7124-45c7-a64a-7f6891e1842c
+      - 677c29a5-f808-49d5-8721-1567d71bb5c5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:51:57 GMT
+      - Wed, 30 Jul 2025 13:50:02 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1213,57 +1249,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2202933b-6322-44f0-8e8f-f43af19f504d
+      - d13bcfea-529b-4005-9e62-9f0f5c1685bb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:50:37.427112Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:02 GMT
+      - Wed, 30 Jul 2025 13:50:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1273,57 +1311,245 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a62ad54-b4dd-4311-ac40-98dd7420cbff
+      - 9241b97d-601a-460c-a1b5-1f58978382ff
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:52:02.652457Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
+    method: GET
+  response:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    headers:
+      Content-Length:
+      - "1558"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 30 Jul 2025 13:50:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 732e8c11-485f-4115-9a1f-af52339912ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
+    method: GET
+  response:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    headers:
+      Content-Length:
+      - "1558"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 30 Jul 2025 13:50:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6fed04cb-3939-4f5b-a915-c322f70a6cf2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
+    method: GET
+  response:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:48:44.319911Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+      "description":"", "status":"creating", "version":"1.32.3", "cni":"cilium", "tags":[],
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
+      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
+      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
+      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
+      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
+      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
+    headers:
+      Content-Length:
+      - "1558"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 30 Jul 2025 13:50:23 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-1;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35958c06-1ba0-4560-8a29-dd55f40661a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:50:23.628089Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"ready", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:52:02.652457Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:50:23.628089Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"ready", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1473"
+      - "1555"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:07 GMT
+      - Wed, 30 Jul 2025 13:50:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1333,43 +1559,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a874ea-896a-4a5e-976a-97c49a3e685c
+      - b53b934a-8dee-4ede-977b-c1df099a1f24
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f",
-      "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "created_at":"2025-05-14T11:50:35.082285Z",
-      "updated_at":"2025-05-14T11:50:35.082285Z", "name":"default", "status":"scaling",
+    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2",
+      "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "created_at":"2025-07-30T13:48:41.446445Z",
+      "updated_at":"2025-07-30T13:48:41.446445Z", "name":"default", "status":"scaling",
       "version":"1.32.3", "node_type":"gp1_xs", "autoscaling":false, "size":1, "min_size":0,
       "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[],
       "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1,
       "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd", "root_volume_size":150000000000,
-      "public_ip_disabled":false}]}'
+      "public_ip_disabled":false, "new_images_enabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}]}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859/pools?order_by=created_at_asc&page=1&status=unknown
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69/pools?order_by=created_at_asc&page=1&status=unknown
     method: GET
   response:
-    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f",
-      "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "created_at":"2025-05-14T11:50:35.082285Z",
-      "updated_at":"2025-05-14T11:50:35.082285Z", "name":"default", "status":"scaling",
+    body: '{"total_count":1, "pools":[{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2",
+      "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "created_at":"2025-07-30T13:48:41.446445Z",
+      "updated_at":"2025-07-30T13:48:41.446445Z", "name":"default", "status":"scaling",
       "version":"1.32.3", "node_type":"gp1_xs", "autoscaling":false, "size":1, "min_size":0,
       "max_size":1, "container_runtime":"containerd", "autohealing":false, "tags":[],
       "placement_group_id":null, "kubelet_args":{}, "upgrade_policy":{"max_unavailable":1,
       "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd", "root_volume_size":150000000000,
-      "public_ip_disabled":false}]}'
+      "public_ip_disabled":false, "new_images_enabled":false, "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}]}'
     headers:
       Content-Length:
-      - "648"
+      - "736"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:07 GMT
+      - Wed, 30 Jul 2025 13:50:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1379,41 +1605,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6def0c5-2505-4dad-aad7-e510a0eb32c2
+      - ac755406-80e9-4fa7-b0d4-c60e29460242
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:07 GMT
+      - Wed, 30 Jul 2025 13:50:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1423,41 +1651,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a370e0f-e2fe-4edb-a1aa-aa73df434148
+      - 7db832c0-a9cf-4979-9ebd-772003a91772
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:12 GMT
+      - Wed, 30 Jul 2025 13:50:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1467,41 +1697,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f72e42f1-c386-449b-983a-aa45136a7e92
+      - cfe3221e-7df6-4a91-8cd7-1c043541818c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:17 GMT
+      - Wed, 30 Jul 2025 13:50:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1511,41 +1743,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca18b397-47ab-4429-9040-0a5e9ba46411
+      - 057d8e27-2bb8-4b9a-9d66-1fb31c21c91c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:22 GMT
+      - Wed, 30 Jul 2025 13:50:43 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1555,41 +1789,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae7b0403-ad7b-4bc4-ae05-2fa78a2dd7fa
+      - 9348d299-3d95-471f-aedc-a685a5861484
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:27 GMT
+      - Wed, 30 Jul 2025 13:50:48 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1599,41 +1835,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47ab7f2e-db33-4090-a14c-dd76474890a2
+      - 4d0f6161-81e6-4490-9428-2fb32f4b0af0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:32 GMT
+      - Wed, 30 Jul 2025 13:50:53 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1643,41 +1881,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 875772c1-2056-4f47-8434-0ae185de2834
+      - 14fdb6a8-a41d-49af-8819-afa164114484
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:37 GMT
+      - Wed, 30 Jul 2025 13:50:58 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1687,41 +1927,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd501905-48e0-4352-b265-80f9a6bf54ea
+      - f980e4c7-a2cf-469d-ad5c-06a9995f5701
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:42 GMT
+      - Wed, 30 Jul 2025 13:51:03 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1731,41 +1973,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7cbb386-ad29-4753-89f5-403a19ef83bc
+      - 5e5e566d-1030-4e33-86e6-0e275ccb429b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:47 GMT
+      - Wed, 30 Jul 2025 13:51:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1775,41 +2019,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d772869-5d71-4a30-a042-637605dc7cbc
+      - b3aec758-4052-4649-9aee-16eb1bc9939a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:53 GMT
+      - Wed, 30 Jul 2025 13:51:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1819,41 +2065,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebcc09ec-0beb-47fd-9e9e-7b1fb85f66cc
+      - f07d7bdf-e076-48de-8e4d-8cb8808821cd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:52:58 GMT
+      - Wed, 30 Jul 2025 13:51:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1863,41 +2111,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8459d05-b729-4354-8f29-6c2a1f7d1fb6
+      - e5f394f0-e512-4485-b490-6ba71d73976e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:03 GMT
+      - Wed, 30 Jul 2025 13:51:24 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1907,41 +2157,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 495ca5a7-cd7e-4f40-a258-a97491e20a5d
+      - f885fb75-abd2-4f70-8da2-ef533ef18a68
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:08 GMT
+      - Wed, 30 Jul 2025 13:51:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1951,41 +2203,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e18f3f4b-b6d3-4bc2-aff1-bf8d07f751b4
+      - dc0746b9-216c-439e-b468-f1bfc414c6c6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:13 GMT
+      - Wed, 30 Jul 2025 13:51:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -1995,41 +2249,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0789987-7672-4d3b-8f48-2ba0b525f072
+      - c009bd4f-21e8-41da-a4bc-a6d24bb4f4b5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:18 GMT
+      - Wed, 30 Jul 2025 13:51:39 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2039,41 +2295,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 543ac11c-8195-41b7-91c9-83a13977726e
+      - a5a8880d-f82e-4390-9759-02fc065fa246
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:23 GMT
+      - Wed, 30 Jul 2025 13:51:44 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2083,41 +2341,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d714750a-309c-4ac5-9e6e-f35a69af01dd
+      - 4661d538-a808-40be-841e-a883b883c430
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:28 GMT
+      - Wed, 30 Jul 2025 13:51:49 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2127,41 +2387,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 630a01fc-4f01-48f4-ab36-368273655e1f
+      - c2784b57-85cf-4992-ad91-4f577b508e16
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:33 GMT
+      - Wed, 30 Jul 2025 13:51:54 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2171,41 +2433,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2ddafa8-166e-4d50-889e-4c16e850b60f
+      - bb9118c9-02ec-4966-83ce-1bc3bb0a084f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:38 GMT
+      - Wed, 30 Jul 2025 13:51:59 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2215,41 +2479,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 879f1aa1-f2e1-4201-b07b-fa0389d13c20
+      - 926e9528-59c5-40f1-9588-16e81ccd53e4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:43 GMT
+      - Wed, 30 Jul 2025 13:52:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2259,41 +2525,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a9ad43a-f126-4eb6-8d5c-a299eddb365c
+      - 152b7bdf-7301-4cb5-8b71-fd0a2fdcd265
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:48 GMT
+      - Wed, 30 Jul 2025 13:52:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2303,41 +2571,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8760113b-02ea-4b0e-9ec7-5af9bcdad80b
+      - 48748930-d5a9-45b0-ac96-58c14924ff56
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:53 GMT
+      - Wed, 30 Jul 2025 13:52:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2347,41 +2617,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d5d166c-60fb-4b36-8af7-1268dd06173f
+      - 6178329c-f512-46a0-b873-a1ba686a6869
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:53:58 GMT
+      - Wed, 30 Jul 2025 13:52:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2391,41 +2663,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92407ff7-2c50-4e12-ad1a-e0ef1f604468
+      - 1dc95f33-336c-4aff-8876-02a8a71ca524
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:03 GMT
+      - Wed, 30 Jul 2025 13:52:24 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2435,41 +2709,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bb645a7-6814-40fa-a6b0-87918e869f3a
+      - c5420fbb-213c-41b8-b30d-afc28e8c39e3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:08 GMT
+      - Wed, 30 Jul 2025 13:52:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2479,41 +2755,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03476a91-a474-4cf3-ad60-9fbbedd5bf80
+      - 776c7a17-9e52-4cda-938e-495390940ce5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:13 GMT
+      - Wed, 30 Jul 2025 13:52:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2523,41 +2801,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7362a25-8589-48ff-9b12-26525f56861a
+      - 5738613a-ef57-406d-9d74-67715060febe
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:18 GMT
+      - Wed, 30 Jul 2025 13:52:39 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2567,41 +2847,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56b202f1-1901-489c-8bd9-dbb22261f8aa
+      - ca68faeb-d9bd-4e33-b356-6f25f5c65a29
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:23 GMT
+      - Wed, 30 Jul 2025 13:52:44 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2611,41 +2893,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e93c9fa-e250-4cb3-8d87-de76f2902c7a
+      - a4ff8d56-9667-4043-a825-81a16f47de51
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:28 GMT
+      - Wed, 30 Jul 2025 13:52:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2655,41 +2939,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12003dc6-d680-4287-8513-b154b87c1992
+      - ae3daae6-d6a1-42a3-9ee1-e403366f9e9f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:33 GMT
+      - Wed, 30 Jul 2025 13:52:55 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2699,41 +2985,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02840b68-e704-47fc-bab9-63464ceec0ea
+      - 08ed61dd-bb2f-4ca3-8308-e343b65a87bd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:39 GMT
+      - Wed, 30 Jul 2025 13:53:01 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2743,41 +3031,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2753bc22-3eaa-4be5-8db9-2ab7cc942645
+      - d1f285bb-3222-430e-9d45-5a851d02a7e9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:44 GMT
+      - Wed, 30 Jul 2025 13:53:06 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2787,41 +3077,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b651c8-f629-4484-96b0-0cf13b12feed
+      - 54c9902f-7387-437b-92e9-9295c81b6858
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:49 GMT
+      - Wed, 30 Jul 2025 13:53:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2831,41 +3123,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fff24988-b1c0-4ad7-915d-f219cc6f6986
+      - 12518f94-128a-4e81-a9e4-b730d081f951
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:54 GMT
+      - Wed, 30 Jul 2025 13:53:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2875,41 +3169,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b484517-c226-420d-aecb-9f9655267ff6
+      - 6733f03e-0a4b-4bcc-96a5-49e9b23c0822
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:54:59 GMT
+      - Wed, 30 Jul 2025 13:53:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2919,41 +3215,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a49868e4-b4fc-4f63-a4fb-5ab81683ca83
+      - 6d905ab6-9154-4797-918e-ad7aeb2320a2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:04 GMT
+      - Wed, 30 Jul 2025 13:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -2963,41 +3261,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0948c407-4678-4391-9c4b-ead3bb041eb7
+      - 143476d1-2a81-45ea-91dc-c1e8075c1fa9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:09 GMT
+      - Wed, 30 Jul 2025 13:53:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3007,41 +3307,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a94ce50c-511d-450d-bc2e-52399529bba9
+      - c544ab92-481a-48c3-a6fc-e0215d1c883f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:14 GMT
+      - Wed, 30 Jul 2025 13:53:36 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3051,41 +3353,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de3134c9-d396-42f6-9165-c961c055a61c
+      - 0b51a3f6-f446-480b-ad93-ca59862e0c21
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:50:35.082285Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:48:41.446445Z",
       "name":"default", "status":"scaling", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "619"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:19 GMT
+      - Wed, 30 Jul 2025 13:53:41 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3095,41 +3399,43 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff95461a-6cf0-4fc3-b943-1fc663cb43a7
+      - 34224927-f2d0-4128-bcd0-3346ddf2e5b0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:55:23.038022Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:53:43.490527Z",
       "name":"default", "status":"ready", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/c256c3d6-2469-42b0-8528-dbbdd178ab0f
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/pools/f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"c256c3d6-2469-42b0-8528-dbbdd178ab0f", "cluster_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
-      "created_at":"2025-05-14T11:50:35.082285Z", "updated_at":"2025-05-14T11:55:23.038022Z",
+    body: '{"region":"fr-par", "id":"f3b5fc12-a57f-4c67-a8ca-df9d7c14d5f2", "cluster_id":"1bb9c594-04d0-489c-83c7-5722321c0b69",
+      "created_at":"2025-07-30T13:48:41.446445Z", "updated_at":"2025-07-30T13:53:43.490527Z",
       "name":"default", "status":"ready", "version":"1.32.3", "node_type":"gp1_xs",
       "autoscaling":false, "size":1, "min_size":0, "max_size":1, "container_runtime":"containerd",
       "autohealing":false, "tags":[], "placement_group_id":null, "kubelet_args":{},
       "upgrade_policy":{"max_unavailable":1, "max_surge":0}, "zone":"fr-par-1", "root_volume_type":"l_ssd",
-      "root_volume_size":150000000000, "public_ip_disabled":false}'
+      "root_volume_size":150000000000, "public_ip_disabled":false, "new_images_enabled":false,
+      "security_group_id":"592f683f-83b9-47e4-9434-ca1931bdaa4b"}'
     headers:
       Content-Length:
-      - "617"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:24 GMT
+      - Wed, 30 Jul 2025 13:53:46 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3139,57 +3445,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 963b5550-f137-4ef6-b368-a1a18c0a7e08
+      - 40200e08-5155-4159-9690-2823006f6681
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859?with_additional_resources=true
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69?with_additional_resources=true
     method: DELETE
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:24 GMT
+      - Wed, 30 Jul 2025 13:53:46 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3199,57 +3507,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27174516-c729-44fe-91b6-3a842ca29490
+      - d9246173-3b88-4283-8a07-0e4a4d9d4d1b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:24 GMT
+      - Wed, 30 Jul 2025 13:53:46 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3259,57 +3569,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d97fcdd-2f26-4aff-9695-68d363f83039
+      - a2752a7a-2d93-4619-8d91-445280942f11
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:29 GMT
+      - Wed, 30 Jul 2025 13:53:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3319,57 +3631,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ea2db57-85e6-4ac4-8eee-0fcd680959a8
+      - 44d4cf05-4348-48e1-94ab-50a5e445f678
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:34 GMT
+      - Wed, 30 Jul 2025 13:53:57 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3379,57 +3693,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66698326-bc99-45a2-a615-0c1c3cbc728c
+      - a0e54112-e09f-455f-b890-b1857182e965
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:39 GMT
+      - Wed, 30 Jul 2025 13:54:02 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3439,57 +3755,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7297bd17-d555-4b21-b6ce-95f2387f7f71
+      - 4910dcac-0a54-4854-bb62-42a36277f19f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:44 GMT
+      - Wed, 30 Jul 2025 13:54:07 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3499,57 +3817,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cd5d8a9-8d30-4c00-a285-da4b0ea5da12
+      - 0c6d142f-2e20-4aa1-9447-ad8aefaae0bb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:49 GMT
+      - Wed, 30 Jul 2025 13:54:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3559,57 +3879,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9d68116-0686-4955-9100-963561cf3883
+      - c103b82c-b630-4c8a-aac0-896d3b45658b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:54 GMT
+      - Wed, 30 Jul 2025 13:54:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3619,57 +3941,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 122db086-b86f-4ef8-98c2-5669b6b050fd
+      - 697c7b4e-811e-4b28-8ad7-46ba8a707ed7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:55:59 GMT
+      - Wed, 30 Jul 2025 13:54:22 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3679,57 +4003,59 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ec69b9f-61a0-407e-9f80-91bb1769c260
+      - aad274d7-cc4b-4c3a-a76a-9afad4e33f12
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
+    body: '{"region":"fr-par", "id":"1bb9c594-04d0-489c-83c7-5722321c0b69", "organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552",
+      "project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552", "created_at":"2025-07-30T13:48:41.594300Z",
+      "updated_at":"2025-07-30T13:53:46.558610Z", "type":"kapsule", "name":"cli-test-wait-cluster",
       "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+      "cluster_url":"https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+      "dns_wildcard":"*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
       "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
       "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
       "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
       "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
       "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
+      "upgrade_available":true, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
       "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
+      "commitment_ends_at":"2025-07-30T13:48:41.594311Z", "acl_available":true, "iam_nodes_group_id":"296bd2f7-4ed2-4faa-97d5-2850241745b6",
+      "new_images_enabled":false, "pod_cidr":"", "service_cidr":"", "service_dns_ip":""}'
     headers:
       Content-Length:
-      - "1476"
+      - "1558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:56:04 GMT
+      - Wed, 30 Jul 2025 13:54:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3739,80 +4065,20 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f32226e-eadd-4202-b103-47bbc985af58
+      - 4d7c6dd6-3178-4ba3-9a4c-7283e2a91f4f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
-      "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
-      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
-      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
-      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
-      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
-      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
-      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1bb9c594-04d0-489c-83c7-5722321c0b69","type":"not_found"}'
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.1; linux; amd64) cli-e2e-test
+    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/1bb9c594-04d0-489c-83c7-5722321c0b69
     method: GET
   response:
-    body: '{"region":"fr-par", "id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859", "organization_id":"6867048b-fe12-4e96-835e-41c79a39604b",
-      "project_id":"6867048b-fe12-4e96-835e-41c79a39604b", "created_at":"2025-05-14T11:50:35.218849Z",
-      "updated_at":"2025-05-14T11:55:24.465735Z", "type":"kapsule", "name":"cli-test-wait-cluster",
-      "description":"", "status":"deleting", "version":"1.32.3", "cni":"cilium", "tags":[],
-      "cluster_url":"https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-      "dns_wildcard":"*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
-      "autoscaler_config":{"scale_down_disabled":false, "scale_down_delay_after_add":"10m",
-      "estimator":"binpacking", "expander":"random", "ignore_daemonsets_utilization":false,
-      "balance_similar_node_groups":false, "expendable_pods_priority_cutoff":-10,
-      "scale_down_unneeded_time":"10m", "scale_down_utilization_threshold":0.5, "max_graceful_termination_sec":600},
-      "auto_upgrade":{"enabled":false, "maintenance_window":{"start_hour":0, "day":"any"}},
-      "upgrade_available":false, "feature_gates":[], "admission_plugins":[], "open_id_connect_config":{"issuer_url":"",
-      "client_id":"", "username_claim":"", "username_prefix":"", "groups_claim":[],
-      "groups_prefix":"", "required_claim":[]}, "apiserver_cert_sans":[], "private_network_id":"82d14678-d815-412b-ac75-2134d5df987b",
-      "commitment_ends_at":"2025-05-14T11:50:35.218860Z", "acl_available":true, "iam_nodes_group_id":"79520eae-6d9a-402a-a78b-19335adf2f14"}'
-    headers:
-      Content-Length:
-      - "1476"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 14 May 2025 11:56:09 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 99bffcaf-baf3-4d5c-b8e8-6c33a8b2e39d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859","type":"not_found"}'
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.24.2; darwin; arm64) cli-e2e-test
-    url: https://api.scaleway.com/k8s/v1/regions/fr-par/clusters/7ab71cf4-d372-4e2a-8a07-65c5e52d0859
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"7ab71cf4-d372-4e2a-8a07-65c5e52d0859","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"1bb9c594-04d0-489c-83c7-5722321c0b69","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3821,7 +4087,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 14 May 2025 11:56:15 GMT
+      - Wed, 30 Jul 2025 13:54:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
@@ -3831,7 +4097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79e09bc6-91ed-4589-9a0b-8fe5b8abfbc7
+      - 22c3f6d9-bf4d-4e4d-b00e-07b6d15030c7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/internal/namespaces/k8s/v1/testdata/test-wait-cluster-wait-for-pools.golden
+++ b/internal/namespaces/k8s/v1/testdata/test-wait-cluster-wait-for-pools.golden
@@ -1,24 +1,27 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
 🟩🟩🟩 STDOUT️ 🟩🟩🟩️
-ID                7ab71cf4-d372-4e2a-8a07-65c5e52d0859
+ID                1bb9c594-04d0-489c-83c7-5722321c0b69
 Type              kapsule
 Name              cli-test-wait-cluster
 Status            ready
 Version           1.32.3
 Region            fr-par
-OrganizationID    6867048b-fe12-4e96-835e-41c79a39604b
-ProjectID         6867048b-fe12-4e96-835e-41c79a39604b
+OrganizationID    fa1e3217-dc80-42ac-85c3-3f034b78b552
+ProjectID         fa1e3217-dc80-42ac-85c3-3f034b78b552
 Cni               cilium
 Description       -
-ClusterURL        https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443
-DNSWildcard       *.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud
+ClusterURL        https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443
+DNSWildcard       *.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud
 CreatedAt         few seconds ago
 UpdatedAt         few seconds ago
-UpgradeAvailable  false
-PrivateNetworkID  82d14678-d815-412b-ac75-2134d5df987b
+UpgradeAvailable  true
+PrivateNetworkID  bcf823a3-b7c7-4d1f-8939-b8eba6a964bc
 CommitmentEndsAt  few seconds ago
 ACLAvailable      true
-IamNodesGroupID   79520eae-6d9a-402a-a78b-19335adf2f14
+IamNodesGroupID   296bd2f7-4ed2-4faa-97d5-2850241745b6
+NewImagesEnabled  false
+PodCidr           -
+ServiceCidr       -
 
 Autoscaler configuration:
 ScaleDownDisabled              false
@@ -45,19 +48,19 @@ UsernamePrefix  -
 GroupsPrefix    -
 🟩🟩🟩 JSON STDOUT 🟩🟩🟩
 {
-  "id": "7ab71cf4-d372-4e2a-8a07-65c5e52d0859",
+  "id": "1bb9c594-04d0-489c-83c7-5722321c0b69",
   "type": "kapsule",
   "name": "cli-test-wait-cluster",
   "status": "ready",
   "version": "1.32.3",
   "region": "fr-par",
-  "organization_id": "6867048b-fe12-4e96-835e-41c79a39604b",
-  "project_id": "6867048b-fe12-4e96-835e-41c79a39604b",
+  "organization_id": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
+  "project_id": "fa1e3217-dc80-42ac-85c3-3f034b78b552",
   "tags": [],
   "cni": "cilium",
   "description": "",
-  "cluster_url": "https://7ab71cf4-d372-4e2a-8a07-65c5e52d0859.api.k8s.fr-par.scw.cloud:6443",
-  "dns_wildcard": "*.7ab71cf4-d372-4e2a-8a07-65c5e52d0859.nodes.k8s.fr-par.scw.cloud",
+  "cluster_url": "https://1bb9c594-04d0-489c-83c7-5722321c0b69.api.k8s.fr-par.scw.cloud:6443",
+  "dns_wildcard": "*.1bb9c594-04d0-489c-83c7-5722321c0b69.nodes.k8s.fr-par.scw.cloud",
   "created_at": "1970-01-01T00:00:00.0Z",
   "updated_at": "1970-01-01T00:00:00.0Z",
   "autoscaler_config": {
@@ -79,7 +82,7 @@ GroupsPrefix    -
       "day": "any"
     }
   },
-  "upgrade_available": false,
+  "upgrade_available": true,
   "feature_gates": [],
   "admission_plugins": [],
   "open_id_connect_config": {
@@ -92,8 +95,12 @@ GroupsPrefix    -
     "required_claim": []
   },
   "apiserver_cert_sans": [],
-  "private_network_id": "82d14678-d815-412b-ac75-2134d5df987b",
+  "private_network_id": "bcf823a3-b7c7-4d1f-8939-b8eba6a964bc",
   "commitment_ends_at": "1970-01-01T00:00:00.0Z",
   "acl_available": true,
-  "iam_nodes_group_id": "79520eae-6d9a-402a-a78b-19335adf2f14"
+  "iam_nodes_group_id": "296bd2f7-4ed2-4faa-97d5-2850241745b6",
+  "new_images_enabled": false,
+  "pod_cidr": "",
+  "service_cidr": "",
+  "service_dns_ip": ""
 }


### PR DESCRIPTION
Now that the `TryDeletingPrivateNetwork` function is available in the [sdk-go](https://github.com/scaleway/scaleway-sdk-go/pull/2660) we should remove the duplicate.