### PR TITLE
fix(version): report build date and commit from embedded VCS stamps

### DIFF
--- a/cmd/scw/build_info_test.go
+++ b/cmd/scw/build_info_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testInjectedDate     = "2025-06-26T08:16:28AM"
+	testInjectedCommit   = "abcdef1"
+	testVCSTime          = "2026-09-07T15:09:20Z"
+	testVCSRevision      = "bede29c38b66ef43eb38ef3c08aea75c601dd7fa"
+	testVCSShortRevision = "bede29c"
+	testShortRevision    = "abc"
+)
+
+func vcsBuildInfo() *debug.BuildInfo {
+	return &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs", Value: "git"},
+			{Key: vcsRevisionSetting, Value: testVCSRevision},
+			{Key: vcsTimeSetting, Value: testVCSTime},
+			{Key: "vcs.modified", Value: "false"},
+		},
+	}
+}
+
+func Test_buildDate(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		injected   string
+		buildInfos *debug.BuildInfo
+		expected   string
+	}{
+		{
+			name:       "injected at link time wins over the embedded stamp",
+			injected:   testInjectedDate,
+			buildInfos: vcsBuildInfo(),
+			expected:   testInjectedDate,
+		},
+		{
+			name:       "falls back to the embedded commit date",
+			injected:   unknownBuildValue,
+			buildInfos: vcsBuildInfo(),
+			expected:   testVCSTime,
+		},
+		{
+			name:       "empty injected value falls back too",
+			injected:   "",
+			buildInfos: vcsBuildInfo(),
+			expected:   testVCSTime,
+		},
+		{
+			name:       "stays unknown without build info",
+			injected:   unknownBuildValue,
+			buildInfos: nil,
+			expected:   unknownBuildValue,
+		},
+		{
+			name:       "stays unknown when the binary carries no VCS stamp",
+			injected:   unknownBuildValue,
+			buildInfos: &debug.BuildInfo{},
+			expected:   unknownBuildValue,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildDate(tt.injected, tt.buildInfos))
+		})
+	}
+}
+
+func Test_gitCommit(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		injected   string
+		buildInfos *debug.BuildInfo
+		expected   string
+	}{
+		{
+			name:       "injected at link time wins over the embedded stamp",
+			injected:   testInjectedCommit,
+			buildInfos: vcsBuildInfo(),
+			expected:   testInjectedCommit,
+		},
+		{
+			name:       "falls back to the embedded revision, shortened",
+			injected:   unknownBuildValue,
+			buildInfos: vcsBuildInfo(),
+			expected:   testVCSShortRevision,
+		},
+		{
+			name:       "empty injected value falls back too",
+			injected:   "",
+			buildInfos: vcsBuildInfo(),
+			expected:   testVCSShortRevision,
+		},
+		{
+			name:       "stays unknown without build info",
+			injected:   unknownBuildValue,
+			buildInfos: nil,
+			expected:   unknownBuildValue,
+		},
+		{
+			name:       "stays unknown when the binary carries no VCS stamp",
+			injected:   unknownBuildValue,
+			buildInfos: &debug.BuildInfo{},
+			expected:   unknownBuildValue,
+		},
+		{
+			name:     "a revision shorter than the short form is kept as is",
+			injected: unknownBuildValue,
+			buildInfos: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{{Key: vcsRevisionSetting, Value: testShortRevision}},
+			},
+			expected: testShortRevision,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, gitCommit(tt.injected, tt.buildInfos))
+		})
+	}
+}
+
+func Test_newBuildInfo(t *testing.T) {
+	t.Run("resolves the embedded stamps into the reported build info", func(t *testing.T) {
+		buildInfo := newBuildInfo(vcsBuildInfo())
+
+		assert.Equal(t, testVCSTime, buildInfo.BuildDate)
+		assert.Equal(t, testVCSShortRevision, buildInfo.GitCommit)
+		// The Go toolchain embeds no branch name, so this one stays unknown.
+		assert.Equal(t, unknownBuildValue, buildInfo.GitBranch)
+		assert.Equal(t, GoVersion, buildInfo.GoVersion)
+		assert.Equal(t, userAgentPrefix, buildInfo.UserAgentPrefix)
+	})
+
+	t.Run("stays unknown when the binary carries no VCS stamp", func(t *testing.T) {
+		buildInfo := newBuildInfo(&debug.BuildInfo{})
+
+		assert.Equal(t, unknownBuildValue, buildInfo.BuildDate)
+		assert.Equal(t, unknownBuildValue, buildInfo.GitCommit)
+		assert.Equal(t, unknownBuildValue, buildInfo.GitBranch)
+	})
+}

--- a/cmd/scw/main.go
+++ b/cmd/scw/main.go
@@ -22,9 +22,9 @@ var (
 
 	// These are initialized by the build script
 
-	BuildDate = "unknown" // date -u '+%Y-%m-%d_%I:%M:%S%p'
-	GitBranch = "unknown" // git symbolic-ref -q --short HEAD || echo HEAD"
-	GitCommit = "unknown" // git rev-parse --short HEAD
+	BuildDate = unknownBuildValue // date -u '+%Y-%m-%d_%I:%M:%S%p'
+	GitBranch = unknownBuildValue // git symbolic-ref -q --short HEAD || echo HEAD"
+	GitCommit = unknownBuildValue // git rev-parse --short HEAD
 
 	// These are GO constants
 
@@ -34,6 +34,23 @@ var (
 	BetaMode  = os.Getenv(scw.ScwEnableBeta) == "true"
 
 	userAgentPrefix = "scaleway-cli"
+)
+
+const (
+	// unknownBuildValue is reported when a build value could be resolved neither
+	// from link-time injection nor from the VCS stamps embedded in the binary.
+	unknownBuildValue = "unknown"
+
+	// vcsRevisionSetting and vcsTimeSetting are the debug.BuildInfo settings that
+	// the Go toolchain embeds when the binary is built from a VCS checkout.
+	vcsRevisionSetting = "vcs.revision"
+	vcsTimeSetting     = "vcs.time"
+
+	// shortCommitLength abbreviates the 40-character embedded revision to the
+	// conventional git short-hash length. scripts/build.sh and goreleaser inject
+	// `git rev-parse --short` output, whose width git adapts to the repository, so
+	// the two paths stay consistent in form rather than byte-for-byte.
+	shortCommitLength = 7
 )
 
 // cleanup does the recover
@@ -64,24 +81,94 @@ func buildVersion() string {
 	return Version
 }
 
+// vcsSetting returns the value of a VCS build setting embedded by the Go
+// toolchain, or an empty string when the binary was not built from a checkout.
+func vcsSetting(buildInfos *debug.BuildInfo, key string) string {
+	if buildInfos == nil {
+		return ""
+	}
+
+	for _, setting := range buildInfos.Settings {
+		if setting.Key == key {
+			return setting.Value
+		}
+	}
+
+	return ""
+}
+
+// injectedAtLinkTime reports whether the linker provided a real value for a
+// build variable, in which case the embedded VCS stamp must not override it.
+func injectedAtLinkTime(value string) bool {
+	return value != "" && value != unknownBuildValue
+}
+
+// buildDate returns the date injected at link time by scripts/build.sh or
+// goreleaser. A binary built straight from a checkout (`go build ./cmd/scw`)
+// carries no injected value, but the toolchain does embed the commit date there,
+// so it is used as a fallback instead of reporting "unknown". Module-proxy
+// builds (`go install <pkg>@<version>`) embed no VCS stamp at all and keep
+// reporting "unknown".
+func buildDate(injected string, buildInfos *debug.BuildInfo) string {
+	if injectedAtLinkTime(injected) {
+		return injected
+	}
+
+	if vcsTime := vcsSetting(buildInfos, vcsTimeSetting); vcsTime != "" {
+		return vcsTime
+	}
+
+	return unknownBuildValue
+}
+
+// gitCommit mirrors buildDate for the commit hash. The embedded revision is a
+// full 40-character hash, so it is abbreviated to shortCommitLength.
+func gitCommit(injected string, buildInfos *debug.BuildInfo) string {
+	if injectedAtLinkTime(injected) {
+		return injected
+	}
+
+	revision := vcsSetting(buildInfos, vcsRevisionSetting)
+	if revision == "" {
+		return unknownBuildValue
+	}
+
+	if len(revision) > shortCommitLength {
+		revision = revision[:shortCommitLength]
+	}
+
+	return revision
+}
+
 func main() {
 	exitCode := mainNoExit()
 	os.Exit(exitCode)
 }
 
-func mainNoExit() int {
-	buildInfo := &core.BuildInfo{
+// newBuildInfo assembles the build information reported by `scw version`. Values
+// the linker did not inject are resolved from the VCS stamps that the Go
+// toolchain embedded in the binary.
+func newBuildInfo(buildInfos *debug.BuildInfo) *core.BuildInfo {
+	return &core.BuildInfo{
 		Version: version.Must(
 			version.NewSemver(buildVersion()),
 		), // panic when version does not respect semantic versioning
-		BuildDate:       BuildDate,
+		BuildDate:       buildDate(BuildDate, buildInfos),
 		GoVersion:       GoVersion,
 		GitBranch:       GitBranch,
-		GitCommit:       GitCommit,
+		GitCommit:       gitCommit(GitCommit, buildInfos),
 		GoOS:            GoOS,
 		GoArch:          GoArch,
 		UserAgentPrefix: userAgentPrefix,
 	}
+}
+
+func mainNoExit() int {
+	// A nil buildInfos (ok == false) is expected for binaries built without module
+	// support; the resolvers fall back to unknownBuildValue in that case.
+	buildInfos, _ := debug.ReadBuildInfo()
+
+	buildInfo := newBuildInfo(buildInfos)
 	defer cleanup(buildInfo)
 
 	exitCode, _, _ := core.Bootstrap(context.Background(), &core.BootstrapConfig{


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #4866

## What

`scw version` reported `unknown` for `BuildDate` and `GitCommit` on binaries built straight from a checkout, even though the Go toolchain had **already embedded that exact data in the binary**:

```
$ go build -o scw ./cmd/scw
$ go version -m scw | grep vcs
	build	vcs=git
	build	vcs.revision=bede29c38b66ef43eb38ef3c08aea75c601dd7fa
	build	vcs.time=2026-09-07T15:09:20Z
	build	vcs.modified=false

$ ./scw version
BuildDate        unknown
GitCommit        unknown
```

`BuildDate`/`GitBranch`/`GitCommit` are only ever populated through `-ldflags -X`, which `scripts/build.sh` and `.goreleaser.yml` do. Any other build leaves the defaults untouched.

This reads the `vcs.revision` / `vcs.time` build settings as a **fallback**, applying the same pattern `buildVersion()` already uses for `Version`. Values injected at link time stay authoritative, so release builds are byte-for-byte unchanged.

## Scope — what this does and does not fix

Please read this before treating it as a full fix for the issue; that is why it says `Relates` and not `Closes`.

| Build path | Before | After |
|---|---|---|
| `go build ./cmd/scw` / `go run ./cmd/scw` from a checkout | `unknown` | **commit + date reported** |
| `scripts/build.sh`, goreleaser, Docker (`-ldflags -X`) | injected | injected (unchanged) |
| `go install <pkg>@<version>` (module cache) | `unknown` | `unknown` — a module-proxy build embeds no VCS stamp at all |
| Homebrew (builds from a release tarball, no `.git`) | `unknown` | `unknown` — same reason |
| `GitBranch`, any path | `unknown` | `unknown` — **the Go toolchain records no branch name**; only `vcs`, `vcs.revision`, `vcs.time` and `vcs.modified` exist, so it cannot be recovered from the binary |

So this closes the gap for builds made from a source checkout and leaves the packaged install paths exactly as they are. Populating them there would need a change to the packaging, not to the CLI.

## Test verification (RED → GREEN)

Both runs are on the same clean checkout with the same command; only the patch differs.

**RED** — upstream `main` (`bede29c3`), no patch:

```
$ go build -o scw ./cmd/scw
$ go version -m scw | grep vcs      # the toolchain DID embed the data
	build	vcs=git
	build	vcs.revision=bede29c38b66ef43eb38ef3c08aea75c601dd7fa
	build	vcs.time=2026-09-07T15:09:20Z
	build	vcs.modified=false

$ ./scw version                     # ...but it is reported as unknown
Version          2.62.1-0.20260907150920-bede29c38b66
BuildDate        unknown
GoVersion        go1.26.3
GitBranch        unknown
GitCommit        unknown
```

**GREEN** — same checkout, with this patch:

```
$ go build -o scw ./cmd/scw
$ ./scw version
Version          2.62.1-0.20260908075737-a01f7534867e
BuildDate        2026-09-08T07:57:37Z
GoVersion        go1.26.3
GitBranch        unknown
GitCommit        a01f753
```

**Release path unchanged** — with the `-ldflags` that `scripts/build.sh` and goreleaser pass, the injected values still win:

```
$ go build -ldflags '-X main.BuildDate=2026-01-02T03:04:05AM -X main.GitBranch=release-branch -X main.GitCommit=deadbee' -o scw ./cmd/scw
$ ./scw version
BuildDate        2026-01-02T03:04:05AM
GitBranch        release-branch
GitCommit        deadbee
```

**Unit RED** — the new test applied to unmodified `main` (the behaviour does not exist yet):

```
$ go test ./cmd/scw/ -run 'Test_buildDate|Test_gitCommit|Test_newBuildInfo'
cmd/scw/build_info_test.go:68:33: undefined: buildDate
cmd/scw/build_info_test.go:44:16: undefined: unknownBuildValue
FAIL	github.com/scaleway/scaleway-cli/v2/cmd/scw [build failed]
```

**Unit GREEN** — same test with the patch:

```
$ go test ./cmd/scw/ -run 'Test_buildDate|Test_gitCommit|Test_newBuildInfo' -v
--- PASS: Test_buildDate (0.00s)
    --- PASS: Test_buildDate/injected_at_link_time_wins_over_the_embedded_stamp
    --- PASS: Test_buildDate/falls_back_to_the_embedded_commit_date
    --- PASS: Test_buildDate/empty_injected_value_falls_back_too
    --- PASS: Test_buildDate/stays_unknown_without_build_info
    --- PASS: Test_buildDate/stays_unknown_when_the_binary_carries_no_VCS_stamp
--- PASS: Test_gitCommit (0.00s)
    --- PASS: Test_gitCommit/injected_at_link_time_wins_over_the_embedded_stamp
    --- PASS: Test_gitCommit/falls_back_to_the_embedded_revision,_shortened
    --- PASS: Test_gitCommit/empty_injected_value_falls_back_too
    --- PASS: Test_gitCommit/stays_unknown_without_build_info
    --- PASS: Test_gitCommit/stays_unknown_when_the_binary_carries_no_VCS_stamp
    --- PASS: Test_gitCommit/a_revision_shorter_than_the_short_form_is_kept_as_is
--- PASS: Test_newBuildInfo (0.00s)
    --- PASS: Test_newBuildInfo/resolves_the_embedded_stamps_into_the_reported_build_info
    --- PASS: Test_newBuildInfo/stays_unknown_when_the_binary_carries_no_VCS_stamp
ok  	github.com/scaleway/scaleway-cli/v2/cmd/scw
```

## Full local suite

The repository CI jobs were replayed locally on the upstream baseline and on this branch, with Go 1.26.3 and golangci-lint v2.13.

| Job | `main` (bede29c3) | this branch |
|---|---|---|
| `go list ./... \| grep -v internal/namespaces \| xargs gotestsum` | 1872 tests, 9 skipped, 0 failures | **1888 tests**, 9 skipped, 0 failures |
| `go run cmd/scw/main.go -h` (runtime smoke) | pass | pass |
| `go mod tidy` + `git diff --exit-code` | pass | pass |
| `./scripts/build.sh` + `./scripts/check-size.sh` | pass | pass |
| `golangci-lint run --timeout 10m ./...` | pass | pass |

No new failure and no changed failure signature; the passing-test count grows by the 16 subtests this PR adds. `gofmt -l` reports `internal/namespaces/object/v1/custom_disabled.go` on both the baseline and this branch — a pre-existing, untouched file behind a `//go:build !(darwin || linux || windows)` tag, which is why `golangci-lint` does not flag it.

Coverage of every function this PR adds is 100%:

```
vcsSetting          100.0%
injectedAtLinkTime  100.0%
buildDate           100.0%
gitCommit           100.0%
newBuildInfo        100.0%
```

`cmd/scw` had 0.0% statement coverage before this PR and has 62.5% after. `mainNoExit` stays uncovered — it is the process entry point and was uncovered on the baseline too; its two changed statements are exercised by the runtime-smoke job and by the binary-level RED → GREEN above.

## Files changed

| File | Change |
|---|---|
| `cmd/scw/main.go` | resolve `BuildDate`/`GitCommit` from the embedded VCS stamps when the linker injected nothing; extract `newBuildInfo` so the assembly is testable |
| `cmd/scw/build_info_test.go` | new table-driven tests for precedence (injected > stamp > unknown) and the nil / empty / short-revision boundaries |

`cmd/scw-wasm/main.go` carries the same defaults and is intentionally left alone to keep this PR to one concern; happy to follow up if you would like the helpers shared between both binaries.

```release-note
`scw version` now reports the build date and git commit for binaries built from a source checkout, instead of `unknown`.
```
