### PR TITLE
feat(core): autocomplete srn arguments on create commands

### DIFF
--- a/core/autocomplete_test.go
+++ b/core/autocomplete_test.go
@@ -75,6 +75,36 @@ func testAutocompleteGetCommands() *core.Commands {
 			Short:      "this command is deprecated",
 			Long:       "This command is deprecated and should not show up in autocomplete.",
 		},
+		&core.Command{
+			Namespace: "test",
+			Resource:  "tree",
+			Verb:      "create",
+			ArgsType: reflect.TypeOf(struct {
+				Srn string
+			}{}),
+			ArgSpecs: core.ArgSpecs{
+				{
+					Name: "srn",
+				},
+			},
+			Run: func(_ context.Context, _ any) (any, error) {
+				return nil, nil
+			},
+		},
+		&core.Command{
+			Namespace: "test",
+			Resource:  "tree",
+			Verb:      "list",
+			ArgsType:  reflect.TypeOf(struct{}{}),
+			Run: func(_ context.Context, _ any) (any, error) {
+				return []struct {
+					Srn string
+				}{
+					{Srn: "srn:tree:oak"},
+					{Srn: "srn:tree:pine"},
+				}, nil
+			},
+		},
 	)
 }
 
@@ -135,7 +165,7 @@ func TestAutocomplete(t *testing.T) {
 		"scw te flower create name=plop",
 		run(&testCase{WordToCompleteIndex: 1, Suggestions: core.AutocompleteSuggestions{"test"}}),
 	)
-	t.Run("scw test ", run(&testCase{Suggestions: core.AutocompleteSuggestions{"flower"}}))
+	t.Run("scw test ", run(&testCase{Suggestions: core.AutocompleteSuggestions{"flower", "tree"}}))
 	t.Run("scw test fl", run(&testCase{Suggestions: core.AutocompleteSuggestions{"flower"}}))
 	t.Run(
 		"scw test flower ",
@@ -185,6 +215,20 @@ func TestAutocomplete(t *testing.T) {
 		),
 	)
 	t.Run("scw test flower create name=plop n", run(&testCase{Suggestions: nil}))
+
+	// An "srn" argument references a foreign resource, so it must stay
+	// completable on "create" verbs (from the resource's own list verb) unlike
+	// the resource's own identity fields such as "name".
+	t.Run(
+		"scw test tree create srn=",
+		run(&testCase{
+			Suggestions: core.AutocompleteSuggestions{"srn=srn:tree:oak", "srn=srn:tree:pine"},
+		}),
+	)
+	t.Run(
+		"scw test tree create srn=srn:tree:o",
+		run(&testCase{Suggestions: core.AutocompleteSuggestions{"srn=srn:tree:oak"}}),
+	)
 	t.Run(
 		"scw test flower create n name=plop",
 		run(&testCase{WordToCompleteIndex: 4, Suggestions: nil}),

--- a/core/autocomplete_utils.go
+++ b/core/autocomplete_utils.go
@@ -85,6 +85,11 @@ var autocompleteResourceToNamespace = map[string]string{
 	"private-network": "vpc",
 }
 
+// srnArgName is the conventional name of arguments holding a Scaleway Resource
+// Name. Such an argument always references a pre-existing, foreign resource
+// rather than an attribute of the resource the command operates on.
+const srnArgName = "srn"
+
 // AutocompleteGetArg tries to complete an argument by using the list verb if it exists for the same resource
 // It will search for the same field in the response of the list
 // Field name will be stripped of the resource name (ex: cluster-id -> id)
@@ -114,7 +119,9 @@ func AutocompleteGetArg(
 	// skip if creating a resource and the arg to complete is from the same resource
 	// does not complete name in "scw instance server create name=<tab>"
 	// but still complete for different resources ex: "scw container container create namespace-id=<tab>"
-	if cmd.Verb == "create" && argResource == cmd.Resource {
+	// an "srn" argument is an exception: it references a foreign resource by its
+	// Scaleway Resource Name, so it stays completable on "create" verbs.
+	if cmd.Verb == "create" && argResource == cmd.Resource && argName != srnArgName {
 		return nil
 	}
 


### PR DESCRIPTION
The generic argument autocompleter skipped any create-verb argument sharing the command's resource name, which silently disabled completion of `srn` arguments (e.g. `scw annotations binding create srn=<tab>`). An `srn` argument references a foreign, pre-existing resource by its Scaleway Resource Name rather than the resource being created, so it is now exempted from that skip and completed from the resource's list verb.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,5 +1,2 @@
        	            	-(core.AutocompleteSuggestions) (len=2) {
        	            	- (string) (len=16) "srn=srn:tree:oak",
        	            	- (string) (len=17) "srn=srn:tree:pine"
        	            	-}
        	            	+(core.AutocompleteSuggestions) <nil>
        	            	 
        	Test:       	TestAutocomplete/scw_test_tree_create_srn=
=== RUN   TestAutocomplete/scw_test_tree_create_srn=srn:tree:o
    autocomplete_test.go:228: 
        	Error Trace:	/home/ousama/contribute-work/scaleway__scaleway-cli/core/autocomplete_test.go:142
        	Error:      	Not equal: 
        	            	expected: core.AutocompleteSuggestions{"srn=srn:tree:oak"}
        	            	actual  : core.AutocompleteSuggestions(nil)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,2 @@
        	            	-(core.AutocompleteSuggestions) (len=1) {
        	            	- (string) (len=16) "srn=srn:tree:oak"
        	            	-}
        	            	+(core.AutocompleteSuggestions) <nil>
        	            	 
        	Test:       	TestAutocomplete/scw_test_tree_create_srn=srn:tree:o
--- FAIL: TestAutocomplete (0.00s)
    --- FAIL: TestAutocomplete/scw_test_tree_create_srn= (0.00s)
    --- FAIL: TestAutocomplete/scw_test_tree_create_srn=srn:tree:o (0.00s)
=== RUN   TestAutocompleteArgs
--- PASS: TestAutocompleteArgs (0.00s)
=== RUN   TestAutocompleteProfiles
--- PASS: TestAutocompleteProfiles (0.00s)
=== RUN   TestAutocompleteDeprecatedCommand
--- PASS: TestAutocompleteDeprecatedCommand (0.00s)
FAIL
FAIL	github.com/scaleway/scaleway-cli/v2/core	0.006s
FAIL
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
=== RUN   TestAutocomplete
=== RUN   TestAutocomplete/scw_test_tree_create_srn=
=== RUN   TestAutocomplete/scw_test_tree_create_srn=srn:tree:o
--- PASS: TestAutocomplete (0.00s)
    --- PASS: TestAutocomplete/scw_test_tree_create_srn= (0.00s)
    --- PASS: TestAutocomplete/scw_test_tree_create_srn=srn:tree:o (0.00s)
=== RUN   TestAutocompleteArgs
--- PASS: TestAutocompleteArgs (0.00s)
=== RUN   TestAutocompleteProfiles
--- PASS: TestAutocompleteProfiles (0.00s)
=== RUN   TestAutocompleteDeprecatedCommand
--- PASS: TestAutocompleteDeprecatedCommand (0.00s)
PASS
ok  	github.com/scaleway/scaleway-cli/v2/core	0.006s
```

## Full local suite

Command: `export PATH="/home/ousama/.local/share/go-1.26.6/go/bin:$PATH" GOTOOLCHAIN=auto; go build ./... && go test ./core/...`

```
ok  	github.com/scaleway/scaleway-cli/v2/core	(cached)
ok  	github.com/scaleway/scaleway-cli/v2/core/human	(cached)
```

Fix #5807
