### PR TITLE
docs(docgen): remove ToC from doc template

### DIFF
--- a/internal/docgen/tpl.go
+++ b/internal/docgen/tpl.go
@@ -9,13 +9,6 @@ const tplStr = `
 {{ remove_escape_sequence (.Cmd.Long | default .Cmd.Short) }}
   
 {{ range $resourceName, $resource := .Resources -}}
-- [{{ $resource.Cmd.Short }}](#{{ anchor $resource.Cmd.Short }})
-{{- range $verbName, $cmd := $resource.Verbs }}
-  - [{{ $cmd.Short }}](#{{ anchor $cmd.Short }})
-{{- end }}
-{{ end }}
-  
-{{ range $resourceName, $resource := .Resources -}}
 ## {{ $resource.Cmd.Short }}
 
 {{ $resource.Cmd.Long }}


### PR DESCRIPTION
Removed the section from the doc template that creates tables of contents at the begining of markdown tables, as GitHub/doc website natively provide an outline for markdown files. 

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):

```release-note
Removed automatically-generated table of contents at the begining of documentation pages.
```