### PR TITLE
fix(instance): list images: pass arguments to the request

### DIFF
--- a/internal/namespaces/instance/v1/custom_image.go
+++ b/internal/namespaces/instance/v1/custom_image.go
@@ -185,10 +185,15 @@ func imageListBuilder(c *core.Command) *core.Command {
 		// Get images
 		args := argsI.(*customListImageRequest)
 
-		req := &instance.ListImagesRequest{}
-		req.Organization = args.OrganizationID
-		req.Project = args.ProjectID
-		req.Public = scw.BoolPtr(false)
+		req := &instance.ListImagesRequest{
+			Organization: args.OrganizationID,
+			Name:         args.Name,
+			Public:       scw.BoolPtr(false),
+			Arch:         args.Arch,
+			Project:      args.ProjectID,
+			Tags:         args.Tags,
+		}
+
 		client := core.ExtractClient(ctx)
 		api := instance.NewAPI(client)
 		blockAPI := block.NewAPI(client)


### PR DESCRIPTION
This PR fixes a bug introduced by #5032: only `organization_id` and `project_id` arguments were correctly passed to the request. 