### PR TITLE
fix(rdb): remove AfterFuncWhenUpdatingCassette wrapper to ensure backups are cleaned up after every test run

### DIFF
--- a/internal/namespaces/rdb/v1/custom_backup_test.go
+++ b/internal/namespaces/rdb/v1/custom_backup_test.go
@@ -27,9 +27,7 @@ func Test_CreateBackup(t *testing.T) {
 		Cmd:   "scw rdb backup create name=foobar expires-at=2032-01-02T15:04:05-07:00 instance-id={{ .Instance.ID }} database-name=rdb --wait",
 		Check: core.TestCheckGolden(),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.ExecAfterCmd("scw rdb backup delete {{ .CmdResult.ID }}"),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .CmdResult.ID }}"),
 			deleteInstance(),
 		),
 		DefaultRegion: scw.RegionNlAms,
@@ -60,9 +58,7 @@ func Test_RestoreBackup(t *testing.T) {
 			core.TestCheckExitCode(0),
 		),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
 			deleteInstance(),
 		),
 	}))
@@ -92,9 +88,7 @@ func Test_ExportBackup(t *testing.T) {
 			core.TestCheckExitCode(0),
 		),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
 			deleteInstance(),
 		),
 	}))
@@ -120,9 +114,7 @@ func Test_DownloadBackup(t *testing.T) {
 			core.TestCheckExitCode(0),
 		),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
 			deleteInstance(),
 			func(_ *core.AfterFuncCtx) error {
 				err := os.Remove("simple_dump")
@@ -149,9 +141,7 @@ func Test_DownloadBackup(t *testing.T) {
 			core.TestCheckExitCode(0),
 		),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .Backup.ID }}"),
 			deleteInstance(),
 			func(_ *core.AfterFuncCtx) error {
 				err := os.Remove("no_previous_export_dump")
@@ -191,12 +181,8 @@ func Test_ListBackup(t *testing.T) {
 			core.TestCheckExitCode(0),
 		),
 		AfterFunc: core.AfterFuncCombine(
-			core.AfterFuncWhenUpdatingCassette(
-				core.AfterFuncCombine(
-					core.ExecAfterCmd("scw rdb backup delete {{ .BackupA.ID }}"),
-					core.ExecAfterCmd("scw rdb backup delete {{ .BackupB.ID }}"),
-				),
-			),
+			core.ExecAfterCmd("scw rdb backup delete {{ .BackupA.ID }}"),
+			core.ExecAfterCmd("scw rdb backup delete {{ .BackupB.ID }}"),
 			deleteInstance(),
 		),
 	}))


### PR DESCRIPTION

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
