### PR TITLE
fix(instance): snapshot list: get snapshot using image.Zone

### DIFF
--- a/internal/namespaces/instance/v1/custom_image.go
+++ b/internal/namespaces/instance/v1/custom_image.go
@@ -228,7 +228,7 @@ func imageListBuilder(c *core.Command) *core.Command {
 				if volume.VolumeType == instance.VolumeVolumeTypeSbsSnapshot {
 					blockVolume, err := blockAPI.GetSnapshot(&block.GetSnapshotRequest{
 						SnapshotID: volume.ID,
-						Zone:       volume.Zone,
+						Zone:       image.Zone,
 					}, scw.WithContext(ctx))
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
#4766 introduced a bug by getting snapshots using the zone of the volume, but this field is not present for SBS snapshots in the instance API. 
We should use the zone of the image instead.