### PR TITLE
tests(container): standardize timestamps on both actual and expected

### DIFF
--- a/core/testing.go
+++ b/core/testing.go
@@ -777,7 +777,11 @@ func TestCheckGolden() TestCheck {
 
 		expected, err := os.ReadFile(goldenPath)
 		require.NoError(t, err, "expected to find golden file %s", goldenPath)
-		assert.Equal(t, uniformTimestampsWithOffSet(string(expected)), actual)
+		assert.Equal(
+			t,
+			uniformTimestampsWithOffSet(string(expected)),
+			uniformTimestampsWithOffSet(actual),
+		)
 	}
 }
 


### PR DESCRIPTION
This PR should fix the nightly tests for the `container` package: in the new test Test_ContainerLogs, the timestamps should be standardized on both the actual and the expected golden.
