### PR TITLE
ci(sweepers): remove debug output for readability

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,6 @@ jobs:
       - name: Run Sweepers
         run: go run -v ./cmd/scw-sweeper
         env:
-          SCW_DEBUG: 1
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}


### PR DESCRIPTION
SCW_DEBUG floods the output of the sweeper task, we should remove it to be able to read the potential error messages.