### PR TITLE
fix(mcp): support dynamic array and map args

### DIFF
--- a/internal/namespaces/mcp/server/mcp_tools.go
+++ b/internal/namespaces/mcp/server/mcp_tools.go
@@ -254,6 +254,7 @@ func exactArgSpecName(argSpecs core.ArgSpecs, argName string) (string, bool) {
 func dynamicArgToRawArgs(specName string, argName string, argValue any) ([]string, bool) {
 	switch {
 	case strings.Count(specName, dynamicArrayPlaceholder) == 1 &&
+		strings.Count(specName, dynamicMapPlaceholder) == 0 &&
 		strings.HasSuffix(specName, dynamicArrayPlaceholder):
 		prefix := strings.TrimSuffix(specName, dynamicArrayPlaceholder)
 		if strcase.ToKebab(prefix) != argName {
@@ -263,6 +264,7 @@ func dynamicArgToRawArgs(specName string, argName string, argValue any) ([]strin
 		return arrayArgToRawArgs(prefix, argValue), true
 
 	case strings.Count(specName, dynamicMapPlaceholder) == 1 &&
+		strings.Count(specName, dynamicArrayPlaceholder) == 0 &&
 		strings.HasSuffix(specName, dynamicMapPlaceholder):
 		prefix := strings.TrimSuffix(specName, dynamicMapPlaceholder)
 		if strcase.ToKebab(prefix) != argName {

--- a/internal/namespaces/mcp/server/mcp_tools.go
+++ b/internal/namespaces/mcp/server/mcp_tools.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -113,41 +114,11 @@ func (ct *CommandTool) Execute(
 	if ct.Command.ArgsType != nil {
 		cmdArgs = reflect.New(ct.Command.ArgsType).Interface()
 
-		// Convert map[string]any to []string format expected by args.UnmarshalStruct
-		// Format: ["arg1=value1", "arg2=value2"]
+		// Convert map[string]any to []string format expected by args.UnmarshalStruct.
+		// Format: ["arg1=value1", "arg2=value2"].
 		rawArgs := make([]string, 0, len(inputArgs))
 		for argName, argValue := range inputArgs {
-			// Convert from kebab-case back to original arg spec name
-			originalName := argName
-			for _, spec := range ct.Command.ArgSpecs {
-				if strcase.ToKebab(spec.Name) == argName {
-					originalName = spec.Name
-
-					break
-				}
-			}
-
-			// Convert value to string
-			var valueStr string
-			switch v := argValue.(type) {
-			case string:
-				valueStr = v
-			case bool:
-				valueStr = strconv.FormatBool(v)
-			case float64:
-				valueStr = fmt.Sprintf("%v", v)
-			case int:
-				valueStr = strconv.Itoa(v)
-			default:
-				// For complex types, marshal to JSON
-				if b, marshalErr := json.Marshal(v); marshalErr == nil {
-					valueStr = string(b)
-				} else {
-					valueStr = fmt.Sprintf("%v", v)
-				}
-			}
-
-			rawArgs = append(rawArgs, originalName+"="+valueStr)
+			rawArgs = append(rawArgs, inputArgToRawArgs(ct.Command.ArgSpecs, argName, argValue)...)
 		}
 
 		// Apply default values for missing args (e.g. zone, region).
@@ -254,6 +225,120 @@ func (ct *CommandTool) Execute(
 	}
 
 	return callResult, nil
+}
+
+func inputArgToRawArgs(argSpecs core.ArgSpecs, argName string, argValue any) []string {
+	if originalName, ok := exactArgSpecName(argSpecs, argName); ok {
+		return []string{rawArg(originalName, argValue)}
+	}
+
+	for _, spec := range argSpecs {
+		if rawArgs, ok := dynamicArgToRawArgs(spec.Name, argName, argValue); ok {
+			return rawArgs
+		}
+	}
+
+	return []string{rawArg(argName, argValue)}
+}
+
+func exactArgSpecName(argSpecs core.ArgSpecs, argName string) (string, bool) {
+	for _, spec := range argSpecs {
+		if strcase.ToKebab(spec.Name) == argName {
+			return spec.Name, true
+		}
+	}
+
+	return "", false
+}
+
+func dynamicArgToRawArgs(specName string, argName string, argValue any) ([]string, bool) {
+	switch {
+	case strings.Count(specName, dynamicArrayPlaceholder) == 1 &&
+		strings.HasSuffix(specName, dynamicArrayPlaceholder):
+		prefix := strings.TrimSuffix(specName, dynamicArrayPlaceholder)
+		if strcase.ToKebab(prefix) != argName {
+			return nil, false
+		}
+
+		return arrayArgToRawArgs(prefix, argValue), true
+
+	case strings.Count(specName, dynamicMapPlaceholder) == 1 &&
+		strings.HasSuffix(specName, dynamicMapPlaceholder):
+		prefix := strings.TrimSuffix(specName, dynamicMapPlaceholder)
+		if strcase.ToKebab(prefix) != argName {
+			return nil, false
+		}
+
+		return mapArgToRawArgs(prefix, argValue), true
+	}
+
+	return nil, false
+}
+
+func arrayArgToRawArgs(prefix string, argValue any) []string {
+	value := reflect.ValueOf(argValue)
+	if !value.IsValid() || value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
+		return []string{rawArg(prefix, argValue)}
+	}
+
+	rawArgs := make([]string, 0, value.Len())
+	for i := range value.Len() {
+		rawArgName := prefix + dynamicArgSeparator + strconv.Itoa(i)
+		rawArgs = append(rawArgs, rawArg(rawArgName, value.Index(i).Interface()))
+	}
+
+	return rawArgs
+}
+
+func mapArgToRawArgs(prefix string, argValue any) []string {
+	value := reflect.ValueOf(argValue)
+	if !value.IsValid() ||
+		value.Kind() != reflect.Map ||
+		value.Type().Key().Kind() != reflect.String {
+		return []string{rawArg(prefix, argValue)}
+	}
+
+	keys := make([]string, 0, value.Len())
+	iter := value.MapRange()
+	for iter.Next() {
+		keys = append(keys, iter.Key().String())
+	}
+	sort.Strings(keys)
+
+	rawArgs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		rawArgName := prefix + dynamicArgSeparator + key
+		rawArgs = append(
+			rawArgs,
+			rawArg(rawArgName, value.MapIndex(reflect.ValueOf(key)).Interface()),
+		)
+	}
+
+	return rawArgs
+}
+
+func rawArg(argName string, argValue any) string {
+	return argName + "=" + argValueToString(argValue)
+}
+
+func argValueToString(argValue any) string {
+	switch v := argValue.(type) {
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		return fmt.Sprintf("%v", v)
+	case int:
+		return strconv.Itoa(v)
+	default:
+		// For complex types, marshal to JSON.
+		if b, marshalErr := json.Marshal(v); marshalErr == nil {
+			return string(b)
+		}
+
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // CommandNameToToolName converts a command to an MCP tool name

--- a/internal/namespaces/mcp/server/mcp_tools_test.go
+++ b/internal/namespaces/mcp/server/mcp_tools_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	dynamicArrayInputName = "tags"
+	dynamicMapInputName   = "environment-variables"
+	dynamicArrayArgName   = "tags.{index}"
+	dynamicMapArgName     = "environment-variables.{key}"
+	firstTagValue         = "frontend"
+	secondTagValue        = "production"
+	environmentKey        = "SCW_REGION"
+	environmentValue      = "fr-par"
+	enabledInputName      = "enabled"
+	countInputName        = "count"
+	mismatchInputName     = "unknown"
+	parseArgumentError    = "Error parsing arguments"
+)
+
 func TestCommandNameToToolName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -305,6 +320,218 @@ func TestCommandToolExecuteWithKebabCase(t *testing.T) {
 	}
 
 	_ = result
+}
+
+func TestCommandToolExecuteWithDynamicArrayAndMapArgs(t *testing.T) {
+	type testArgs struct {
+		Tags                 []string          `json:"tags"`
+		EnvironmentVariables map[string]string `json:"environment_variables"`
+	}
+
+	executedArgs := &testArgs{}
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "create",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  dynamicArrayArgName,
+				Short: "Tags",
+			},
+			{
+				Name:  dynamicMapArgName,
+				Short: "Environment variables",
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			executedArgs = args.(*testArgs)
+
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	inputArgs := map[string]any{
+		dynamicArrayInputName: []any{firstTagValue, secondTagValue},
+		dynamicMapInputName: map[string]any{
+			environmentKey: environmentValue,
+		},
+	}
+
+	ctx := createTestContextWithMeta(t)
+	_, err := tool.Execute(ctx, inputArgs)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{firstTagValue, secondTagValue}, executedArgs.Tags)
+	require.Equal(
+		t,
+		map[string]string{environmentKey: environmentValue},
+		executedArgs.EnvironmentVariables,
+	)
+}
+
+func TestCommandToolExecuteWithDynamicNilArgsDoesNotPanic(t *testing.T) {
+	type testArgs struct {
+		Tags []string `json:"tags"`
+	}
+
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "create",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  dynamicArrayArgName,
+				Short: "Tags",
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	ctx := createTestContextWithMeta(t)
+
+	var result *mcp.CallToolResult
+	var err error
+	require.NotPanics(t, func() {
+		result, err = tool.Execute(ctx, map[string]any{dynamicArrayInputName: nil})
+	})
+
+	require.Error(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, parseArgumentError)
+}
+
+func TestCommandToolExecuteWithBoolAndIntArgs(t *testing.T) {
+	type testArgs struct {
+		Enabled bool `json:"enabled"`
+		Count   int  `json:"count"`
+	}
+
+	executedArgs := &testArgs{}
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "update",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  enabledInputName,
+				Short: "Enabled",
+			},
+			{
+				Name:  countInputName,
+				Short: "Count",
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			executedArgs = args.(*testArgs)
+
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	ctx := createTestContextWithMeta(t)
+	_, err := tool.Execute(ctx, map[string]any{
+		enabledInputName: true,
+		countInputName:   2,
+	})
+	require.NoError(t, err)
+
+	require.True(t, executedArgs.Enabled)
+	require.Equal(t, 2, executedArgs.Count)
+}
+
+func TestCommandToolExecuteWithUnknownArgUsesFallbackString(t *testing.T) {
+	type testArgs struct{}
+
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "update",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	ctx := createTestContextWithMeta(t)
+	result, err := tool.Execute(ctx, map[string]any{mismatchInputName: make(chan int)})
+	require.Error(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, parseArgumentError)
+}
+
+func TestCommandToolExecuteWithDynamicMapMismatchFallsBack(t *testing.T) {
+	type testArgs struct{}
+
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "update",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  dynamicMapArgName,
+				Short: "Environment variables",
+			},
+			{
+				Name:  "plain",
+				Short: "Plain",
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	ctx := createTestContextWithMeta(t)
+	result, err := tool.Execute(ctx, map[string]any{mismatchInputName: "value"})
+	require.Error(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, parseArgumentError)
+}
+
+func TestCommandToolExecuteWithDynamicNilMapArgsDoesNotPanic(t *testing.T) {
+	type testArgs struct {
+		EnvironmentVariables map[string]string `json:"environment_variables"`
+	}
+
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "create",
+		ArgsType:  reflect.TypeOf(testArgs{}),
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  dynamicMapArgName,
+				Short: "Environment variables",
+			},
+		},
+		Run: func(ctx context.Context, args any) (i any, e error) {
+			return map[string]string{"status": "ok"}, nil
+		},
+	}
+
+	tool := server.NewCommandTool(cmd)
+	ctx := createTestContextWithMeta(t)
+
+	var result *mcp.CallToolResult
+	var err error
+	require.NotPanics(t, func() {
+		result, err = tool.Execute(ctx, map[string]any{dynamicMapInputName: nil})
+	})
+
+	require.Error(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, parseArgumentError)
 }
 
 // TestToolMetaSerialization verifies that the Meta field is properly

--- a/internal/namespaces/mcp/server/schema.go
+++ b/internal/namespaces/mcp/server/schema.go
@@ -1,8 +1,20 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/scaleway/scaleway-cli/v2/core"
 	"github.com/scaleway/scaleway-sdk-go/strcase"
+)
+
+const (
+	dynamicArrayPlaceholder = ".{index}"
+	dynamicMapPlaceholder   = ".{key}"
+	dynamicArgSeparator     = "."
+	disallowAdditionalProps = false
+	jsonSchemaTypeArray     = "array"
+	jsonSchemaTypeObject    = "object"
+	jsonSchemaTypeString    = "string"
 )
 
 // JSONSchema represents a JSON Schema object
@@ -11,9 +23,10 @@ type JSONSchema struct {
 	Description          string                 `json:"description,omitempty"`
 	Properties           map[string]*JSONSchema `json:"properties,omitempty"`
 	Required             []string               `json:"required,omitempty"`
-	AdditionalProperties *bool                  `json:"additionalProperties,omitempty"`
+	AdditionalProperties any                    `json:"additionalProperties,omitempty"`
 	Enum                 []string               `json:"enum,omitempty"`
 	Default              any                    `json:"default,omitempty"`
+	Items                *JSONSchema            `json:"items,omitempty"`
 }
 
 // ArgSpecToJSONSchema converts a core.ArgSpec to JSON Schema
@@ -25,13 +38,13 @@ func ArgSpecToJSONSchema(argSpec *core.ArgSpec) *JSONSchema {
 	// Handle enum values
 	if len(argSpec.EnumValues) > 0 {
 		schema.Enum = argSpec.EnumValues
-		schema.Type = "string"
+		schema.Type = jsonSchemaTypeString
 
 		return schema
 	}
 
 	// Default to string for most args
-	schema.Type = "string"
+	schema.Type = jsonSchemaTypeString
 
 	return schema
 }
@@ -39,22 +52,14 @@ func ArgSpecToJSONSchema(argSpec *core.ArgSpec) *JSONSchema {
 // CommandToFlatArgsSchema creates a flat schema for commands that accept all args as strings
 func CommandToFlatArgsSchema(cmd *core.Command) *JSONSchema {
 	schema := &JSONSchema{
-		Type:                 "object",
+		Type:                 jsonSchemaTypeObject,
 		Properties:           make(map[string]*JSONSchema),
 		Required:             []string{},
-		AdditionalProperties: new(false),
+		AdditionalProperties: disallowAdditionalProps,
 	}
 
 	for _, argSpec := range cmd.ArgSpecs {
-		propName := strcase.ToKebab(argSpec.Name)
-		propSchema := &JSONSchema{
-			Type:        "string",
-			Description: argSpec.Short,
-		}
-
-		if len(argSpec.EnumValues) > 0 {
-			propSchema.Enum = argSpec.EnumValues
-		}
+		propName, propSchema := argSpecToPropertySchema(argSpec)
 
 		schema.Properties[propName] = propSchema
 
@@ -64,4 +69,44 @@ func CommandToFlatArgsSchema(cmd *core.Command) *JSONSchema {
 	}
 
 	return schema
+}
+
+func argSpecToPropertySchema(argSpec *core.ArgSpec) (string, *JSONSchema) {
+	if strings.Count(argSpec.Name, dynamicArrayPlaceholder) == 1 &&
+		strings.HasSuffix(argSpec.Name, dynamicArrayPlaceholder) {
+		propName := strings.TrimSuffix(argSpec.Name, dynamicArrayPlaceholder)
+
+		return strcase.ToKebab(propName), &JSONSchema{
+			Type:        jsonSchemaTypeArray,
+			Description: argSpec.Short,
+			Items: &JSONSchema{
+				Type: jsonSchemaTypeString,
+			},
+		}
+	}
+
+	if strings.Count(argSpec.Name, dynamicMapPlaceholder) == 1 &&
+		strings.HasSuffix(argSpec.Name, dynamicMapPlaceholder) {
+		propName := strings.TrimSuffix(argSpec.Name, dynamicMapPlaceholder)
+
+		return strcase.ToKebab(propName), &JSONSchema{
+			Type:        jsonSchemaTypeObject,
+			Description: argSpec.Short,
+			AdditionalProperties: &JSONSchema{
+				Type: jsonSchemaTypeString,
+			},
+		}
+	}
+
+	propName := strcase.ToKebab(argSpec.Name)
+	propSchema := &JSONSchema{
+		Type:        jsonSchemaTypeString,
+		Description: argSpec.Short,
+	}
+
+	if len(argSpec.EnumValues) > 0 {
+		propSchema.Enum = argSpec.EnumValues
+	}
+
+	return propName, propSchema
 }

--- a/internal/namespaces/mcp/server/schema.go
+++ b/internal/namespaces/mcp/server/schema.go
@@ -73,6 +73,7 @@ func CommandToFlatArgsSchema(cmd *core.Command) *JSONSchema {
 
 func argSpecToPropertySchema(argSpec *core.ArgSpec) (string, *JSONSchema) {
 	if strings.Count(argSpec.Name, dynamicArrayPlaceholder) == 1 &&
+		strings.Count(argSpec.Name, dynamicMapPlaceholder) == 0 &&
 		strings.HasSuffix(argSpec.Name, dynamicArrayPlaceholder) {
 		propName := strings.TrimSuffix(argSpec.Name, dynamicArrayPlaceholder)
 
@@ -86,6 +87,7 @@ func argSpecToPropertySchema(argSpec *core.ArgSpec) (string, *JSONSchema) {
 	}
 
 	if strings.Count(argSpec.Name, dynamicMapPlaceholder) == 1 &&
+		strings.Count(argSpec.Name, dynamicArrayPlaceholder) == 0 &&
 		strings.HasSuffix(argSpec.Name, dynamicMapPlaceholder) {
 		propName := strings.TrimSuffix(argSpec.Name, dynamicMapPlaceholder)
 

--- a/internal/namespaces/mcp/server/schema_test.go
+++ b/internal/namespaces/mcp/server/schema_test.go
@@ -157,3 +157,93 @@ func TestCommandToFlatArgsSchemaDynamicArgs(t *testing.T) {
 		)
 	}
 }
+
+func TestCommandToFlatArgsSchemaNestedDynamicArgs(t *testing.T) {
+	// Arg specs with nested placeholders (e.g., "pools.{index}.kubelet-args.{key}")
+	// should NOT be treated as simple maps or arrays. They must fall through to the
+	// default string case so that the literal placeholder name is exposed as the
+	// property name, matching pre-existing behavior.
+	// See https://github.com/scaleway/scaleway-cli for the original bug report.
+	nestedMapArgName := "pools.{index}.kubelet-args.{key}"
+	nestedArrayArgName := "pools.{index}.tags.{index}"
+
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "create",
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  nestedMapArgName,
+				Short: "Kubelet args",
+			},
+			{
+				Name:  nestedArrayArgName,
+				Short: "Tags",
+			},
+		},
+	}
+
+	schema := server.CommandToFlatArgsSchema(cmd)
+	rawSchema, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("Failed to marshal schema: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(rawSchema, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal schema: %v", err)
+	}
+
+	properties := decoded[schemaPropertiesKey].(map[string]any)
+
+	// The literal placeholder name should be the property key (kebab-cased),
+	// and it should be a plain string, NOT an object/array schema.
+	nestedMapPropName := "pools.{index}.kubelet-args.{key}"
+	nestedArrayPropName := "pools.{index}.tags.{index}"
+
+	mapProp, ok := properties[nestedMapPropName].(map[string]any)
+	if !ok {
+		t.Fatalf(
+			"Expected nested map arg %q to be exposed as a string property, got %v",
+			nestedMapArgName,
+			properties[nestedMapPropName],
+		)
+	}
+	if mapProp[schemaTypeKey] != schemaTypeString {
+		t.Fatalf(
+			"Expected nested map arg %q to be a string, got %v",
+			nestedMapArgName,
+			mapProp[schemaTypeKey],
+		)
+	}
+	if _, hasAdditionalProps := mapProp[schemaAdditionalProps]; hasAdditionalProps {
+		t.Fatalf(
+			"Expected nested map arg %q to NOT have additionalProperties, got %v",
+			nestedMapArgName,
+			mapProp,
+		)
+	}
+
+	arrayProp, ok := properties[nestedArrayPropName].(map[string]any)
+	if !ok {
+		t.Fatalf(
+			"Expected nested array arg %q to be exposed as a string property, got %v",
+			nestedArrayArgName,
+			properties[nestedArrayPropName],
+		)
+	}
+	if arrayProp[schemaTypeKey] != schemaTypeString {
+		t.Fatalf(
+			"Expected nested array arg %q to be a string, got %v",
+			nestedArrayArgName,
+			arrayProp[schemaTypeKey],
+		)
+	}
+	if _, hasItems := arrayProp[schemaItemsKey]; hasItems {
+		t.Fatalf(
+			"Expected nested array arg %q to NOT have items, got %v",
+			nestedArrayArgName,
+			arrayProp,
+		)
+	}
+}

--- a/internal/namespaces/mcp/server/schema_test.go
+++ b/internal/namespaces/mcp/server/schema_test.go
@@ -1,10 +1,25 @@
 package server_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/scaleway/scaleway-cli/v2/core"
 	"github.com/scaleway/scaleway-cli/v2/internal/namespaces/mcp/server"
+)
+
+const (
+	arrayArgName          = "tags.{index}"
+	arrayPropertyName     = "tags"
+	mapArgName            = "environment-variables.{key}"
+	mapPropertyName       = "environment-variables"
+	schemaTypeArray       = "array"
+	schemaTypeObject      = "object"
+	schemaTypeString      = "string"
+	schemaPropertiesKey   = "properties"
+	schemaTypeKey         = "type"
+	schemaItemsKey        = "items"
+	schemaAdditionalProps = "additionalProperties"
 )
 
 func TestCommandToFlatArgsSchema(t *testing.T) {
@@ -61,5 +76,84 @@ func TestArgSpecToJSONSchema(t *testing.T) {
 
 	if len(schema.Enum) != 2 {
 		t.Errorf("Expected 2 enum values, got %d", len(schema.Enum))
+	}
+
+	defaultSchema := server.ArgSpecToJSONSchema(&core.ArgSpec{
+		Name:  "default-arg",
+		Short: "Default argument",
+	})
+	if defaultSchema.Type != "string" {
+		t.Errorf("Expected default type 'string', got '%s'", defaultSchema.Type)
+	}
+}
+
+func TestCommandToFlatArgsSchemaDynamicArgs(t *testing.T) {
+	cmd := &core.Command{
+		Namespace: "test",
+		Resource:  "resource",
+		Verb:      "create",
+		ArgSpecs: core.ArgSpecs{
+			{
+				Name:  arrayArgName,
+				Short: "Tags",
+			},
+			{
+				Name:  mapArgName,
+				Short: "Environment variables",
+			},
+		},
+	}
+
+	schema := server.CommandToFlatArgsSchema(cmd)
+	rawSchema, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("Failed to marshal schema: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(rawSchema, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal schema: %v", err)
+	}
+
+	properties := decoded[schemaPropertiesKey].(map[string]any)
+	if _, ok := properties[arrayArgName]; ok {
+		t.Fatalf("Schema should not expose literal placeholder property %q", arrayArgName)
+	}
+	if _, ok := properties[mapArgName]; ok {
+		t.Fatalf("Schema should not expose literal placeholder property %q", mapArgName)
+	}
+
+	tags := properties[arrayPropertyName].(map[string]any)
+	if tags[schemaTypeKey] != schemaTypeArray {
+		t.Fatalf(
+			"Expected %q to be an array schema, got %v",
+			arrayPropertyName,
+			tags[schemaTypeKey],
+		)
+	}
+	tagItems := tags[schemaItemsKey].(map[string]any)
+	if tagItems[schemaTypeKey] != schemaTypeString {
+		t.Fatalf(
+			"Expected %q items to be strings, got %v",
+			arrayPropertyName,
+			tagItems[schemaTypeKey],
+		)
+	}
+
+	environmentVariables := properties[mapPropertyName].(map[string]any)
+	if environmentVariables[schemaTypeKey] != schemaTypeObject {
+		t.Fatalf(
+			"Expected %q to be an object schema, got %v",
+			mapPropertyName,
+			environmentVariables[schemaTypeKey],
+		)
+	}
+	additionalProperties := environmentVariables[schemaAdditionalProps].(map[string]any)
+	if additionalProperties[schemaTypeKey] != schemaTypeString {
+		t.Fatalf(
+			"Expected %q values to be strings, got %v",
+			mapPropertyName,
+			additionalProperties[schemaTypeKey],
+		)
 	}
 }


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #5582

Release note for [CHANGELOG](https://github.com/scaleway/scaleway-cli/blob/master/CHANGELOG.md):

```release-note
fix MCP dynamic array and map argument schemas and execution
```

## Summary

* expose single dynamic array arguments such as `tags.{index}` as MCP array properties such as `tags`
* expose single dynamic map arguments such as `environment-variables.{key}` as MCP object properties with string values
* expand structured MCP array/object input back into CLI raw args before unmarshalling

## Test verification (RED → GREEN)

RED before implementation, with tests only:

```text
--- FAIL: TestCommandToolExecuteWithDynamicArrayAndMapArgs
cannot unmarshal arg 'tags=["frontend","production"]': missing index on the array
--- FAIL: TestCommandToFlatArgsSchemaDynamicArgs
Schema should not expose literal placeholder property "tags.{index}"
```

GREEN after implementation:

```text
ok github.com/scaleway/scaleway-cli/v2/internal/namespaces/mcp/server
```

Revert check after implementation, with production files stashed and tests kept, went RED again:

```text
--- FAIL: TestCommandToolExecuteWithDynamicArrayAndMapArgs
cannot unmarshal arg 'tags=["frontend","production"]': missing index on the array
--- FAIL: TestCommandToFlatArgsSchemaDynamicArgs
Schema should not expose literal placeholder property "tags.{index}"
```

Full local validation suite:

```text
./run-ci.sh
diff-coverage-gate: PASS 100.00% (126/126) changed production lines covered
golangci-lint: 0 issues
go run cmd/scw/main.go -h: pass
go test -v ./... -timeout 20m: only known baseline Docker-only container deploy failure observed
```

The full-suite baseline failure was already present before this change in `internal/namespaces/container/v1 Test_Deploy/Buildpack` because the Docker test environment cannot create `/.pack`.
