### PR TITLE
fix(baremetal): handle errors in offer list command

### DIFF
--- a/internal/namespaces/baremetal/v1/custom_offer.go
+++ b/internal/namespaces/baremetal/v1/custom_offer.go
@@ -88,10 +88,13 @@ func serverOfferListBuilder(c *core.Command) *core.Command {
 
 		client := core.ExtractClient(ctx)
 		baremetalAPI := baremetal.NewAPI(client)
-		offers, _ := baremetalAPI.ListOffers(req, scw.WithAllPages())
+		offers, err := baremetalAPI.ListOffers(req, scw.WithAllPages())
+		if err != nil {
+			return nil, err
+		}
 
 		productAPI := productcatalog.NewPublicCatalogAPI(client)
-		environmentalImpact, _ := productAPI.ListPublicCatalogProducts(
+		environmentalImpact, err := productAPI.ListPublicCatalogProducts(
 			&productcatalog.PublicCatalogAPIListPublicCatalogProductsRequest{
 				ProductTypes: []productcatalog.ListPublicCatalogProductsRequestProductType{
 					productcatalog.ListPublicCatalogProductsRequestProductTypeElasticMetal,
@@ -100,6 +103,9 @@ func serverOfferListBuilder(c *core.Command) *core.Command {
 			},
 			scw.WithAllPages(),
 		)
+		if err != nil {
+			return nil, err
+		}
 
 		var unitOfMeasure productcatalog.PublicCatalogProductUnitOfMeasureCountableUnit
 		if req.SubscriptionPeriod == "monthly" {


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference in `baremetal offer list` command
- Add proper error handling for `ListOffers` and `ListPublicCatalogProducts` API calls

## Details
The `ListOffers` and `ListPublicCatalogProducts` API calls were ignoring errors (using `_`), causing a nil pointer dereference when the API returned an error.

Fixes #5278

## Test plan
- [ ] Run `scw baremetal offer list` with invalid/missing credentials - should show proper error instead of panic
- [ ] Run `scw baremetal offer list` with valid credentials - should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)