### PR TITLE
feat(secret): add inject command

### DIFF
--- a/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
@@ -1,0 +1,52 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+Substitute secret references in a template file with their actual values.
+
+References use the syntax `{{ scw://REFERENCE }}` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}
+
+USAGE:
+  scw secret inject [arg=value ...]
+
+EXAMPLES:
+  Render a template from stdin to stdout
+    echo "password: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject
+
+  Render a template file to an output file
+    scw secret inject in-file=config.tpl out-file=config.yaml
+
+  Extract a JSON field and write to a file with custom permissions
+    scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640
+
+ARGS:
+  [in-file]          Template file to read from (default: stdin)
+  [out-file]         Output file (default: stdout)
+  [file-mode=0600]   Permissions of the output file, in octal (only used with --out-file)
+  [region=fr-par]    Region to target. If none is passed will use default region from the config (fr-par | nl-ams | pl-waw)
+
+FLAGS:
+  -h, --help                help for inject
+      --list-sub-commands   List all subcommands
+
+GLOBAL FLAGS:
+  -c, --config string    The path to the config file
+  -D, --debug            Enable debug mode
+  -o, --output string    Output format: json or human, see 'scw help output' for more info (default "human")
+  -p, --profile string   The config profile to use

--- a/cmd/scw/testdata/test-all-usage-secret-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-secret-usage.golden
@@ -9,6 +9,9 @@ AVAILABLE COMMANDS:
   secret      Secret management commands
   version     Secret Version management commands
 
+SECURITY COMMANDS:
+  inject      Inject Scaleway secrets into a template file
+
 FLAGS:
   -h, --help                help for secret
       --list-sub-commands   List all subcommands

--- a/internal/namespaces/secret/v1beta1/custom.go
+++ b/internal/namespaces/secret/v1beta1/custom.go
@@ -19,5 +19,7 @@ func GetCommands() *core.Commands {
 	cmds.MustFind("secret", "version", "create").Override(secretVersionCreateBuilder)
 	cmds.MustFind("secret", "version", "access").Override(secretVersionAccessBuilder)
 
+	cmds.Merge(core.NewCommands(secretInjectCommand()))
+
 	return cmds
 }

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -1,0 +1,283 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/scaleway/scaleway-cli/v2/core"
+	secret "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// matches {{ scw://REFERENCE }} with optional surrounding whitespace inside braces
+var secretRefRegex = regexp.MustCompile(`\{\{\s*scw://([^\s}]+)\s*\}\}`)
+
+type secretInjectArgs struct {
+	InFile   string
+	OutFile  string
+	FileMode string
+	Region   scw.Region
+}
+
+type parsedSecretRef struct {
+	secretID   string // UUID-based lookup
+	secretName string // name-based lookup
+	secretPath string // path prefix for name-based lookup
+	revision   string
+	field      string
+}
+
+func secretInjectCommand() *core.Command {
+	return &core.Command{
+		Short: `Inject Scaleway secrets into a template file`,
+		Long: `Substitute secret references in a template file with their actual values.
+
+References use the syntax ` + "`{{ scw://REFERENCE }}`" + ` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}`,
+		Namespace: "secret",
+		Resource:  "inject",
+		ArgsType:  reflect.TypeOf(secretInjectArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  "in-file",
+				Short: "Template file to read from (default: stdin)",
+			},
+			{
+				Name:  "out-file",
+				Short: "Output file (default: stdout)",
+			},
+			{
+				Name:    "file-mode",
+				Short:   "Permissions of the output file, in octal (only used with --out-file)",
+				Default: core.DefaultValueSetter("0600"),
+			},
+			core.RegionArgSpec(
+				scw.RegionFrPar,
+				scw.RegionNlAms,
+				scw.RegionPlWaw,
+			),
+		},
+		Groups:         []string{"security"},
+		ExcludeFromMCP: true,
+		Run:            secretInjectRun,
+		Examples: []*core.Example{
+			{
+				Short: "Render a template from stdin to stdout",
+				Raw:   `echo "password: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject`,
+			},
+			{
+				Short: "Render a template file to an output file",
+				Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml`,
+			},
+		{
+			Short: "Extract a JSON field and write to a file with custom permissions",
+			Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640`,
+		},
+		},
+	}
+}
+
+func secretInjectRun(ctx context.Context, argsI any) (any, error) {
+	args := argsI.(*secretInjectArgs)
+
+	input, err := readInjectInput(ctx, args.InFile)
+	if err != nil {
+		return nil, err
+	}
+
+	api := secret.NewAPI(core.ExtractClient(ctx))
+
+	rendered, err := renderTemplate(input, api, args.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	if args.OutFile != "" {
+		mode, err := strconv.ParseUint(args.FileMode, 8, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid file-mode %q: expected octal value like 0600", args.FileMode)
+		}
+		if err := os.WriteFile(args.OutFile, []byte(rendered), os.FileMode(mode)); err != nil {
+			return nil, fmt.Errorf("writing output file: %w", err)
+		}
+		return &core.SuccessResult{Empty: true}, nil
+	}
+
+	return core.RawResult(rendered), nil
+}
+
+func readInjectInput(ctx context.Context, inFile string) (string, error) {
+	if inFile != "" {
+		data, err := os.ReadFile(inFile)
+		if err != nil {
+			return "", fmt.Errorf("reading template file: %w", err)
+		}
+		return string(data), nil
+	}
+
+	data, err := io.ReadAll(core.ExtractStdin(ctx))
+	if err != nil {
+		return "", fmt.Errorf("reading stdin: %w", err)
+	}
+	return string(data), nil
+}
+
+func renderTemplate(input string, api *secret.API, region scw.Region) (string, error) {
+	// Collect unique references first to batch-deduplicate API calls.
+	matches := secretRefRegex.FindAllStringSubmatch(input, -1)
+	cache := make(map[string]string, len(matches))
+
+	for _, m := range matches {
+		rawRef := m[1]
+		if _, seen := cache[rawRef]; seen {
+			continue
+		}
+
+		ref, err := parseSecretRef(rawRef)
+		if err != nil {
+			return "", fmt.Errorf("invalid reference %q: %w", rawRef, err)
+		}
+
+		value, err := resolveSecretRef(api, ref, region)
+		if err != nil {
+			return "", fmt.Errorf("resolving {{ scw://%s }}: %w", rawRef, err)
+		}
+
+		cache[rawRef] = value
+	}
+
+	var replaceErr error
+	rendered := secretRefRegex.ReplaceAllStringFunc(input, func(match string) string {
+		sub := secretRefRegex.FindStringSubmatch(match)
+		return cache[sub[1]]
+	})
+	if replaceErr != nil {
+		return "", replaceErr
+	}
+
+	return rendered, nil
+}
+
+// parseSecretRef parses a reference of the form:
+//
+//	(UUID|PATH/NAME)[@REVISION][:FIELD]
+func parseSecretRef(raw string) (*parsedSecretRef, error) {
+	ref := &parsedSecretRef{revision: "latest"}
+
+	// Strip optional :FIELD (last colon, since neither UUID nor revision contain one)
+	if idx := strings.LastIndex(raw, ":"); idx != -1 {
+		ref.field = raw[idx+1:]
+		raw = raw[:idx]
+		if ref.field == "" {
+			return nil, fmt.Errorf("empty field name after ':'")
+		}
+	}
+
+	// Strip optional @REVISION
+	if idx := strings.Index(raw, "@"); idx != -1 {
+		ref.revision = raw[idx+1:]
+		raw = raw[:idx]
+		if ref.revision == "" {
+			return nil, fmt.Errorf("empty revision after '@'")
+		}
+	}
+
+	if raw == "" {
+		return nil, fmt.Errorf("empty secret identifier")
+	}
+
+	if isSecretUUID(raw) {
+		ref.secretID = raw
+	} else {
+		// PATH/NAME: last path segment is the name, the rest is the path.
+		if idx := strings.LastIndex(raw, "/"); idx != -1 {
+			ref.secretPath = "/" + strings.TrimPrefix(raw[:idx], "/")
+			ref.secretName = raw[idx+1:]
+		} else {
+			ref.secretPath = "/"
+			ref.secretName = raw
+		}
+		if ref.secretName == "" {
+			return nil, fmt.Errorf("empty secret name in path reference")
+		}
+	}
+
+	return ref, nil
+}
+
+func isSecretUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func resolveSecretRef(api *secret.API, ref *parsedSecretRef, region scw.Region) (string, error) {
+	var (
+		resp *secret.AccessSecretVersionResponse
+		err  error
+	)
+
+	if ref.secretID != "" {
+		resp, err = api.AccessSecretVersion(&secret.AccessSecretVersionRequest{
+			Region:   region,
+			SecretID: ref.secretID,
+			Revision: ref.revision,
+		})
+	} else {
+		resp, err = api.AccessSecretVersionByPath(&secret.AccessSecretVersionByPathRequest{
+			Region:     region,
+			SecretName: ref.secretName,
+			SecretPath: ref.secretPath,
+			Revision:   ref.revision,
+		})
+	}
+	if err != nil {
+		return "", err
+	}
+
+	data := resp.Data
+	if ref.field != "" {
+		data, err = getSecretVersionField(data, ref.field)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return string(data), nil
+}

--- a/internal/namespaces/secret/v1beta1/custom_inject_test.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject_test.go
@@ -1,0 +1,119 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseSecretRef(t *testing.T) {
+	tests := []struct {
+		raw          string
+		wantID       string
+		wantName     string
+		wantPath     string
+		wantRevision string
+		wantField    string
+		wantErr      bool
+	}{
+		{
+			raw:          "11111111-1111-1111-1111-111111111111",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111@2",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "2",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111:api-key",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+			wantField:    "api-key",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111@latest:api-key",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+			wantField:    "api-key",
+		},
+		{
+			raw:          "my-secret",
+			wantName:     "my-secret",
+			wantPath:     "/",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "db/my-secret",
+			wantName:     "my-secret",
+			wantPath:     "/db",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "my-app/db/password@2:key",
+			wantName:     "password",
+			wantPath:     "/my-app/db",
+			wantRevision: "2",
+			wantField:    "key",
+		},
+		{
+			raw:     "@",
+			wantErr: true,
+		},
+		{
+			raw:     "my-secret:",
+			wantErr: true,
+		},
+		{
+			raw:     "my-secret@",
+			wantErr: true,
+		},
+		{
+			raw:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			ref, err := parseSecretRef(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, ref.secretID)
+			assert.Equal(t, tt.wantName, ref.secretName)
+			assert.Equal(t, tt.wantPath, ref.secretPath)
+			assert.Equal(t, tt.wantRevision, ref.revision)
+			assert.Equal(t, tt.wantField, ref.field)
+		})
+	}
+}
+
+func Test_RenderTemplate_NoRefs(t *testing.T) {
+	rendered, err := renderTemplate("hello world\nno secrets here", nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\nno secrets here", rendered)
+}
+
+func Test_IsSecretUUID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"11111111-1111-1111-1111-111111111111", true},
+		{"abcdef01-abcd-abcd-abcd-abcdef012345", true},
+		{"not-a-uuid", false},
+		{"11111111-1111-1111-1111-11111111111G", false}, // uppercase G
+		{"11111111-1111-1111-1111-111111111111X", false}, // too long
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSecretUUID(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #0000

## Summary

- Adds `scw secret inject` command that substitutes `{{ scw://REFERENCE }}` placeholders in a template file with actual secret values, similar to `op inject` from 1Password CLI.
- Reads from `--in-file` or stdin, writes to `--out-file` or stdout. Output files default to `0600` permissions (configurable via `--file-mode`).
- Duplicate references in the same template are deduplicated — only one API call per unique reference.

## Changes

### Reference syntax

Template files use `{{ scw://REFERENCE }}` placeholders where `REFERENCE` supports:

| Form | Lookup |
|---|---|
| `UUID` | by secret ID, latest revision |
| `UUID@REVISION` | by secret ID, specific revision |
| `UUID:FIELD` | by secret ID, extract JSON field |
| `PATH/NAME@REVISION:FIELD` | by path + name, revision, JSON field |

`REVISION` can be an integer, `latest`, or `latest_enabled`. `FIELD` extracts a string key from a JSON-encoded secret payload.

### Usage

```bash
# stdin → stdout
echo "token: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject

# file → file (secure permissions by default)
scw secret inject in-file=config.tpl out-file=config.yaml

# custom output permissions
scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640
```

```release-note
Add `scw secret inject` command to substitute `{{ scw://... }}` secret references in template files, reading from stdin or a file and writing to stdout or a file (default mode `0600`).
```