### PR TITLE
test(instance): remove unused parameters from test helper functions

### DIFF
--- a/internal/namespaces/instance/v1/custom_image_test.go
+++ b/internal/namespaces/instance/v1/custom_image_test.go
@@ -280,7 +280,7 @@ func Test_ImageUpdate(t *testing.T) {
 			AfterFunc: core.AfterFuncCombine(
 				deleteServer("Server"),
 				deleteImage("ImageExtraVol"),
-				deleteVolume("Volume"),
+				deleteVolume(),
 			),
 		})
 	})

--- a/internal/namespaces/instance/v1/custom_server_create_test.go
+++ b/internal/namespaces/instance/v1/custom_server_create_test.go
@@ -328,7 +328,7 @@ func Test_CreateServer(t *testing.T) {
 				block.GetCommands(),
 			),
 			BeforeFunc: core.BeforeFuncCombine(
-				createSbsVolume("Volume", 20),
+				createSbsVolume(20),
 			),
 			Cmd: testServerCommand(
 				"image=ubuntu_jammy additional-volumes.0={{.Volume.ID}} stopped=true",
@@ -381,7 +381,7 @@ func Test_CreateServer(t *testing.T) {
 				block.GetCommands(),
 			),
 			BeforeFunc: core.BeforeFuncCombine(
-				createSbsVolume("Volume", 20),
+				createSbsVolume(20),
 			),
 			Cmd: testServerCommand("image=none root-volume={{.Volume.ID}} stopped=true"),
 			Check: core.TestCheckCombine(
@@ -689,13 +689,13 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid total local volumes size: too low 3", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: createVolume("Volume", 5, instanceSDK.VolumeVolumeTypeLSSD),
+		BeforeFunc: createVolume(5),
 		Cmd:        testServerCommand("image=ubuntu_jammy root-volume={{ .Volume.ID }}"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
 		),
-		AfterFunc:       deleteVolume("Volume"),
+		AfterFunc:       deleteVolume(),
 		DisableParallel: true,
 	}))
 
@@ -723,7 +723,7 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: invalid total local volumes size: too high 3", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: createVolume("Volume", 20, instanceSDK.VolumeVolumeTypeLSSD),
+		BeforeFunc: createVolume(20),
 		Cmd: testServerCommand(
 			"image=ubuntu_jammy root-volume={{ .Volume.ID }} additional-volumes.0=local:10GB",
 		),
@@ -731,7 +731,7 @@ func Test_CreateServerErrors(t *testing.T) {
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
 		),
-		AfterFunc:       deleteVolume("Volume"),
+		AfterFunc:       deleteVolume(),
 		DisableParallel: true,
 	}))
 
@@ -749,13 +749,13 @@ func Test_CreateServerErrors(t *testing.T) {
 
 	t.Run("Error: disallow existing root volume ID", core.Test(&core.TestConfig{
 		Commands:   instance.GetCommands(),
-		BeforeFunc: createVolume("Volume", 20, instanceSDK.VolumeVolumeTypeLSSD),
+		BeforeFunc: createVolume(20),
 		Cmd:        testServerCommand("image=ubuntu_jammy root-volume={{ .Volume.ID }}"),
 		Check: core.TestCheckCombine(
 			core.TestCheckGolden(),
 			core.TestCheckExitCode(1),
 		),
-		AfterFunc:       deleteVolume("Volume"),
+		AfterFunc:       deleteVolume(),
 		DisableParallel: true,
 	}))
 

--- a/internal/namespaces/instance/v1/custom_server_test.go
+++ b/internal/namespaces/instance/v1/custom_server_test.go
@@ -25,7 +25,7 @@ func Test_ServerVolumeUpdate(t *testing.T) {
 			),
 			BeforeFunc: core.BeforeFuncCombine(
 				createServer("Server"),
-				createSbsVolume("Volume", 10),
+				createSbsVolume(10),
 			),
 			Cmd: "scw instance server attach-volume server-id={{ .Server.ID }} volume-id={{ .Volume.ID }}",
 			Check: core.TestCheckCombine(
@@ -51,7 +51,7 @@ func Test_ServerVolumeUpdate(t *testing.T) {
 			Commands: instance.GetCommands(),
 			BeforeFunc: core.BeforeFuncCombine(
 				createServer("Server"),
-				createVolume("Volume", 10, instanceSDK.VolumeVolumeTypeLSSD),
+				createVolume(10),
 			),
 			Cmd: "scw instance server attach-volume server-id={{ .Server.ID }} volume-id={{ .Volume.ID }}",
 			Check: core.TestCheckCombine(
@@ -283,7 +283,7 @@ func Test_ServerUpdateCustom(t *testing.T) {
 			),
 			BeforeFunc: core.BeforeFuncCombine(
 				createServer("Server"),
-				createSbsVolume("Volume", 10),
+				createSbsVolume(10),
 			),
 			Cmd: `scw instance server update {{ .Server.ID }} volume-ids.0={{ (index .Server.Volumes "0").ID }} volume-ids.1={{ .Volume.ID }}`,
 			Check: core.TestCheckCombine(

--- a/internal/namespaces/instance/v1/custom_snapshot_test.go
+++ b/internal/namespaces/instance/v1/custom_snapshot_test.go
@@ -37,7 +37,7 @@ func Test_UpdateSnapshot(t *testing.T) {
 			),
 			AfterFunc: core.AfterFuncCombine(
 				deleteSnapshot("CreateSnapshot"),
-				deleteVolume("Volume"),
+				deleteVolume(),
 			),
 		}))
 		t.Run("Change name", core.Test(&core.TestConfig{
@@ -65,7 +65,7 @@ func Test_UpdateSnapshot(t *testing.T) {
 			),
 			AfterFunc: core.AfterFuncCombine(
 				deleteSnapshot("CreateSnapshot"),
-				deleteVolume("Volume"),
+				deleteVolume(),
 			),
 		}))
 	})

--- a/internal/namespaces/instance/v1/helpers_test.go
+++ b/internal/namespaces/instance/v1/helpers_test.go
@@ -87,34 +87,31 @@ func deleteServer(metaKey string) core.AfterFunc {
 //
 
 // createVolume creates a volume of the given size and type and
-// register it in the context Meta at metaKey.
+// register it in the context Meta at "Volume".
 func createVolume(
-	metaKey string,
 	sizeInGb int,
-	volumeType instanceSDK.VolumeVolumeType,
 ) core.BeforeFunc {
 	return func(ctx *core.BeforeFuncCtx) error {
 		cmd := fmt.Sprintf(
-			"scw instance volume create name=cli-test size=%dGB volume-type=%s",
+			"scw instance volume create name=cli-test size=%dGB volume-type=l_ssd",
 			sizeInGb,
-			volumeType,
 		)
 		res := ctx.ExecuteCmd(strings.Split(cmd, " "))
 		createVolumeResponse := res.(*instanceSDK.CreateVolumeResponse)
-		ctx.Meta[metaKey] = createVolumeResponse.Volume
+		ctx.Meta["Volume"] = createVolumeResponse.Volume
 
 		return nil
 	}
 }
 
-// deleteVolume deletes a volume previously registered in the context Meta at metaKey.
-func deleteVolume(metaKey string) core.AfterFunc {
-	return core.ExecAfterCmd("scw instance volume delete {{ ." + metaKey + ".ID }}")
+// deleteVolume deletes a volume previously registered in the context Meta at "Volume".
+func deleteVolume() core.AfterFunc {
+	return core.ExecAfterCmd("scw instance volume delete {{ .Volume.ID }}")
 }
 
 // createSbsVolume creates a volume of the given size and
-// register it in the context Meta at metaKey
-func createSbsVolume(metaKey string, sizeInGb int) core.BeforeFunc {
+// register it in the context Meta at "Volume".
+func createSbsVolume(sizeInGb int) core.BeforeFunc {
 	return func(ctx *core.BeforeFuncCtx) error {
 		cmd := fmt.Sprintf(
 			"scw block volume create name=%s from-empty.size=%dGB perf-iops=5000 -w",
@@ -123,7 +120,7 @@ func createSbsVolume(metaKey string, sizeInGb int) core.BeforeFunc {
 		)
 		res := ctx.ExecuteCmd(strings.Split(cmd, " "))
 		volume := res.(*block.Volume)
-		ctx.Meta[metaKey] = volume
+		ctx.Meta["Volume"] = volume
 
 		return nil
 	}


### PR DESCRIPTION
This PR fixes the golangci-lint unparam errors by removing unused parameters from test helper functions:

- `createVolume`: removed `metaKey` (always "Volume") and `volumeType` (always "l_ssd")
- `deleteVolume`: removed `metaKey` (always "Volume")  
- `createSbsVolume`: removed `metaKey` (always "Volume")

All call sites have been updated accordingly.