### PR TITLE
chore: add support for ignore in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -213,3 +213,9 @@ require (
 )
 
 tool gotest.tools/gotestsum
+
+ignore (
+	./docs
+	./scripts
+	./wasm
+)


### PR DESCRIPTION
Requires go 1.25