### PR TITLE
fix(mcp): fix empty server-type list in mcp and encode return value as json instead of a string

### DIFF
--- a/internal/namespaces/mcp/server/mcp_tools.go
+++ b/internal/namespaces/mcp/server/mcp_tools.go
@@ -239,13 +239,21 @@ func (ct *CommandTool) Execute(
 		resultStr = "Command executed successfully (no output)"
 	}
 
-	return &mcp.CallToolResult{
+	callResult := &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{
 				Text: resultStr,
 			},
 		},
-	}, nil
+	}
+
+	// Set StructuredContent to the raw result value so clients receive
+	// proper JSON data instead of a JSON-encoded string.
+	if result != nil {
+		callResult.StructuredContent = result
+	}
+
+	return callResult, nil
 }
 
 // CommandNameToToolName converts a command to an MCP tool name

--- a/internal/namespaces/mcp/server/mcp_tools.go
+++ b/internal/namespaces/mcp/server/mcp_tools.go
@@ -150,6 +150,10 @@ func (ct *CommandTool) Execute(
 			rawArgs = append(rawArgs, originalName+"="+valueStr)
 		}
 
+		// Apply default values for missing args (e.g. zone, region).
+		// This mirrors the normal CLI execution path in cobra_utils.go.
+		rawArgs = core.ApplyDefaultValues(ctx, ct.Command.ArgSpecs, args.RawArgs(rawArgs))
+
 		// Unmarshal the args into the struct
 		if unmarshalErr := args.UnmarshalStruct(rawArgs, cmdArgs); unmarshalErr != nil {
 			return &mcp.CallToolResult{
@@ -219,6 +223,13 @@ func (ct *CommandTool) Execute(
 	// Format the result
 	var resultStr string
 	if result != nil {
+		// JSON marshals nil slices as "null". Convert them to empty slices
+		// so list commands return "[]" instead of "null" when there are no results.
+		v := reflect.ValueOf(result)
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			result = reflect.MakeSlice(v.Type(), 0, 0).Interface()
+		}
+
 		if data, err := json.MarshalIndent(result, "", "  "); err == nil {
 			resultStr = string(data)
 		} else {

--- a/internal/namespaces/mcp/server/mcp_tools_test.go
+++ b/internal/namespaces/mcp/server/mcp_tools_test.go
@@ -111,6 +111,8 @@ func TestCommandToolExecuteStructuredContent(t *testing.T) {
 	require.True(t, ok, "StructuredContent should be []*Server, got %T", result.StructuredContent)
 	require.Len(t, servers, 2)
 	require.Equal(t, "server-1", servers[0].ID)
+	require.Equal(t, "server-2", servers[1].ID)
+	require.Equal(t, "web-1", servers[0].Name)
 	require.Equal(t, "web-2", servers[1].Name)
 }
 

--- a/internal/namespaces/mcp/server/mcp_tools_test.go
+++ b/internal/namespaces/mcp/server/mcp_tools_test.go
@@ -78,6 +78,42 @@ func createTestContextWithMeta(t *testing.T) context.Context {
 	})
 }
 
+// TestCommandToolExecuteStructuredContent verifies that StructuredContent
+// contains the raw Go value (not a JSON-encoded string) so MCP clients
+// receive proper JSON data they can inspect without parsing.
+func TestCommandToolExecuteStructuredContent(t *testing.T) {
+	type Server struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	cmd := &core.Command{
+		Namespace: "instance",
+		Resource:  "server",
+		Verb:      "list",
+		ArgsType:  nil,
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			return []*Server{
+				{ID: "server-1", Name: "web-1"},
+				{ID: "server-2", Name: "web-2"},
+			}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+
+	ctx := createTestContextWithMeta(t)
+	result, err := tool.Execute(ctx, map[string]any{})
+	require.NoError(t, err)
+
+	// StructuredContent should be the raw slice, not a JSON string.
+	servers, ok := result.StructuredContent.([]*Server)
+	require.True(t, ok, "StructuredContent should be []*Server, got %T", result.StructuredContent)
+	require.Len(t, servers, 2)
+	require.Equal(t, "server-1", servers[0].ID)
+	require.Equal(t, "web-2", servers[1].Name)
+}
+
 // TestCommandToolExecuteNilSlice verifies that a nil slice result (e.g. from a
 // list command with no results) is serialized as "[]" instead of "null".
 func TestCommandToolExecuteNilSlice(t *testing.T) {

--- a/internal/namespaces/mcp/server/mcp_tools_test.go
+++ b/internal/namespaces/mcp/server/mcp_tools_test.go
@@ -78,6 +78,82 @@ func createTestContextWithMeta(t *testing.T) context.Context {
 	})
 }
 
+// TestCommandToolExecuteNilSlice verifies that a nil slice result (e.g. from a
+// list command with no results) is serialized as "[]" instead of "null".
+func TestCommandToolExecuteNilSlice(t *testing.T) {
+	type Server struct {
+		ID string
+	}
+
+	cmd := &core.Command{
+		Namespace: "instance",
+		Resource:  "server",
+		Verb:      "list",
+		ArgsType:  nil,
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			var servers []*Server
+
+			return servers, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+
+	ctx := createTestContextWithMeta(t)
+	result, err := tool.Execute(ctx, map[string]any{})
+	require.NoError(t, err)
+
+	require.Len(t, result.Content, 1)
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+
+	require.Equal(t, "[]", tc.Text)
+}
+
+// TestCommandToolExecuteAppliesDefaultValues verifies that default values
+// from ArgSpecs (e.g. zone) are applied when args are not provided by the caller.
+// This mirrors the normal CLI execution path which calls ApplyDefaultValues.
+func TestCommandToolExecuteAppliesDefaultValues(t *testing.T) {
+	type testArgs struct {
+		Zone string `json:"zone"`
+	}
+
+	executedArgs := &testArgs{}
+	cmd := &core.Command{
+		Namespace: "instance",
+		Resource:  "server-type",
+		Verb:      "list",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:       "zone",
+				Short:      "Zone",
+				Required:   false,
+				Positional: false,
+				Default: func(ctx context.Context) (string, string) {
+					client := core.ExtractClient(ctx)
+					zone, _ := client.GetDefaultZone()
+
+					return zone.String(), zone.String()
+				},
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			executedArgs = args.(*testArgs)
+
+			return []string{}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+
+	ctx := createTestContextWithMeta(t)
+	_, err := tool.Execute(ctx, map[string]any{})
+	require.NoError(t, err)
+
+	require.Equal(t, "fr-par-1", executedArgs.Zone)
+}
+
 func TestCommandToolExecute(t *testing.T) {
 	type testArgs struct {
 		Name  string `json:"name"`

--- a/internal/namespaces/mcp/server/server.go
+++ b/internal/namespaces/mcp/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -73,18 +72,10 @@ func NewMCPServer(
 
 				return result, output, err
 			}
-			// Extract text content for structured output
-			if len(result.Content) > 0 {
-				if tc, ok := result.Content[0].(*mcp.TextContent); ok {
-					output["result"] = tc.Text
-				} else {
-					// Handle non-TextContent types by marshaling to JSON
-					if data, marshalErr := json.Marshal(result.Content[0]); marshalErr == nil {
-						output["result"] = string(data)
-					} else {
-						output["result"] = fmt.Sprintf("%T", result.Content[0])
-					}
-				}
+			// Use StructuredContent (raw Go value) so clients receive proper JSON
+			// instead of a JSON-encoded string.
+			if result.StructuredContent != nil {
+				output["result"] = result.StructuredContent
 			} else {
 				output["result"] = "Command executed successfully (no output)"
 			}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):
<!--
If the change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```
