### PR TITLE
feat(containers): deploy allow to specify platform

### DIFF
--- a/internal/namespaces/container/v1/custom_deploy.go
+++ b/internal/namespaces/container/v1/custom_deploy.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	pack "github.com/buildpacks/pack/pkg/client"
@@ -21,6 +22,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/scaleway/scaleway-cli/v2/core"
 	"github.com/scaleway/scaleway-cli/v2/internal/namespaces/container/v1/getorcreate"
 	"github.com/scaleway/scaleway-cli/v2/internal/tasks"
@@ -43,6 +45,7 @@ type containerDeployRequest struct {
 	BuildSource string
 	Cache       bool
 	BuildArgs   map[string]*string
+	Platform    string
 
 	NamespaceID *string
 	Port        uint32
@@ -90,6 +93,10 @@ func containerDeployCommand() *core.Command {
 				Name:    "cache",
 				Short:   "Use cache when building the image",
 				Default: core.DefaultValueSetter("true"),
+			},
+			{
+				Name:  "platform",
+				Short: "Platform to build for (e.g., linux/amd64, linux/arm64)",
 			},
 			{
 				Name:     "build-args.{key}",
@@ -295,6 +302,19 @@ func DeployStepDockerBuildImage(
 ) (*DeployStepBuildImageResponse, error) {
 	tag := data.RegistryEndpoint + "/" + data.Args.Name + ":latest"
 
+	var platforms []ocispec.Platform
+	if data.Args.Platform != "" {
+		for _, p := range strings.Split(data.Args.Platform, ",") {
+			parts := strings.Split(strings.TrimSpace(p), "/")
+			if len(parts) == 2 {
+				platforms = append(platforms, ocispec.Platform{
+					OS:           parts[0],
+					Architecture: parts[1],
+				})
+			}
+		}
+	}
+
 	httpClient := core.ExtractHTTPClient(ctx)
 	dockerClient, err := NewCustomDockerClient(httpClient)
 	if err != nil {
@@ -302,15 +322,20 @@ func DeployStepDockerBuildImage(
 	}
 	defer dockerClient.Close()
 
+	buildOpts := client.ImageBuildOptions{
+		Dockerfile: data.Args.Dockerfile,
+		Tags:       []string{tag},
+		NoCache:    !data.Args.Cache,
+		BuildArgs:  data.Args.BuildArgs,
+	}
+	if len(platforms) > 0 {
+		buildOpts.Platforms = platforms
+	}
+
 	imageBuildResponse, err := dockerClient.ImageBuild(
 		ctx,
 		data.Tar,
-		client.ImageBuildOptions{
-			Dockerfile: data.Args.Dockerfile,
-			Tags:       []string{tag},
-			NoCache:    !data.Args.Cache,
-			BuildArgs:  data.Args.BuildArgs,
-		},
+		buildOpts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not build image: %w", errors.Unwrap(err))

--- a/internal/namespaces/container/v1/custom_deploy.go
+++ b/internal/namespaces/container/v1/custom_deploy.go
@@ -295,6 +295,20 @@ type DeployStepBuildImageResponse struct {
 	DockerClient     DockerClient
 }
 
+func parsePlatforms(platformStr string) []ocispec.Platform {
+	var platforms []ocispec.Platform
+	for _, p := range strings.Split(platformStr, ",") {
+		parts := strings.Split(strings.TrimSpace(p), "/")
+		if len(parts) == 2 {
+			platforms = append(platforms, ocispec.Platform{
+				OS:           parts[0],
+				Architecture: parts[1],
+			})
+		}
+	}
+	return platforms
+}
+
 func DeployStepDockerBuildImage(
 	ctx context.Context,
 	t *tasks.Task,
@@ -302,25 +316,14 @@ func DeployStepDockerBuildImage(
 ) (*DeployStepBuildImageResponse, error) {
 	tag := data.RegistryEndpoint + "/" + data.Args.Name + ":latest"
 
-	var platforms []ocispec.Platform
-	if data.Args.Platform != "" {
-		for _, p := range strings.Split(data.Args.Platform, ",") {
-			parts := strings.Split(strings.TrimSpace(p), "/")
-			if len(parts) == 2 {
-				platforms = append(platforms, ocispec.Platform{
-					OS:           parts[0],
-					Architecture: parts[1],
-				})
-			}
-		}
-	}
-
 	httpClient := core.ExtractHTTPClient(ctx)
 	dockerClient, err := NewCustomDockerClient(httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to Docker: %w", err)
 	}
 	defer dockerClient.Close()
+
+	platforms := parsePlatforms(data.Args.Platform)
 
 	buildOpts := client.ImageBuildOptions{
 		Dockerfile: data.Args.Dockerfile,

--- a/internal/namespaces/container/v1/custom_deploy_test.go
+++ b/internal/namespaces/container/v1/custom_deploy_test.go
@@ -112,29 +112,53 @@ func Test_Deploy(t *testing.T) {
 		DisableParallel: true,
 	}))
 
-	buildArgsPath := filepath.Join(path, "build-args")
-	t.Run("Build args", core.Test(&core.TestConfig{
-		Commands: commands,
-		BeforeFunc: core.BeforeFuncCombine(
-			mkdirAllBeforeFunc(buildArgsPath),
-			loadTestdataBeforeFunc(buildArgsPath, "index.html", testdataDockerIndexHTML),
-			loadTestdataBeforeFunc(buildArgsPath, "Dockerfile", testdataDockerDockerfileBuildArgs),
-		),
-		Cmd: fmt.Sprintf(
-			"scw container deploy name=%s build-source=%s port=80 build-args.TEST=thisisatest",
-			appName+"-ba",
-			buildArgsPath,
-		),
-		Check: core.TestCheckCombine(
-			core.TestCheckGolden(),
-			core.TestCheckExitCode(0),
-		),
-		AfterFunc: core.AfterFuncCombine(
-			testDeleteContainersNamespaceAfter(appName+"-ba"),
-			testDeleteRegistryAfter(appName+"-ba"),
-		),
-		DisableParallel: true,
-	}))
+		buildArgsPath := filepath.Join(path, "build-args")
+		t.Run("Build args", core.Test(&core.TestConfig{
+			Commands: commands,
+			BeforeFunc: core.BeforeFuncCombine(
+				mkdirAllBeforeFunc(buildArgsPath),
+				loadTestdataBeforeFunc(buildArgsPath, "index.html", testdataDockerIndexHTML),
+				loadTestdataBeforeFunc(buildArgsPath, "Dockerfile", testdataDockerDockerfileBuildArgs),
+			),
+			Cmd: fmt.Sprintf(
+				"scw container deploy name=%s build-source=%s port=80 build-args.TEST=thisisatest",
+				appName+"-ba",
+				buildArgsPath,
+			),
+			Check: core.TestCheckCombine(
+				core.TestCheckGolden(),
+				core.TestCheckExitCode(0),
+			),
+			AfterFunc: core.AfterFuncCombine(
+				testDeleteContainersNamespaceAfter(appName+"-ba"),
+				testDeleteRegistryAfter(appName+"-ba"),
+			),
+			DisableParallel: true,
+		}))
+
+		platformPath := filepath.Join(path, "platform")
+		t.Run("Platform", core.Test(&core.TestConfig{
+			Commands: commands,
+			BeforeFunc: core.BeforeFuncCombine(
+				mkdirAllBeforeFunc(platformPath),
+				loadTestdataBeforeFunc(platformPath, "index.html", testdataDockerIndexHTML),
+				loadTestdataBeforeFunc(platformPath, "Dockerfile", testdataDockerDockerfile),
+			),
+			Cmd: fmt.Sprintf(
+				"scw container deploy name=%s build-source=%s port=80 platform=linux/amd64",
+				appName+"-pl",
+				platformPath,
+			),
+			Check: core.TestCheckCombine(
+				core.TestCheckGolden(),
+				core.TestCheckExitCode(0),
+			),
+			AfterFunc: core.AfterFuncCombine(
+				testDeleteContainersNamespaceAfter(appName+"-pl"),
+				testDeleteRegistryAfter(appName+"-pl"),
+			),
+			DisableParallel: true,
+		}))
 
 	buildpackPath := filepath.Join(path, "bp")
 	t.Run("Buildpack", core.Test(&core.TestConfig{


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* added `--platform` argument on `scw container deploy` to allow deployment for amd64 as Serverless Containers only support this architecture.
```
