### PR TITLE
feat(secret): add inject command to substitute secret references in template files

### DIFF
--- a/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
@@ -1,0 +1,52 @@
+🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
+🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+Substitute secret references in a template file with their actual values.
+
+References use the syntax `{{ scw://REFERENCE }}` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}
+
+USAGE:
+  scw secret inject [arg=value ...]
+
+EXAMPLES:
+  Render a template from stdin to stdout
+    echo "password: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject
+
+  Render a template file to an output file
+    scw secret inject in-file=config.tpl out-file=config.yaml
+
+  Extract a JSON field and write to a file with custom permissions
+    scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640
+
+ARGS:
+  [in-file]          Template file to read from (default: stdin)
+  [out-file]         Output file (default: stdout)
+  [file-mode=0600]   Permissions of the output file, in octal (only used with --out-file)
+  [region=fr-par]    Region to target. If none is passed will use default region from the config (fr-par | nl-ams | pl-waw)
+
+FLAGS:
+  -h, --help                help for inject
+      --list-sub-commands   List all subcommands
+
+GLOBAL FLAGS:
+  -c, --config string    The path to the config file
+  -D, --debug            Enable debug mode
+  -o, --output string    Output format: json or human, see 'scw help output' for more info (default "human")
+  -p, --profile string   The config profile to use

--- a/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-secret-inject-usage.golden
@@ -1,5 +1,5 @@
 🎲🎲🎲 EXIT CODE: 0 🎲🎲🎲
-🟩🟩🟩 STDOUT️ 🟩🟩🟩️
+🟥🟥🟥 STDERR️️ 🟥🟥🟥️
 Substitute secret references in a template file with their actual values.
 
 References use the syntax `{{ scw://REFERENCE }}` where REFERENCE can be:
@@ -42,8 +42,7 @@ ARGS:
   [region=fr-par]    Region to target. If none is passed will use default region from the config (fr-par | nl-ams | pl-waw)
 
 FLAGS:
-  -h, --help                help for inject
-      --list-sub-commands   List all subcommands
+  -h, --help   help for inject
 
 GLOBAL FLAGS:
   -c, --config string    The path to the config file

--- a/cmd/scw/testdata/test-all-usage-secret-usage.golden
+++ b/cmd/scw/testdata/test-all-usage-secret-usage.golden
@@ -9,6 +9,9 @@ AVAILABLE COMMANDS:
   secret      Secret management commands
   version     Secret Version management commands
 
+SECURITY COMMANDS:
+  inject      Inject Scaleway secrets into a template file
+
 FLAGS:
   -h, --help   help for secret
 

--- a/docs/commands/autocomplete.md
+++ b/docs/commands/autocomplete.md
@@ -45,7 +45,7 @@ scw autocomplete script [arg=value ...]
 
 | Name |   | Description |
 |------|---|-------------|
-| shell | Default: `/bin/zsh` |  |
+| shell | Default: `/bin/bash` |  |
 | basename | Default: `` |  |
 
 

--- a/docs/commands/autocomplete.md
+++ b/docs/commands/autocomplete.md
@@ -45,7 +45,7 @@ scw autocomplete script [arg=value ...]
 
 | Name |   | Description |
 |------|---|-------------|
-| shell | Default: `/bin/bash` |  |
+| shell | Default: `/bin/zsh` |  |
 | basename | Default: `` |  |
 
 

--- a/docs/commands/secret.md
+++ b/docs/commands/secret.md
@@ -2,6 +2,7 @@
 # Documentation for `scw secret`
 This API allows you to manage your Secret Manager services, for storing, accessing and sharing sensitive data such as passwords, API keys and certificates.
   
+- [Inject Scaleway secrets into a template file](#inject-scaleway-secrets-into-a-template-file)
 - [Secret management commands](#secret-management-commands)
   - [Allow a product to use the secret](#allow-a-product-to-use-the-secret)
   - [Create a secret](#create-a-secret)
@@ -23,6 +24,90 @@ This API allows you to manage your Secret Manager services, for storing, accessi
   - [Update metadata of a version](#update-metadata-of-a-version)
 
   
+## Inject Scaleway secrets into a template file
+
+Substitute secret references in a template file with their actual values.
+
+References use the syntax `{{ scw://REFERENCE }}` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}
+
+Substitute secret references in a template file with their actual values.
+
+References use the syntax `{{ scw://REFERENCE }}` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}
+
+**Usage:**
+
+```
+scw secret inject [arg=value ...]
+```
+
+
+**Args:**
+
+| Name |   | Description |
+|------|---|-------------|
+| in-file |  | Template file to read from (default: stdin) |
+| out-file |  | Output file (default: stdout) |
+| file-mode | Default: `0600` | Permissions of the output file, in octal (only used with --out-file) |
+| region | Default: `fr-par`<br />One of: `fr-par`, `nl-ams`, `pl-waw` | Region to target. If none is passed will use default region from the config |
+
+
+**Examples:**
+
+
+Render a template from stdin to stdout
+```
+echo "password: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject
+```
+
+Render a template file to an output file
+```
+scw secret inject in-file=config.tpl out-file=config.yaml
+```
+
+Extract a JSON field and write to a file with custom permissions
+```
+scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640
+```
+
+
+
+
 ## Secret management commands
 
 Secrets are logical containers made up of zero or more immutable versions, that contain sensitive data.

--- a/internal/namespaces/secret/v1beta1/custom.go
+++ b/internal/namespaces/secret/v1beta1/custom.go
@@ -19,5 +19,7 @@ func GetCommands() *core.Commands {
 	cmds.MustFind("secret", "version", "create").Override(secretVersionCreateBuilder)
 	cmds.MustFind("secret", "version", "access").Override(secretVersionAccessBuilder)
 
+	cmds.Merge(core.NewCommands(secretInjectCommand()))
+
 	return cmds
 }

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -120,7 +120,10 @@ func secretInjectRun(ctx context.Context, argsI any) (any, error) {
 	if args.OutFile != "" {
 		mode, err := strconv.ParseUint(args.FileMode, 8, 32)
 		if err != nil {
-			return nil, fmt.Errorf("invalid file-mode %q: expected octal value like 0600", args.FileMode)
+			return nil, fmt.Errorf(
+				"invalid file-mode %q: expected octal value like 0600",
+				args.FileMode,
+			)
 		}
 
 		if err := os.WriteFile(args.OutFile, []byte(rendered), os.FileMode(mode)); err != nil {

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -1,0 +1,283 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/scaleway/scaleway-cli/v2/core"
+	secret "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+// matches {{ scw://REFERENCE }} with optional surrounding whitespace inside braces
+var secretRefRegex = regexp.MustCompile(`\{\{\s*scw://([^\s}]+)\s*\}\}`)
+
+type secretInjectArgs struct {
+	InFile   string
+	OutFile  string
+	FileMode string
+	Region   scw.Region
+}
+
+type parsedSecretRef struct {
+	secretID   string // UUID-based lookup
+	secretName string // name-based lookup
+	secretPath string // path prefix for name-based lookup
+	revision   string
+	field      string
+}
+
+func secretInjectCommand() *core.Command {
+	return &core.Command{
+		Short: `Inject Scaleway secrets into a template file`,
+		Long: `Substitute secret references in a template file with their actual values.
+
+References use the syntax ` + "`{{ scw://REFERENCE }}`" + ` where REFERENCE can be:
+
+  UUID                       secret ID, latest revision
+  UUID@REVISION              secret ID, specific revision
+  UUID:FIELD                 secret ID, latest revision, JSON field
+  UUID@REVISION:FIELD        secret ID, specific revision, JSON field
+  NAME                       secret name, latest revision
+  PATH/NAME                  secret by path and name, latest revision
+  PATH/NAME@REVISION:FIELD   path/name with revision and field
+
+REVISION can be an integer, "latest", or "latest_enabled".
+
+FIELD extracts a string field from a JSON-encoded secret.
+
+Examples:
+
+  {{ scw://11111111-1111-1111-1111-111111111111 }}
+  {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
+  {{ scw://my-app/db-password@latest }}`,
+		Namespace: "secret",
+		Resource:  "inject",
+		ArgsType:  reflect.TypeOf(secretInjectArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  "in-file",
+				Short: "Template file to read from (default: stdin)",
+			},
+			{
+				Name:  "out-file",
+				Short: "Output file (default: stdout)",
+			},
+			{
+				Name:    "file-mode",
+				Short:   "Permissions of the output file, in octal (only used with --out-file)",
+				Default: core.DefaultValueSetter("0600"),
+			},
+			core.RegionArgSpec(
+				scw.RegionFrPar,
+				scw.RegionNlAms,
+				scw.RegionPlWaw,
+			),
+		},
+		Groups:         []string{"security"},
+		ExcludeFromMCP: true,
+		Run:            secretInjectRun,
+		Examples: []*core.Example{
+			{
+				Short: "Render a template from stdin to stdout",
+				Raw:   `echo "password: {{ scw://11111111-1111-1111-1111-111111111111 }}" | scw secret inject`,
+			},
+			{
+				Short: "Render a template file to an output file",
+				Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml`,
+			},
+		{
+			Short: "Extract a JSON field and write to a file with custom permissions",
+			Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640`,
+		},
+		},
+	}
+}
+
+func secretInjectRun(ctx context.Context, argsI any) (any, error) {
+	args := argsI.(*secretInjectArgs)
+
+	input, err := readInjectInput(ctx, args.InFile)
+	if err != nil {
+		return nil, err
+	}
+
+	api := secret.NewAPI(core.ExtractClient(ctx))
+
+	rendered, err := renderTemplate(input, api, args.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	if args.OutFile != "" {
+		mode, err := strconv.ParseUint(args.FileMode, 8, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid file-mode %q: expected octal value like 0600", args.FileMode)
+		}
+		if err := os.WriteFile(args.OutFile, []byte(rendered), os.FileMode(mode)); err != nil {
+			return nil, fmt.Errorf("writing output file: %w", err)
+		}
+		return &core.SuccessResult{Empty: true}, nil
+	}
+
+	return core.RawResult(rendered), nil
+}
+
+func readInjectInput(ctx context.Context, inFile string) (string, error) {
+	if inFile != "" {
+		data, err := os.ReadFile(inFile)
+		if err != nil {
+			return "", fmt.Errorf("reading template file: %w", err)
+		}
+		return string(data), nil
+	}
+
+	data, err := io.ReadAll(core.ExtractStdin(ctx))
+	if err != nil {
+		return "", fmt.Errorf("reading stdin: %w", err)
+	}
+	return string(data), nil
+}
+
+func renderTemplate(input string, api *secret.API, region scw.Region) (string, error) {
+	// Collect unique references first to batch-deduplicate API calls.
+	matches := secretRefRegex.FindAllStringSubmatch(input, -1)
+	cache := make(map[string]string, len(matches))
+
+	for _, m := range matches {
+		rawRef := m[1]
+		if _, seen := cache[rawRef]; seen {
+			continue
+		}
+
+		ref, err := parseSecretRef(rawRef)
+		if err != nil {
+			return "", fmt.Errorf("invalid reference %q: %w", rawRef, err)
+		}
+
+		value, err := resolveSecretRef(api, ref, region)
+		if err != nil {
+			return "", fmt.Errorf("resolving {{ scw://%s }}: %w", rawRef, err)
+		}
+
+		cache[rawRef] = value
+	}
+
+	var replaceErr error
+	rendered := secretRefRegex.ReplaceAllStringFunc(input, func(match string) string {
+		sub := secretRefRegex.FindStringSubmatch(match)
+		return cache[sub[1]]
+	})
+	if replaceErr != nil {
+		return "", replaceErr
+	}
+
+	return rendered, nil
+}
+
+// parseSecretRef parses a reference of the form:
+//
+//	(UUID|PATH/NAME)[@REVISION][:FIELD]
+func parseSecretRef(raw string) (*parsedSecretRef, error) {
+	ref := &parsedSecretRef{revision: "latest"}
+
+	// Strip optional :FIELD (last colon, since neither UUID nor revision contain one)
+	if idx := strings.LastIndex(raw, ":"); idx != -1 {
+		ref.field = raw[idx+1:]
+		raw = raw[:idx]
+		if ref.field == "" {
+			return nil, fmt.Errorf("empty field name after ':'")
+		}
+	}
+
+	// Strip optional @REVISION
+	if idx := strings.Index(raw, "@"); idx != -1 {
+		ref.revision = raw[idx+1:]
+		raw = raw[:idx]
+		if ref.revision == "" {
+			return nil, fmt.Errorf("empty revision after '@'")
+		}
+	}
+
+	if raw == "" {
+		return nil, fmt.Errorf("empty secret identifier")
+	}
+
+	if isSecretUUID(raw) {
+		ref.secretID = raw
+	} else {
+		// PATH/NAME: last path segment is the name, the rest is the path.
+		if idx := strings.LastIndex(raw, "/"); idx != -1 {
+			ref.secretPath = "/" + strings.TrimPrefix(raw[:idx], "/")
+			ref.secretName = raw[idx+1:]
+		} else {
+			ref.secretPath = "/"
+			ref.secretName = raw
+		}
+		if ref.secretName == "" {
+			return nil, fmt.Errorf("empty secret name in path reference")
+		}
+	}
+
+	return ref, nil
+}
+
+func isSecretUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func resolveSecretRef(api *secret.API, ref *parsedSecretRef, region scw.Region) (string, error) {
+	var (
+		resp *secret.AccessSecretVersionResponse
+		err  error
+	)
+
+	if ref.secretID != "" {
+		resp, err = api.AccessSecretVersion(&secret.AccessSecretVersionRequest{
+			Region:   region,
+			SecretID: ref.secretID,
+			Revision: ref.revision,
+		})
+	} else {
+		resp, err = api.AccessSecretVersionByPath(&secret.AccessSecretVersionByPathRequest{
+			Region:     region,
+			SecretName: ref.secretName,
+			SecretPath: ref.secretPath,
+			Revision:   ref.revision,
+		})
+	}
+	if err != nil {
+		return "", err
+	}
+
+	data := resp.Data
+	if ref.field != "" {
+		data, err = getSecretVersionField(data, ref.field)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return string(data), nil
+}

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -11,9 +11,12 @@ import (
 	"strconv"
 	"strings"
 
+	"sync"
+
 	"github.com/scaleway/scaleway-cli/v2/core"
 	secret "github.com/scaleway/scaleway-sdk-go/api/secret/v1beta1"
 	"github.com/scaleway/scaleway-sdk-go/scw"
+	"golang.org/x/sync/errgroup"
 )
 
 // matches {{ scw://REFERENCE }} with optional surrounding whitespace inside braces
@@ -155,27 +158,57 @@ func readInjectInput(ctx context.Context, inFile string) (string, error) {
 }
 
 func renderTemplate(input string, api *secret.API, region scw.Region) (string, error) {
-	// Collect unique references first to batch-deduplicate API calls.
 	matches := secretRefRegex.FindAllStringSubmatch(input, -1)
-	cache := make(map[string]string, len(matches))
+
+	// Deduplicate and parse all references before fetching.
+	type pendingRef struct {
+		rawRef string
+		ref    *parsedSecretRef
+	}
+
+	seen := make(map[string]struct{}, len(matches))
+	pending := make([]pendingRef, 0, len(matches))
 
 	for _, m := range matches {
 		rawRef := m[1]
-		if _, seen := cache[rawRef]; seen {
+		if _, ok := seen[rawRef]; ok {
 			continue
 		}
+
+		seen[rawRef] = struct{}{}
 
 		ref, err := parseSecretRef(rawRef)
 		if err != nil {
 			return "", fmt.Errorf("invalid reference %q: %w", rawRef, err)
 		}
 
-		value, err := resolveSecretRef(api, ref, region)
-		if err != nil {
-			return "", fmt.Errorf("resolving {{ scw://%s }}: %w", rawRef, err)
-		}
+		pending = append(pending, pendingRef{rawRef: rawRef, ref: ref})
+	}
 
-		cache[rawRef] = value
+	// Fetch all unique secrets concurrently.
+	var mu sync.Mutex
+
+	cache := make(map[string]string, len(pending))
+	g, _ := errgroup.WithContext(context.Background())
+
+	for _, p := range pending {
+		p := p
+		g.Go(func() error {
+			value, err := resolveSecretRef(api, p.ref, region)
+			if err != nil {
+				return fmt.Errorf("resolving {{ scw://%s }}: %w", p.rawRef, err)
+			}
+
+			mu.Lock()
+			cache[p.rawRef] = value
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return "", err
 	}
 
 	rendered := secretRefRegex.ReplaceAllStringFunc(input, func(match string) string {

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -81,7 +81,6 @@ Examples:
 			),
 		},
 		Groups:         []string{"security"},
-		ExcludeFromMCP: true,
 		Run:            secretInjectRun,
 		Examples: []*core.Example{
 			{

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,8 @@ import (
 
 // matches {{ scw://REFERENCE }} with optional surrounding whitespace inside braces
 var secretRefRegex = regexp.MustCompile(`\{\{\s*scw://([^\s}]+)\s*\}\}`)
+
+const revisionLatest = "latest"
 
 type secretInjectArgs struct {
 	InFile   string
@@ -57,7 +60,7 @@ Examples:
   {{ scw://11111111-1111-1111-1111-111111111111 }}
   {{ scw://11111111-1111-1111-1111-111111111111@2:api-key }}
   {{ scw://my-app/db-password@latest }}`,
-		Namespace: "secret",
+		Namespace: "secret", //nolint:goconst
 		Resource:  "inject",
 		ArgsType:  reflect.TypeOf(secretInjectArgs{}),
 		ArgSpecs: core.ArgSpecs{
@@ -80,8 +83,8 @@ Examples:
 				scw.RegionPlWaw,
 			),
 		},
-		Groups:         []string{"security"},
-		Run:            secretInjectRun,
+		Groups: []string{"security"},
+		Run:    secretInjectRun,
 		Examples: []*core.Example{
 			{
 				Short: "Render a template from stdin to stdout",
@@ -91,10 +94,10 @@ Examples:
 				Short: "Render a template file to an output file",
 				Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml`,
 			},
-		{
-			Short: "Extract a JSON field and write to a file with custom permissions",
-			Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640`,
-		},
+			{
+				Short: "Extract a JSON field and write to a file with custom permissions",
+				Raw:   `scw secret inject in-file=config.tpl out-file=config.yaml file-mode=0640`,
+			},
 		},
 	}
 }
@@ -119,9 +122,11 @@ func secretInjectRun(ctx context.Context, argsI any) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid file-mode %q: expected octal value like 0600", args.FileMode)
 		}
+
 		if err := os.WriteFile(args.OutFile, []byte(rendered), os.FileMode(mode)); err != nil {
 			return nil, fmt.Errorf("writing output file: %w", err)
 		}
+
 		return &core.SuccessResult{Empty: true}, nil
 	}
 
@@ -134,6 +139,7 @@ func readInjectInput(ctx context.Context, inFile string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("reading template file: %w", err)
 		}
+
 		return string(data), nil
 	}
 
@@ -141,6 +147,7 @@ func readInjectInput(ctx context.Context, inFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading stdin: %w", err)
 	}
+
 	return string(data), nil
 }
 
@@ -168,14 +175,11 @@ func renderTemplate(input string, api *secret.API, region scw.Region) (string, e
 		cache[rawRef] = value
 	}
 
-	var replaceErr error
 	rendered := secretRefRegex.ReplaceAllStringFunc(input, func(match string) string {
 		sub := secretRefRegex.FindStringSubmatch(match)
+
 		return cache[sub[1]]
 	})
-	if replaceErr != nil {
-		return "", replaceErr
-	}
 
 	return rendered, nil
 }
@@ -184,14 +188,15 @@ func renderTemplate(input string, api *secret.API, region scw.Region) (string, e
 //
 //	(UUID|PATH/NAME)[@REVISION][:FIELD]
 func parseSecretRef(raw string) (*parsedSecretRef, error) {
-	ref := &parsedSecretRef{revision: "latest"}
+	ref := &parsedSecretRef{revision: revisionLatest}
 
 	// Strip optional :FIELD (last colon, since neither UUID nor revision contain one)
 	if idx := strings.LastIndex(raw, ":"); idx != -1 {
 		ref.field = raw[idx+1:]
 		raw = raw[:idx]
+
 		if ref.field == "" {
-			return nil, fmt.Errorf("empty field name after ':'")
+			return nil, errors.New("empty field name after ':'")
 		}
 	}
 
@@ -199,13 +204,14 @@ func parseSecretRef(raw string) (*parsedSecretRef, error) {
 	if idx := strings.Index(raw, "@"); idx != -1 {
 		ref.revision = raw[idx+1:]
 		raw = raw[:idx]
+
 		if ref.revision == "" {
-			return nil, fmt.Errorf("empty revision after '@'")
+			return nil, errors.New("empty revision after '@'")
 		}
 	}
 
 	if raw == "" {
-		return nil, fmt.Errorf("empty secret identifier")
+		return nil, errors.New("empty secret identifier")
 	}
 
 	if isSecretUUID(raw) {
@@ -219,8 +225,9 @@ func parseSecretRef(raw string) (*parsedSecretRef, error) {
 			ref.secretPath = "/"
 			ref.secretName = raw
 		}
+
 		if ref.secretName == "" {
-			return nil, fmt.Errorf("empty secret name in path reference")
+			return nil, errors.New("empty secret name in path reference")
 		}
 	}
 
@@ -231,6 +238,7 @@ func isSecretUUID(s string) bool {
 	if len(s) != 36 {
 		return false
 	}
+
 	for i, c := range s {
 		switch i {
 		case 8, 13, 18, 23:
@@ -243,6 +251,7 @@ func isSecretUUID(s string) bool {
 			}
 		}
 	}
+
 	return true
 }
 
@@ -266,6 +275,7 @@ func resolveSecretRef(api *secret.API, ref *parsedSecretRef, region scw.Region) 
 			Revision:   ref.revision,
 		})
 	}
+
 	if err != nil {
 		return "", err
 	}

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -128,14 +128,38 @@ func secretInjectRun(ctx context.Context, argsI any) (any, error) {
 			)
 		}
 
-		if err := os.WriteFile(args.OutFile, []byte(rendered), os.FileMode(mode)); err != nil {
-			return nil, fmt.Errorf("writing output file: %w", err)
+		if err := writeOutputFile(args.OutFile, rendered, os.FileMode(mode)); err != nil {
+			return nil, err
 		}
 
 		return &core.SuccessResult{Empty: true}, nil
 	}
 
 	return core.RawResult(rendered), nil
+}
+
+func writeOutputFile(path, content string, mode os.FileMode) (err error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("writing output file: %w", cerr)
+		}
+	}()
+
+	// Chmod before writing so the secret never lands in a wider-mode file.
+	if err := f.Chmod(mode); err != nil {
+		return fmt.Errorf("setting output file permissions: %w", err)
+	}
+
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+
+	return nil
 }
 
 func readInjectInput(ctx context.Context, inFile string) (string, error) {

--- a/internal/namespaces/secret/v1beta1/custom_inject.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
 	"sync"
 
 	"github.com/scaleway/scaleway-cli/v2/core"
@@ -192,7 +191,6 @@ func renderTemplate(input string, api *secret.API, region scw.Region) (string, e
 	g, _ := errgroup.WithContext(context.Background())
 
 	for _, p := range pending {
-		p := p
 		g.Go(func() error {
 			value, err := resolveSecretRef(api, p.ref, region)
 			if err != nil {

--- a/internal/namespaces/secret/v1beta1/custom_inject_test.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject_test.go
@@ -1,0 +1,119 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseSecretRef(t *testing.T) {
+	tests := []struct {
+		raw          string
+		wantID       string
+		wantName     string
+		wantPath     string
+		wantRevision string
+		wantField    string
+		wantErr      bool
+	}{
+		{
+			raw:          "11111111-1111-1111-1111-111111111111",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111@2",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "2",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111:api-key",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+			wantField:    "api-key",
+		},
+		{
+			raw:          "11111111-1111-1111-1111-111111111111@latest:api-key",
+			wantID:       "11111111-1111-1111-1111-111111111111",
+			wantRevision: "latest",
+			wantField:    "api-key",
+		},
+		{
+			raw:          "my-secret",
+			wantName:     "my-secret",
+			wantPath:     "/",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "db/my-secret",
+			wantName:     "my-secret",
+			wantPath:     "/db",
+			wantRevision: "latest",
+		},
+		{
+			raw:          "my-app/db/password@2:key",
+			wantName:     "password",
+			wantPath:     "/my-app/db",
+			wantRevision: "2",
+			wantField:    "key",
+		},
+		{
+			raw:     "@",
+			wantErr: true,
+		},
+		{
+			raw:     "my-secret:",
+			wantErr: true,
+		},
+		{
+			raw:     "my-secret@",
+			wantErr: true,
+		},
+		{
+			raw:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			ref, err := parseSecretRef(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, ref.secretID)
+			assert.Equal(t, tt.wantName, ref.secretName)
+			assert.Equal(t, tt.wantPath, ref.secretPath)
+			assert.Equal(t, tt.wantRevision, ref.revision)
+			assert.Equal(t, tt.wantField, ref.field)
+		})
+	}
+}
+
+func Test_RenderTemplate_NoRefs(t *testing.T) {
+	rendered, err := renderTemplate("hello world\nno secrets here", nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world\nno secrets here", rendered)
+}
+
+func Test_IsSecretUUID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"11111111-1111-1111-1111-111111111111", true},
+		{"abcdef01-abcd-abcd-abcd-abcdef012345", true},
+		{"not-a-uuid", false},
+		{"11111111-1111-1111-1111-11111111111G", false}, // uppercase G
+		{"11111111-1111-1111-1111-111111111111X", false}, // too long
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSecretUUID(tt.input))
+		})
+	}
+}

--- a/internal/namespaces/secret/v1beta1/custom_inject_test.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject_test.go
@@ -3,10 +3,9 @@ package secret_test
 import (
 	"testing"
 
+	secret "github.com/scaleway/scaleway-cli/v2/internal/namespaces/secret/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	secret "github.com/scaleway/scaleway-cli/v2/internal/namespaces/secret/v1beta1"
 )
 
 const (

--- a/internal/namespaces/secret/v1beta1/custom_inject_test.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject_test.go
@@ -1,6 +1,8 @@
 package secret_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	secret "github.com/scaleway/scaleway-cli/v2/internal/namespaces/secret/v1beta1"
@@ -126,4 +128,21 @@ func Test_IsSecretUUID(t *testing.T) {
 			assert.Equal(t, tt.want, secret.IsSecretUUID(tt.input))
 		})
 	}
+}
+
+func Test_WriteOutputFile_EnforcesModeOnExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.yaml")
+
+	// Mimic a leftover world-readable file from a previous run.
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	require.NoError(t, secret.WriteOutputFile(path, "secret-value", 0o600))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value", string(data))
 }

--- a/internal/namespaces/secret/v1beta1/custom_inject_test.go
+++ b/internal/namespaces/secret/v1beta1/custom_inject_test.go
@@ -1,10 +1,18 @@
-package secret
+package secret_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	secret "github.com/scaleway/scaleway-cli/v2/internal/namespaces/secret/v1beta1"
+)
+
+const (
+	testUUID     = "11111111-1111-1111-1111-111111111111"
+	testLatest   = "latest"
+	testMySecret = "my-secret"
 )
 
 func Test_ParseSecretRef(t *testing.T) {
@@ -18,38 +26,38 @@ func Test_ParseSecretRef(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			raw:          "11111111-1111-1111-1111-111111111111",
-			wantID:       "11111111-1111-1111-1111-111111111111",
-			wantRevision: "latest",
+			raw:          testUUID,
+			wantID:       testUUID,
+			wantRevision: testLatest,
 		},
 		{
-			raw:          "11111111-1111-1111-1111-111111111111@2",
-			wantID:       "11111111-1111-1111-1111-111111111111",
+			raw:          testUUID + "@2",
+			wantID:       testUUID,
 			wantRevision: "2",
 		},
 		{
-			raw:          "11111111-1111-1111-1111-111111111111:api-key",
-			wantID:       "11111111-1111-1111-1111-111111111111",
-			wantRevision: "latest",
+			raw:          testUUID + ":api-key",
+			wantID:       testUUID,
+			wantRevision: testLatest,
 			wantField:    "api-key",
 		},
 		{
-			raw:          "11111111-1111-1111-1111-111111111111@latest:api-key",
-			wantID:       "11111111-1111-1111-1111-111111111111",
-			wantRevision: "latest",
+			raw:          testUUID + "@latest:api-key",
+			wantID:       testUUID,
+			wantRevision: testLatest,
 			wantField:    "api-key",
 		},
 		{
-			raw:          "my-secret",
-			wantName:     "my-secret",
+			raw:          testMySecret,
+			wantName:     testMySecret,
 			wantPath:     "/",
-			wantRevision: "latest",
+			wantRevision: testLatest,
 		},
 		{
-			raw:          "db/my-secret",
-			wantName:     "my-secret",
+			raw:          "db/" + testMySecret,
+			wantName:     testMySecret,
 			wantPath:     "/db",
-			wantRevision: "latest",
+			wantRevision: testLatest,
 		},
 		{
 			raw:          "my-app/db/password@2:key",
@@ -63,11 +71,11 @@ func Test_ParseSecretRef(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			raw:     "my-secret:",
+			raw:     testMySecret + ":",
 			wantErr: true,
 		},
 		{
-			raw:     "my-secret@",
+			raw:     testMySecret + "@",
 			wantErr: true,
 		},
 		{
@@ -78,23 +86,25 @@ func Test_ParseSecretRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.raw, func(t *testing.T) {
-			ref, err := parseSecretRef(tt.raw)
+			ref, err := secret.ParseSecretRef(tt.raw)
 			if tt.wantErr {
 				require.Error(t, err)
+
 				return
 			}
+
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantID, ref.secretID)
-			assert.Equal(t, tt.wantName, ref.secretName)
-			assert.Equal(t, tt.wantPath, ref.secretPath)
-			assert.Equal(t, tt.wantRevision, ref.revision)
-			assert.Equal(t, tt.wantField, ref.field)
+			assert.Equal(t, tt.wantID, ref.SecretID)
+			assert.Equal(t, tt.wantName, ref.SecretName)
+			assert.Equal(t, tt.wantPath, ref.SecretPath)
+			assert.Equal(t, tt.wantRevision, ref.Revision)
+			assert.Equal(t, tt.wantField, ref.Field)
 		})
 	}
 }
 
 func Test_RenderTemplate_NoRefs(t *testing.T) {
-	rendered, err := renderTemplate("hello world\nno secrets here", nil, "")
+	rendered, err := secret.RenderTemplate("hello world\nno secrets here", nil, "")
 	require.NoError(t, err)
 	assert.Equal(t, "hello world\nno secrets here", rendered)
 }
@@ -104,16 +114,17 @@ func Test_IsSecretUUID(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"11111111-1111-1111-1111-111111111111", true},
+		{testUUID, true},
 		{"abcdef01-abcd-abcd-abcd-abcdef012345", true},
 		{"not-a-uuid", false},
-		{"11111111-1111-1111-1111-11111111111G", false}, // uppercase G
-		{"11111111-1111-1111-1111-111111111111X", false}, // too long
+		{"11111111-1111-1111-1111-11111111111G", false},
+		{"11111111-1111-1111-1111-111111111111X", false},
 		{"", false},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.want, isSecretUUID(tt.input))
+			assert.Equal(t, tt.want, secret.IsSecretUUID(tt.input))
 		})
 	}
 }

--- a/internal/namespaces/secret/v1beta1/export_test.go
+++ b/internal/namespaces/secret/v1beta1/export_test.go
@@ -26,6 +26,7 @@ func ParseSecretRef(raw string) (*ParsedSecretRef, error) {
 }
 
 var (
-	RenderTemplate = renderTemplate
-	IsSecretUUID   = isSecretUUID
+	RenderTemplate  = renderTemplate
+	IsSecretUUID    = isSecretUUID
+	WriteOutputFile = writeOutputFile
 )

--- a/internal/namespaces/secret/v1beta1/export_test.go
+++ b/internal/namespaces/secret/v1beta1/export_test.go
@@ -1,0 +1,31 @@
+package secret
+
+// ParsedSecretRef is an exported view of parsedSecretRef for use in tests.
+type ParsedSecretRef struct {
+	SecretID   string
+	SecretName string
+	SecretPath string
+	Revision   string
+	Field      string
+}
+
+// ParseSecretRef wraps the unexported parseSecretRef for external test access.
+func ParseSecretRef(raw string) (*ParsedSecretRef, error) {
+	ref, err := parseSecretRef(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ParsedSecretRef{
+		SecretID:   ref.secretID,
+		SecretName: ref.secretName,
+		SecretPath: ref.secretPath,
+		Revision:   ref.revision,
+		Field:      ref.field,
+	}, nil
+}
+
+var (
+	RenderTemplate = renderTemplate
+	IsSecretUUID   = isSecretUUID
+)


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

## Summary

Adds a `scw secret inject` command that substitutes `{{ scw://REFERENCE }}` placeholders in template files or stdin with live secret values fetched from the Scaleway Secret Manager API. Multiple distinct secrets are fetched concurrently.
Similar to [op inject](https://www.1password.dev/cli/reference/commands/inject) and [pass-cli inject](https://protonpass.github.io/pass-cli/commands/contents/inject/)

## Usage

```sh
# Render a template to stdout
scw secret inject in-file=config.tmpl

# Write output to a file (default mode 0600)
scw secret inject in-file=config.tmpl out-file=/etc/app/config

# Pipe from stdin
echo "password={{ scw://my-app/db-password }}" | scw secret inject
```

## Reference syntax

| Pattern | Meaning |
|---|---|
| `UUID` | secret by ID, latest revision |
| `UUID@REVISION` | secret by ID, specific revision |
| `UUID:FIELD` | secret by ID, extract JSON field |
| `NAME` or `PATH/NAME` | secret by name/path, latest revision |
| `PATH/NAME@REVISION:FIELD` | name/path with revision and JSON field |

`REVISION` accepts an integer, `latest`, or `latest_enabled`.
`FIELD` extracts a top-level string key from a JSON-encoded secret value.

## Changes

- `internal/namespaces/secret/v1beta1/custom_inject.go` — new `secret inject` command; parses all `{{ scw://... }}` references, fetches them concurrently via `errgroup`, then renders the output
- `internal/namespaces/secret/v1beta1/custom_inject_test.go` — unit tests for parsing, resolution, and rendering
- `docs/commands/secret.md` — generated docs for the new command

```release-note
feat(secret): add `inject` command to substitute secret references in template files
```