### PR TITLE
fix(login): properly encode redirect URL

### DIFF
--- a/internal/namespaces/login/login.go
+++ b/internal/namespaces/login/login.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"reflect"
 	"time"
 
@@ -72,7 +73,9 @@ Once you connected to Scaleway, the profile should be configured.
 
 			callbackURL := fmt.Sprintf("http://localhost:%d/callback", wb.Port())
 
-			accountURL := "https://account.scaleway.com/authenticate?redirectToUrl=" + callbackURL
+			params := url.Values{}
+			params.Add("redirectToUrl", callbackURL)
+			accountURL := "https://account.scaleway.com/authenticate?" + params.Encode()
 
 			logger.Debugf("Web server started, waiting for callback on %s\n", callbackURL)
 


### PR DESCRIPTION
## Description

The callback URL in the login flow wasn't getting properly URL-encoded when passed as a query parameter. The auth server was rejecting the redirect because of the unescaped special characters. Switched to using `url.Values` to handle the encoding instead of raw string concatenation.

## Related issues

Fixes #5477

## Release note

Fixed login flow redirect URL encoding issue that was causing "Invalid App to redirect" errors.